### PR TITLE
fix: rounding total score issue

### DIFF
--- a/client/src/components/Profile/StudentStatsModal.tsx
+++ b/client/src/components/Profile/StudentStatsModal.tsx
@@ -51,7 +51,7 @@ class StudentStatsModal extends React.PureComponent<Props> {
             )}
             <p style={{ marginBottom: 5 }}>
               Total Score: <Text mark>{totalScore}</Text>
-              {maxCourseScore && ` / ${maxCourseScore}`}
+              {maxCourseScore && ` / ${maxCourseScore.toFixed(1)}`}
             </p>
             <p style={{ marginBottom: 30 }}>
               Course progress: {`${scoredTasks} / ${tasks.length} tasks were scored (${courseProgress}%)`}

--- a/client/src/components/Profile/__test__/__snapshots__/StudentStatsModal.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/StudentStatsModal.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`StudentStatsModal Should render correctly 1`] = `
         >
           1201
         </Text>
-         / 340
+         / 340.0
       </p>
       <p
         style={


### PR DESCRIPTION
Displayed maximum score value is now rounded to 1 decimal place. [Fixed issue](https://github.com/rolling-scopes/rsschool-app/issues/429).