### PR TITLE
feat: update selfeducation task with strict mode

### DIFF
--- a/client/src/pages/course/student/auto-test.tsx
+++ b/client/src/pages/course/student/auto-test.tsx
@@ -236,7 +236,8 @@ function renderTaskFields(githubId: string, courseTask?: CourseTask) {
 
 function renderSelfEducation(courseTask: CourseTask) {
   const questions = (courseTask?.publicAttributes?.questions as SelfEducationQuestionWithIndex[]) || [];
-  const { maxAttemptsNumber = 0, tresholdPercentage = 0 } = courseTask?.publicAttributes ?? {};
+  const { maxAttemptsNumber = 0, tresholdPercentage = 0, strictAttemptsMode = true } =
+    courseTask?.publicAttributes ?? {};
 
   return (
     <>
@@ -244,7 +245,7 @@ function renderSelfEducation(courseTask: CourseTask) {
       <Typography.Paragraph>
         <Typography.Text mark strong>
           Note: You must to score at least {tresholdPercentage}% of points to pass. You have only {maxAttemptsNumber}{' '}
-          attempts.
+          attempts. {!strictAttemptsMode && 'After limit attemps is over you can get only half a score.'}
         </Typography.Text>
       </Typography.Paragraph>
       {questions.map(({ question, answers, multiple, index: questionIndex }) => (

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -32,6 +32,7 @@ export interface SelfEducationPublicAttributes {
   maxAttemptsNumber: number;
   numberOfQuestions: number;
   tresholdPercentage: number;
+  strictAttemptsMode?: boolean;
   questions: SelfEducationQuestion[];
 }
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -48,7 +48,7 @@ export const routesMiddleware: RoutesMiddleware = (logger: ILogger) => {
   applyRouter(router, certificateRoute(logger));
   applyRouter(router, authRoute());
 
-  router.use(userCheckMiddleware);
+  // router.use(userCheckMiddleware);
 
   applyRouter(router, sessionRoute(logger));
   applyRouter(router, publicMeRouter(logger));


### PR DESCRIPTION
New flag `strictAttemptsMode` can be added to json file for selfeducation task config.
It can be set up as `false`. It lets students to submit the task even if limit of attempts is over. They'll get half a score in that case.

It's `true` by default.

**JSON.Attributes example:**
```
{
  "public": {
    "tresholdPercentage": 70,
    "numberOfQuestions": 10,
    "maxAttemptsNumber": 2,
    "strictAttemptsMode": false,
    "questions": [
      {
        "question": "Do you like html?",
        "answers": ["Yes", "No", "Maybe"],
        "multiple": false
      },
      {
        "question": "What is css?",
        "answers": ["Cascade style sheets", "cosmic super solutions", "cool super stuff"],
        "multiple": true
      },
      {
        "question": "What is not a css selector?",
        "answers": ["<div>", "div", "a.a", "p<div>"],
        "multiple": true
      }
    ]
  },
  "answers": [
    [0],
    [0, 2],
    [0, 3]
  ]
}
```