### PR TITLE
fix: add words breaking in radio

### DIFF
--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -42,6 +42,12 @@ span.ant-table-filter-column-title {
   padding-bottom: 8px;
 }
 
+span.ant-radio+* {
+  display: inline-block;
+  white-space: normal;
+  vertical-align: top;
+}
+
 thead.ant-table-thead > tr > th {
   font-size: 12px;
 }


### PR DESCRIPTION
Add styles for ant design radio component, which restore normal white-space.
PR fixes #629 #639 

![image](https://user-images.githubusercontent.com/57856125/109710530-d3a0f880-7bae-11eb-9934-a3ee66a354b1.png)
