### PR TITLE
feat: add pictures for RSSAPP Tests

### DIFF
--- a/client/src/pages/course/student/auto-test.tsx
+++ b/client/src/pages/course/student/auto-test.tsx
@@ -355,32 +355,62 @@ function renderSelfEducation(courseTask: CourseTask) {
           attempts. {!strictAttemptsMode && 'After limit attemps is over you can get only half a score.'}
         </Typography.Text>
       </Typography.Paragraph>
-      {questions.map(({ question, answers, multiple, index: questionIndex }) => (
-        <Form.Item
-          key={questionIndex}
-          label={question}
-          name={`answer-${questionIndex}`}
-          rules={[{ required: true, message: 'Please answer the question' }]}
-        >
-          {multiple ? (
-            <Checkbox.Group>
-              {answers.map((answer, index) => (
-                <Row key={index}>
-                  <Checkbox value={index}>{answer}</Checkbox>
-                </Row>
-              ))}
-            </Checkbox.Group>
-          ) : (
-            <Radio.Group>
-              {answers.map((answer, index) => (
-                <Row key={index}>
-                  <Radio value={index}>{answer}</Radio>
-                </Row>
-              ))}
-            </Radio.Group>
-          )}
-        </Form.Item>
-      ))}
+      {questions.map(({ question, answers, multiple, index: questionIndex, questionImage, answersType }) => {
+        return (
+          <Form.Item
+            key={questionIndex}
+            label={question}
+            name={`answer-${questionIndex}`}
+            rules={[{ required: true, message: 'Please answer the question' }]}
+          >
+            {questionImage && (
+              <Row>
+                <img
+                  src={questionImage}
+                  style={{
+                    width: '100%',
+                    maxWidth: '700px',
+                    marginBottom: '10px',
+                  }}
+                />
+              </Row>
+            )}
+            {multiple ? (
+              <Checkbox.Group>
+                {answers.map((answer, index) => (
+                  <Row key={index}>
+                    <Checkbox value={index}>{answer}</Checkbox>
+                  </Row>
+                ))}
+              </Checkbox.Group>
+            ) : (
+              <Radio.Group>
+                {answers.map((answer, index) => (
+                  <Row key={index}>
+                    <Radio value={index}>
+                      {answersType === 'image' ? (
+                        <>
+                          ({index + 1}){' '}
+                          <img
+                            src={answer}
+                            style={{
+                              width: '100%',
+                              maxWidth: '400px',
+                              marginBottom: '10px',
+                            }}
+                          />
+                        </>
+                      ) : (
+                        answer
+                      )}
+                    </Radio>
+                  </Row>
+                ))}
+              </Radio.Group>
+            )}
+          </Form.Item>
+        );
+      })}
     </>
   );
 }

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -53,6 +53,8 @@ export interface SelfEducationQuestion {
   question: string;
   answers: string[];
   multiple: boolean;
+  questionImage?: string;
+  answersType?: 'image';
 }
 
 export interface SelfEducationQuestionWithIndex extends SelfEducationQuestion {


### PR DESCRIPTION
New flags `questionImage` and `answersType` can be added to json file for RSAPP Task config.
They are optional.

`"questionImage": "https://urlwhereyoustoreyourimage.com"` - let you show some image under the question text
 `"answersType": "image"` - let you put url to answers and show image instead of answer's text.

**JSON.Attributes example:**
```
{
  "public": {
    "tresholdPercentage": 70,
    "numberOfQuestions": 10,
    "maxAttemptsNumber": 2,
    "strictAttemptsMode": false,
    "questions": [
      {
        "question": "Look at the picture and select the right answer",
        "questionImage": "https://i.imgur.com/I8z0Pzw.jpeg",
        "answersType": "image",
        "answers": [
          "https://i.imgur.com/1E6cZuv.jpeg",
          "https://i.imgur.com/Br5yYVc.jpeg",
          "https://i.imgur.com/Nrqih1V.jpeg"
        ],
        "multiple": false
      },
      {
        "question": "What is css?",
        "answers": [
          "Cascade style sheets",
          "cosmic super solutions",
          "cool super stuff"
        ],
        "multiple": true
      },
      {
        "question": "What is not a css selector?",
        "answers": [
          "<div>",
          "div",
          "a.a",
          "p<div>"
        ],
        "multiple": true
      }
    ]
  },
  "answers": [
    [
      0
    ],
    [
      0,
      2
    ],
    [
      0,
      3
    ]
  ]
}
```

**Screenshot**
![image](https://user-images.githubusercontent.com/3992761/124991400-a8de1980-e052-11eb-8485-3c88c5ee4478.png)
