### PR TITLE
fix: hide course if registration is closed

### DIFF
--- a/client/src/modules/Registry/hooks/useStudentsCourseData.tsx
+++ b/client/src/modules/Registry/hooks/useStudentsCourseData.tsx
@@ -2,7 +2,7 @@ import { useAsync } from 'react-use';
 import { CoursesService } from 'services/courses';
 import { Course } from 'services/models';
 import { UserService } from 'services/user';
-import { StudentStats } from '../../../../../../../common/models';
+import { StudentStats } from '../../../../../common/models';
 
 type IdName = {
   id: number;
@@ -67,12 +67,16 @@ function isCourseAvailableForRegistration(course: Course, registeredCourses: IdN
   if (course.completed || registeredCourses.some(({ id }) => id === course.id)) {
     return false;
   }
+
+  const isRegistrationActive = new Date(course.registrationEndDate || 0).getTime() > Date.now();
+  if (isRegistrationActive) {
+    return true;
+  }
+
   if (course.planned) {
     return true;
   }
-  if (course.registrationEndDate) {
-    return new Date(course.registrationEndDate).getTime() > Date.now();
-  }
+
   return false;
 }
 

--- a/client/src/modules/Registry/pages/Student/index.tsx
+++ b/client/src/modules/Registry/pages/Student/index.tsx
@@ -15,7 +15,7 @@ import { Location } from '../../../../../../common/models';
 import { Info } from 'modules/Registry/components';
 import { css } from 'styled-jsx/css';
 import { DEFAULT_ROW_GUTTER, TEXT_EMAIL_TOOLTIP, TEXT_LOCATION_STUDENT_TOOLTIP } from 'modules/Registry/constants';
-import { useStudentCourseData } from './hooks/useStudentsCourseData';
+import { useStudentCourseData } from '../../hooks/useStudentsCourseData';
 
 export const TYPES = {
   MENTOR: 'mentor',


### PR DESCRIPTION
#### 🤔 This is a ...
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/943

#### 💡 Background and solution 

We need to filter course if registration is ended even if it's planned. 

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
