### PR TITLE
feat: switch to own CDN for Github avatars

### DIFF
--- a/client/src/components/GithubAvatar.tsx
+++ b/client/src/components/GithubAvatar.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 import { Avatar } from 'antd';
+import { CDN_AVATARS_URL } from 'configs/cdn';
 
 type Props = {
   githubId?: string;
   size: 24 | 32 | 48 | 96;
   style?: React.CSSProperties;
+  alt?: string;
 };
 
 export function GithubAvatar({ githubId, size, style }: Props) {
   if (!githubId) {
     return <Avatar size={size} style={style} />;
   }
-  return <Avatar src={`https://github.com/${githubId}.png?size=${size * 2}`} size={size} style={style} />;
+  return <Avatar src={`${CDN_AVATARS_URL}/${githubId}.png?size=${size * 2}`} size={size} style={style} />;
 }

--- a/client/src/components/GithubUserLink.tsx
+++ b/client/src/components/GithubUserLink.tsx
@@ -1,5 +1,6 @@
 import { GithubFilled } from '@ant-design/icons';
 import css from 'styled-jsx/css';
+import { CDN_AVATARS_URL } from 'configs/cdn';
 
 export function GithubUserLink(props: { value: string }) {
   const imgProps: any = { loading: 'lazy' };
@@ -9,7 +10,7 @@ export function GithubUserLink(props: { value: string }) {
         <img
           {...imgProps}
           style={{ height: '24px', width: '24px', borderRadius: '12px' }}
-          src={`https://github.com/${props.value}.png?size=48`}
+          src={`${CDN_AVATARS_URL}/${props.value}.png?size=48`}
         />{' '}
         {props.value}
       </a>{' '}

--- a/client/src/components/Profile/MentorStatsModal.tsx
+++ b/client/src/components/Profile/MentorStatsModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { MentorStats } from 'common/models/profile';
-import { Modal, Avatar, Typography, Tag, Row, Col } from 'antd';
+import { Modal, Typography, Tag, Row, Col } from 'antd';
+import { GithubAvatar } from 'components/GithubAvatar';
 
 const { Text } = Typography;
 
@@ -35,12 +36,7 @@ class MentorStatsModal extends React.Component<Props> {
                 <Row style={{ marginBottom: 24 }} justify="space-between">
                   <Col>
                     <div style={{ fontSize: 16, marginBottom: 16 }}>
-                      <Avatar
-                        src={`${guithubLink}.png?size=${128}`}
-                        alt={`${githubId} avatar`}
-                        size={48}
-                        style={{ marginRight: 24 }}
-                      />
+                      <GithubAvatar githubId={githubId} size={48} style={{ marginRight: 24 }} />
                       <Text strong>
                         <a href={profile}>{name}</a>
                       </Text>

--- a/client/src/components/Profile/PublicFeedbackCard.tsx
+++ b/client/src/components/Profile/PublicFeedbackCard.tsx
@@ -9,6 +9,7 @@ import { PublicFeedback } from 'common/models/profile';
 import { ConfigurableProfilePermissions } from 'common/models/profile';
 import { ChangedPermissionsSettings } from 'pages/profile';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
+import { GithubAvatar } from 'components/GithubAvatar';
 
 const { Text, Paragraph } = Typography;
 
@@ -118,12 +119,7 @@ class PublicFeedbackCard extends React.Component<Props, State> {
                 <Comment
                   key={`comment-${idx}`}
                   author={<a href={`/profile?githubId=${fromUser.githubId}`}>{fromUser.name}</a>}
-                  avatar={
-                    <Avatar
-                      src={`https://github.com/${fromUser.githubId}.png?size=${48}`}
-                      alt={`${fromUser.githubId} avatar`}
-                    />
-                  }
+                  avatar={<GithubAvatar size={48} githubId={fromUser.githubId} />}
                   content={
                     <>
                       {badgeId ? (

--- a/client/src/components/Profile/PublicFeedbackModal.tsx
+++ b/client/src/components/Profile/PublicFeedbackModal.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import moment from 'moment';
 import { PublicFeedback } from 'common/models/profile';
-import { Typography, Comment, Avatar, Tooltip, Modal, Row, Col } from 'antd';
+import { Typography, Comment, Tooltip, Modal, Row, Col } from 'antd';
+import { GithubAvatar } from 'components/GithubAvatar';
 import heroesBadges from '../../configs/heroes-badges';
 
 const { Text } = Typography;
@@ -29,12 +30,7 @@ class PublicFeedbackModal extends React.PureComponent<Props> {
             <Col key={`modal-comment-${idx}`} xs={{ span: 24 }} sm={{ span: 12 }} md={{ span: 8 }} lg={{ span: 6 }}>
               <Comment
                 author={<a href={`/profile?githubId=${fromUser.githubId}`}>{fromUser.name}</a>}
-                avatar={
-                  <Avatar
-                    src={`https://github.com/${fromUser.githubId}.png?size=${48}`}
-                    alt={`${fromUser.githubId} avatar`}
-                  />
-                }
+                avatar={<GithubAvatar size={48} githubId={fromUser.githubId} />}
                 content={
                   <>
                     {badgeId ? (

--- a/client/src/components/Profile/__test__/__snapshots__/MentorStatsModal.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/MentorStatsModal.test.tsx.snap
@@ -58,11 +58,9 @@ exports[`MentorStatsModal Should render correctly 1`] = `
               }
             }
           >
-            <Avatar
-              alt="alex avatar"
-              shape="circle"
+            <GithubAvatar
+              githubId="alex"
               size={48}
-              src="https://github.com/alex.png?size=128"
               style={
                 Object {
                   "marginRight": 24,
@@ -181,11 +179,9 @@ exports[`MentorStatsModal Should render correctly 1`] = `
               }
             }
           >
-            <Avatar
-              alt="vasya avatar"
-              shape="circle"
+            <GithubAvatar
+              githubId="vasya"
               size={48}
-              src="https://github.com/vasya.png?size=128"
               style={
                 Object {
                   "marginRight": 24,

--- a/client/src/components/Profile/__test__/__snapshots__/PublicFeedbackCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/PublicFeedbackCard.test.tsx.snap
@@ -209,11 +209,9 @@ exports[`PublicFeedbackCard Should render correctly if is editing mode disabled 
             </a>
           }
           avatar={
-            <Avatar
-              alt="apetr avatar"
-              shape="circle"
-              size="default"
-              src="https://github.com/apetr.png?size=48"
+            <GithubAvatar
+              githubId="apetr"
+              size={48}
             />
           }
           content={
@@ -474,11 +472,9 @@ exports[`PublicFeedbackCard Should render correctly if is editing mode enabled 1
             </a>
           }
           avatar={
-            <Avatar
-              alt="apetr avatar"
-              shape="circle"
-              size="default"
-              src="https://github.com/apetr.png?size=48"
+            <GithubAvatar
+              githubId="apetr"
+              size={48}
             />
           }
           content={

--- a/client/src/components/Profile/__test__/__snapshots__/PublicFeedbackModal.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/PublicFeedbackModal.test.tsx.snap
@@ -50,11 +50,9 @@ exports[`PublicFeedbackModal Should render correctly 1`] = `
           </a>
         }
         avatar={
-          <Avatar
-            alt="apetr avatar"
-            shape="circle"
-            size="default"
-            src="https://github.com/apetr.png?size=48"
+          <GithubAvatar
+            githubId="apetr"
+            size={48}
           />
         }
         content={
@@ -144,11 +142,9 @@ exports[`PublicFeedbackModal Should render correctly 1`] = `
           </a>
         }
         avatar={
-          <Avatar
-            alt="temap avatar"
-            shape="circle"
-            size="default"
-            src="https://github.com/temap.png?size=48"
+          <GithubAvatar
+            githubId="temap"
+            size={48}
           />
         }
         content={
@@ -238,11 +234,9 @@ exports[`PublicFeedbackModal Should render correctly 1`] = `
           </a>
         }
         avatar={
-          <Avatar
-            alt="temap avatar"
-            shape="circle"
-            size="default"
-            src="https://github.com/temap.png?size=48"
+          <GithubAvatar
+            githubId="temap"
+            size={48}
           />
         }
         content={
@@ -332,11 +326,9 @@ exports[`PublicFeedbackModal Should render correctly 1`] = `
           </a>
         }
         avatar={
-          <Avatar
-            alt="temap avatar"
-            shape="circle"
-            size="default"
-            src="https://github.com/temap.png?size=48"
+          <GithubAvatar
+            githubId="temap"
+            size={48}
           />
         }
         content={
@@ -426,11 +418,9 @@ exports[`PublicFeedbackModal Should render correctly 1`] = `
           </a>
         }
         avatar={
-          <Avatar
-            alt="vasssa avatar"
-            shape="circle"
-            size="default"
-            src="https://github.com/vasssa.png?size=48"
+          <GithubAvatar
+            githubId="vasssa"
+            size={48}
           />
         }
         content={
@@ -520,11 +510,9 @@ exports[`PublicFeedbackModal Should render correctly 1`] = `
           </a>
         }
         avatar={
-          <Avatar
-            alt="demaa avatar"
-            shape="circle"
-            size="default"
-            src="https://github.com/demaa.png?size=48"
+          <GithubAvatar
+            githubId="demaa"
+            size={48}
           />
         }
         content={

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,9 +1,0 @@
-export interface IConfig {
-  algoliaPlacesAppId: string;
-  algoliaPlacesApiKey: string;
-}
-
-export const config: IConfig = {
-  algoliaPlacesAppId: 'plYRMXVHA4VI',
-  algoliaPlacesApiKey: 'c3457dc71fd196231949ed98db03f119',
-};

--- a/client/src/configs/cdn.ts
+++ b/client/src/configs/cdn.ts
@@ -1,0 +1,1 @@
+export const CDN_AVATARS_URL = 'https://cdn.rs.school';


### PR DESCRIPTION
#### 🧑‍⚖️ Pull Request Naming Convention

 - Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 - Do not put issue id in title
 - Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
 - Consider to add `area:*` label(s)

 * [x] I followed naming convention rules

---

#### 🤔 This is a ...
- [ ] New feature
- [ ] Bug fix
- [x] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

N/A

#### 💡 Background and solution 

Let's switch to caching Github avatars on own side in order to prevent rate limiting on Github.
Now you can get user avatar by replacing "github.com" with "cdn.rs.school".

E.g. https://cdn.rs.school/apalchys.png


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
