### PR TITLE
perf: disable prefetch to reduce traffic amount

### DIFF
--- a/client/src/components/AdminSider.tsx
+++ b/client/src/components/AdminSider.tsx
@@ -38,7 +38,7 @@ export function AdminSider(props: Props) {
 
       <Menu theme="dark" mode="inline">
         <Menu.Item key="1">
-          <Link href="/">
+          <Link prefetch={false} href="/">
             <a>
               <HomeOutlined />
               <span>Main</span>
@@ -48,7 +48,7 @@ export function AdminSider(props: Props) {
 
         {props.isAdmin ? (
           <Menu.Item key="2">
-            <Link href="/admin/courses">
+            <Link prefetch={false} href="/admin/courses">
               <a>
                 <GlobalOutlined />
                 <span>Courses</span>
@@ -59,7 +59,7 @@ export function AdminSider(props: Props) {
 
         {props.isAdmin || props.isCoursePowerUser ? (
           <Menu.Item key="3">
-            <Link href="/admin/interview-questions">
+            <Link prefetch={false} href="/admin/interview-questions">
               <a>
                 <QuestionOutlined />
                 <span>Interview questions</span>
@@ -69,7 +69,7 @@ export function AdminSider(props: Props) {
         ) : null}
 
         <Menu.Item key="4">
-          <Link href="/admin/tasks">
+          <Link prefetch={false} href="/admin/tasks">
             <a>
               <AlertOutlined />
               <span>Tasks</span>
@@ -78,7 +78,7 @@ export function AdminSider(props: Props) {
         </Menu.Item>
 
         <Menu.Item key="5">
-          <Link href="/admin/events">
+          <Link prefetch={false} href="/admin/events">
             <a>
               <BellOutlined />
               <span>Events</span>
@@ -88,7 +88,7 @@ export function AdminSider(props: Props) {
 
         {props.isAdmin ? (
           <Menu.Item key="6">
-            <Link href="/admin/users">
+            <Link prefetch={false} href="/admin/users">
               <a>
                 <UserOutlined />
                 <span>Users</span>
@@ -99,7 +99,7 @@ export function AdminSider(props: Props) {
 
         {props.isAdmin || props.isCoursePowerUser ? (
           <Menu.Item key="7">
-            <Link href="/admin/mentor-registry">
+            <Link prefetch={false} href="/admin/mentor-registry">
               <a>
                 <IdcardFilled />
                 <span>Mentor Registry</span>
@@ -110,7 +110,7 @@ export function AdminSider(props: Props) {
 
         {props.isAdmin ? (
           <Menu.Item key="8">
-            <Link href="/admin/discord-server">
+            <Link prefetch={false} href="/admin/discord-server">
               <a>
                 <RobotFilled />
                 <span>Discord Servers</span>
@@ -121,7 +121,7 @@ export function AdminSider(props: Props) {
 
         {props.isAdmin ? (
           <Menu.Item key="9">
-            <Link href="/admin/user-group">
+            <Link prefetch={false} href="/admin/user-group">
               <a>
                 <TeamOutlined />
                 <span>User Groups</span>

--- a/client/src/components/Footer/Menu.tsx
+++ b/client/src/components/Footer/Menu.tsx
@@ -14,7 +14,7 @@ class Menu extends React.Component<any, any> {
           dataSource={this.props.data}
           renderItem={(linkInfo: LinkInfo) => (
             <List.Item key={linkInfo.link}>
-              <Link href={linkInfo.link}>
+              <Link prefetch={false} href={linkInfo.link}>
                 <a target={linkInfo.newTab ? '_blank' : '_self'}>
                   {linkInfo.icon}&nbsp;
                   {linkInfo.name}

--- a/client/src/components/Schedule/EventDetails.tsx
+++ b/client/src/components/Schedule/EventDetails.tsx
@@ -101,7 +101,7 @@ const EventDetails: React.FC<Props> = ({ eventData, alias, isAdmin, isPreview, o
 
         {!isPreview && (
           <div className="button__close">
-            <Link href={`/course/schedule?course=${alias}`}>
+            <Link prefetch={false} href={`/course/schedule?course=${alias}`}>
               <a>
                 <Button icon={<CloseOutlined />} />
               </a>

--- a/client/src/components/Schedule/ListView.tsx
+++ b/client/src/components/Schedule/ListView.tsx
@@ -149,7 +149,10 @@ const getDayEvents = (events: CourseEvent[], timeZone: string, alias: string, st
           <th style={{ width: '10%' }}>{dateWithTimeZoneRenderer(timeZone, 'HH:mm')(dateTime)}</th>
           <th style={{ width: '10%' }}>{renderTagWithStyle(type, storedTagColors)}</th>
           <th style={{ width: '80%' }}>
-            <Link href={`/course/entityDetails?course=${alias}&entityType=${isTask ? 'task' : 'event'}&entityId=${id}`}>
+            <Link
+              prefetch={false}
+              href={`/course/entityDetails?course=${alias}&entityType=${isTask ? 'task' : 'event'}&entityId=${id}`}
+            >
               <a>
                 <Text style={{ width: '100%', height: '100%', display: 'block' }} strong>
                   {name}

--- a/client/src/components/Schedule/TaskDetails.tsx
+++ b/client/src/components/Schedule/TaskDetails.tsx
@@ -197,7 +197,7 @@ const TaskDetails: React.FC<Props> = ({ taskData, alias, isAdmin, isPreview, onE
 
         {!isPreview && (
           <div className="button__close">
-            <Link href={`/course/schedule?course=${alias}`}>
+            <Link prefetch={false} href={`/course/schedule?course=${alias}`}>
               <a>
                 <Button icon={<CloseOutlined />} />
               </a>

--- a/client/src/modules/Home/pages/HomePage/index.tsx
+++ b/client/src/modules/Home/pages/HomePage/index.tsx
@@ -145,7 +145,7 @@ export function HomePage(props: Props) {
                 dataSource={courseLinks}
                 renderItem={(linkInfo: LinkRenderData) => (
                   <List.Item key={linkInfo.url}>
-                    <Link href={linkInfo.url}>
+                    <Link prefetch={false} href={linkInfo.url}>
                       <a>
                         {linkInfo.icon} {linkInfo.name}
                       </a>
@@ -167,7 +167,7 @@ export function HomePage(props: Props) {
                   dataSource={adminLinks}
                   renderItem={(linkInfo: LinkRenderData) => (
                     <List.Item key={linkInfo.url}>
-                      <Link href={linkInfo.url}>
+                      <Link prefetch={false} href={linkInfo.url}>
                         <a>
                           {linkInfo.icon} {linkInfo.name}
                         </a>

--- a/client/src/modules/Score/data/getColumns.tsx
+++ b/client/src/modules/Score/data/getColumns.tsx
@@ -51,7 +51,7 @@ export function getColumns(props: Props) {
       width: 150,
       sorter: 'name',
       render: (value: any, record: StudentScore) => (
-        <Link href={`/profile?githubId=${record.githubId}`}>
+        <Link prefetch={false} href={`/profile?githubId=${record.githubId}`}>
           <a>{value}</a>
         </Link>
       ),
@@ -101,7 +101,7 @@ export function getColumns(props: Props) {
       sorter: 'mentor',
       defaultFilteredValue: mentor ? (isArray(mentor) ? mentor : [mentor]) : undefined,
       render: (value: string) => (
-        <Link href={`/profile?githubId=${value}`}>
+        <Link prefetch={false} href={`/profile?githubId=${value}`}>
           <a>{value}</a>
         </Link>
       ),


### PR DESCRIPTION
#### 🧑‍⚖️ Pull Request Naming Convention

 - Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 - Do not put issue id in title
 - Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
 - Consider to add `area:*` label(s)

 * [x] I followed naming convention rules

---

#### 🤔 This is a ...
- [ ] New feature
- [ ] Bug fix
- [x] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

_Describe the source of requirement, like related issue link._

#### 💡 Background and solution 

Prefetch is great technique to improve site performance but it also causes multiple requests in the background. Since users mostly visited limited amount of time and we use own small EC2 instance to serve static (CDN is expensive), I want to reduce amount of requests hitting the server.



#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
