### PR TITLE
fix: make submission after deadline unable in UI

### DIFF
--- a/client/src/pages/course/student/cross-check-submit.tsx
+++ b/client/src/pages/course/student/cross-check-submit.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Form, Input, message, Row, Modal, Checkbox } from 'antd';
+import { Button, Col, Form, Input, message, Row, Modal, Checkbox, Typography } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import { PageLayout, CrossCheckComments } from 'components';
 import withCourseData from 'components/withCourseData';
@@ -33,6 +33,7 @@ function Page(props: CoursePageProps) {
   const [newComments, setNewComments] = useState([] as CrossCheckComment[]);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [buttonDisabled, setButtonDisabled] = useState(true);
+  const [submitDeadlinePassed, setSubmitDeadlinePassed] = useState<boolean>(false);
 
   const [authorId, setAuthorId] = useState<number | null>(null);
 
@@ -107,6 +108,8 @@ function Page(props: CoursePageProps) {
 
     const review = submittedSolution?.review ?? [];
     const criteria = taskDetails?.criteria ?? [];
+    const endDate = taskDetails?.studentEndDate ? new Date(taskDetails.studentEndDate) : null;
+    const submitDeadlinePassed = Date.now() > (endDate ? endDate.getTime() : 0);
 
     form.setFieldsValue({ review });
     form.setFieldsValue({ score: calculateFinalScore(review, criteria) });
@@ -116,6 +119,7 @@ function Page(props: CoursePageProps) {
     setSubmittedSolution(submittedSolution);
     setCourseTaskId(courseTask.id);
     setCriteria(criteria);
+    setSubmitDeadlinePassed(submitDeadlinePassed);
     setComments(submittedSolution?.comments ?? []);
     setAuthorId(submittedSolution?.studentId ?? null);
   };
@@ -127,7 +131,7 @@ function Page(props: CoursePageProps) {
 
   const feedbackComments = feedback?.comments ?? [];
   const task = courseTasks.find(task => task.id === courseTaskId);
-  const submitAllowed = !!task;
+  const submitAllowed = !!task && !submitDeadlinePassed;
   const newCrossCheck = criteria.length > 0;
 
   return (
@@ -196,6 +200,11 @@ function Page(props: CoursePageProps) {
                   </Col>
                 )}
               </Row>
+            )}
+            {submitDeadlinePassed && (
+              <Typography.Text strong type="danger">
+                Submission deadline has already passed
+              </Typography.Text>
             )}
           </Form>
         </Col>

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -410,6 +410,7 @@ export class CourseService {
     const result = await this.axios.get<any>(`/task/${courseTaskId}/cross-check/details`);
     return result.data.data as {
       criteria: CrossCheckCriteria[];
+      studentEndDate: string | undefined;
     } | null;
   }
 

--- a/server/src/routes/course/crossCheck/getTaskDetails.ts
+++ b/server/src/routes/course/crossCheck/getTaskDetails.ts
@@ -7,10 +7,11 @@ import { setResponse } from '../../utils';
 export const getTaskDetails = (_: ILogger) => async (ctx: Router.RouterContext) => {
   const { courseTaskId } = ctx.params;
   const crossCheckService = new CrossCheckService(courseTaskId);
-  const { criteria } = await crossCheckService.getTaskDetails();
+  const { criteria, studentEndDate } = await crossCheckService.getTaskDetails();
 
   const response = {
     criteria,
+    studentEndDate,
   };
   setResponse(ctx, OK, response);
 };

--- a/server/src/services/crossCheck.service.ts
+++ b/server/src/services/crossCheck.service.ts
@@ -56,8 +56,9 @@ export class CrossCheckService {
 
   public async getTaskDetails() {
     const courseTask = await getCourseTask(this.courseTaskId);
+    const studentEndDate = courseTask?.studentEndDate;
     const criteria = courseTask?.task?.attributes?.criteria ?? [];
-    return { criteria };
+    return { criteria, studentEndDate };
   }
 
   public async saveSolution(studentId: number, data: Partial<TaskSolution>) {


### PR DESCRIPTION
#### 🧑‍⚖️ Pull Request Naming Convention

 - Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 - Do not put issue id in title
 - Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
 - Consider to add `area:*` label(s)

 * [x] I followed naming convention rules

---

#### 🤔 This is a ...
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/1061

#### 💡 Background and solution 

At the moment there's a problem in RS App: after passing deadline you still can try to submit your solution or cancel submission but you will get an error.  
New behaviour:  
Before deadline you can submit link to solution or cancel submission  
![submit_before](https://user-images.githubusercontent.com/34455330/143085838-38e05a2e-fee2-45e4-ac27-e98ff8b01929.JPG)  
And after deadline you can't do that
![submit_after](https://user-images.githubusercontent.com/34455330/143085858-3909befb-8b05-431a-a7f5-657f787077d0.JPG)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
