### PR TITLE
fix: fix submission UI

### DIFF
--- a/client/src/components/CrossCheck/SubmittedStatus.tsx
+++ b/client/src/components/CrossCheck/SubmittedStatus.tsx
@@ -3,9 +3,21 @@ import React from 'react';
 import { formatDate } from 'services/formatter';
 import { TaskSolution } from 'services/course';
 
-export function SubmittedStatus({ solution }: { solution: TaskSolution | null }) {
+type Props = {
+  solution: TaskSolution | null;
+  deadlinePassed: boolean;
+  taskExists: boolean;
+};
+
+export function SubmittedStatus(props: Props) {
+  const { taskExists, solution, deadlinePassed } = props;
+
+  if (!taskExists) return null;
+
   if (!solution) {
-    return null;
+    const deadlinePassedMessage = 'Sumbission deadline has already passed';
+    const message = `You haven't submitted solution. ${deadlinePassed ? deadlinePassedMessage : ''}`;
+    return <Alert message={message} type="info" showIcon style={{ marginBottom: 8 }} />;
   }
 
   return (

--- a/client/src/pages/course/student/cross-check-submit.tsx
+++ b/client/src/pages/course/student/cross-check-submit.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Form, Input, message, Row, Modal, Checkbox, Typography } from 'antd';
+import { Button, Col, Form, Input, message, Row, Modal, Checkbox } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import { PageLayout, CrossCheckComments } from 'components';
 import withCourseData from 'components/withCourseData';
@@ -131,7 +131,8 @@ function Page(props: CoursePageProps) {
 
   const feedbackComments = feedback?.comments ?? [];
   const task = courseTasks.find(task => task.id === courseTaskId);
-  const submitAllowed = !!task && !submitDeadlinePassed;
+  const taskExists = !!task;
+  const submitAllowed = taskExists && !submitDeadlinePassed;
   const newCrossCheck = criteria.length > 0;
 
   return (
@@ -145,8 +146,11 @@ function Page(props: CoursePageProps) {
         <Col {...colSizes}>
           <Form form={form} onFinish={handleSubmit} layout="vertical">
             <CourseTaskSelect data={courseTasks} onChange={handleTaskChange} />
-            <SubmittedStatus solution={submittedSolution} />
-
+            <SubmittedStatus
+              taskExists={taskExists}
+              solution={submittedSolution}
+              deadlinePassed={submitDeadlinePassed}
+            />
             {submitAllowed && (
               <Form.Item
                 name="url"
@@ -200,11 +204,6 @@ function Page(props: CoursePageProps) {
                   </Col>
                 )}
               </Row>
-            )}
-            {submitDeadlinePassed && (
-              <Typography.Text strong type="danger">
-                Submission deadline has already passed
-              </Typography.Text>
             )}
           </Form>
         </Col>


### PR DESCRIPTION
#### 🧑‍⚖️ Pull Request Naming Convention

 - Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 - Do not put issue id in title
 - Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
 - Consider to add `area:*` label(s)

 * [x] I followed naming convention rules

---

#### 🤔 This is a ...
- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/1084

#### 💡 Background and solution 

Red text has been removed. Now there are 4 diffrent views in UI:

1. When you haven't submitted solution and deadline is not passed yet.
![no_sumbit_deadline_not_passed](https://user-images.githubusercontent.com/34455330/144745564-de597594-40ee-49d6-af71-0b663cb453c6.JPG)
2. When you haven't submitted solution and deadline has passed.
![no_sumbit_deadline_passed](https://user-images.githubusercontent.com/34455330/144745568-0f3b3dc7-e855-41cb-822d-865b1c1ac0d0.JPG)
3. When you have submitted solution and deadline is not passed yet.
![submission_exists_deadline_not_passed](https://user-images.githubusercontent.com/34455330/144745589-92e527f1-6bab-452d-a92e-4ab709ca249a.JPG)
4. When you have submitted solution and deadline has passed.
![submission_exists_deadline_passed](https://user-images.githubusercontent.com/34455330/144745601-0c5350ee-5c6c-4e7b-a3d3-c2041c3e49d4.JPG)

#### 

☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
