### PR TITLE
fix: table view dropdown position

### DIFF
--- a/client/src/components/Schedule/TableView.tsx
+++ b/client/src/components/Schedule/TableView.tsx
@@ -80,7 +80,7 @@ const getColumns = ({
             isSplitedByWeek={isSplitedByWeek}
           />
         )}
-        placement="bottomRight"
+        placement="bottomLeft"
         trigger={['click']}
       >
         <SettingOutlined />


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [X] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

No issue

#### 💡 Background and solution

The position of table head dropdown of app schedule table was brocken.
This commit will fix it
<img width="223" alt="App  The Rolling Scopes School 2022-03-13 14-31-05" src="https://user-images.githubusercontent.com/13301570/158056301-d00416a5-bbe0-492f-b87e-756db9f41c56.png">



#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or **not needed**
- [ ] Documentation is updated/provided or **not needed**
- [x] Changes are tested locally (wthout view test)
