### PR TITLE
feat: add self-study option for expel

### DIFF
--- a/client/src/pages/course/mentor/expel-student.tsx
+++ b/client/src/pages/course/mentor/expel-student.tsx
@@ -10,7 +10,7 @@ import { useAsync } from 'react-use';
 import { CourseService } from 'services/course';
 import { CoursePageProps } from 'services/models';
 
-type ActionOnStudent = 'expel' | 'unassign';
+type ActionOnStudent = 'expel' | 'unassign' | 'self-study';
 
 function Page(props: CoursePageProps) {
   const courseId = props.course.id;
@@ -56,6 +56,11 @@ function Page(props: CoursePageProps) {
     await courseService.unassignStudentFromMentor(githubId, data);
   };
 
+  const setSelfStudy = async (githubId: string, comment: string) =>
+    githubId === userGithubId
+      ? await courseService.selfSetSelfStudy(githubId, comment)
+      : await courseService.setSelfStudy(githubId, comment);
+
   const handleSubmit = async (values: any) => {
     if (!values.githubId || loading) return;
     try {
@@ -66,6 +71,9 @@ function Page(props: CoursePageProps) {
           break;
         case 'unassign':
           await unassignStudent(values.githubId, values.comment);
+          break;
+        case 'self-study':
+          await setSelfStudy(values.githubId, values.comment);
           break;
         default:
           throw new Error(`Wrong action on student type: ${action}`);
@@ -94,7 +102,13 @@ function Page(props: CoursePageProps) {
       success: 'The student has been expelled',
     },
     unassign: {
-      description: 'Selected student will no longer be your mentee',
+      description:
+        'Selected student will no longer be your mentee. They will be put to wait list, so another mentor could take them',
+      reasonPhrase: 'Reason for unassigning:',
+      success: 'The student has been unassigned',
+    },
+    'self-study': {
+      description: 'Selected student will no longer be your mentee and can continue course without a mentor',
       reasonPhrase: 'Reason for unassigning:',
       success: 'The student has been unassigned',
     },
@@ -112,6 +126,7 @@ function Page(props: CoursePageProps) {
           <Radio.Group onChange={e => setAction(e.target.value)}>
             <Radio value="expel">Expel</Radio>
             <Radio value="unassign">Unassign</Radio>
+            <Radio value="self-study">Self-study</Radio>
           </Radio.Group>
         </Form.Item>
         <Typography.Paragraph type="warning">{actionMessages[action].description}</Typography.Paragraph>

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -332,6 +332,14 @@ export class CourseService {
     return result;
   }
 
+  async setSelfStudy(githubId: string, comment: string = '') {
+    await this.axios.post<any>(`/student/${githubId}/status`, { comment, status: 'self-study' });
+  }
+
+  async selfSetSelfStudy(githubId: string, comment: string = '') {
+    await this.axios.post<any>(`/student/${githubId}/status-self`, { comment, status: 'self-study' });
+  }
+
   async expelStudents(
     criteria: { courseTaskIds?: number[]; minScore?: number },
     options: { keepWithMentor?: boolean },

--- a/server/src/repositories/student.repository.ts
+++ b/server/src/repositories/student.repository.ts
@@ -23,6 +23,18 @@ export class StudentRepository extends AbstractRepository<Student> {
     await repo.cancelByStudent(courseId, githubId);
   }
 
+  public async setSelfStudy(courseId: number, githubId: string, comment = '') {
+    const student = await this.findByGithubId(courseId, githubId);
+    if (student == null) {
+      return;
+    }
+    await getRepository(Student).update(student.id, {
+      mentorId: null,
+      mentoring: false,
+      expellingReason: comment || '',
+    });
+  }
+
   public async restore(courseId: number, githubId: string) {
     const student = await this.findByGithubId(courseId, githubId);
     if (student == null) {

--- a/server/src/routes/course/student.ts
+++ b/server/src/routes/course/student.ts
@@ -12,7 +12,7 @@ type FeedbackInput = { toUserId: number; comment: string };
 
 export const updateStudentStatus = (_: ILogger) => async (ctx: Router.RouterContext) => {
   const { githubId, courseId } = ctx.params;
-  const data: { comment?: string; status: 'expelled' | 'active' } = ctx.request.body;
+  const data: { comment?: string; status: 'expelled' | 'active' | 'self-study' } = ctx.request.body;
   const { allow, message = 'no access' } = await studentService.canChangeStatus(ctx.state.user, courseId, githubId);
 
   if (!allow) {
@@ -30,6 +30,10 @@ export const updateStudentStatus = (_: ILogger) => async (ctx: Router.RouterCont
       await studentRepository.expel(courseId, githubId, data.comment);
       setResponse(ctx, OK);
       break;
+    case 'self-study':
+      await studentRepository.setSelfStudy(courseId, githubId, data.comment);
+      setResponse(ctx, OK);
+      break;
     default:
       setResponse(ctx, BAD_REQUEST, { message: 'not supported status' });
       break;
@@ -38,11 +42,13 @@ export const updateStudentStatus = (_: ILogger) => async (ctx: Router.RouterCont
 
 export const selfUpdateStudentStatus = (_: ILogger) => async (ctx: Router.RouterContext) => {
   const { githubId, courseId } = ctx.params;
-  const data: { comment?: string } = ctx.request.body;
+  const data: { status: 'expelled' | 'self-study'; comment?: string } = ctx.request.body;
 
   if (ctx.state.user.githubId === githubId) {
     const studentRepository = getCustomRepository(StudentRepository);
-    await studentRepository.expel(courseId, githubId, data.comment);
+    await (data.status === 'expelled'
+      ? studentRepository.expel(courseId, githubId, data.comment)
+      : studentRepository.setSelfStudy(courseId, githubId));
     setResponse(ctx, OK);
   } else {
     setResponse(ctx, BAD_REQUEST, { message: 'access denied' });


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

This fixes #1092 

#### 💡 Background and solution

Added **self-study** option and description for it:
<img width="633" alt="image" src="https://user-images.githubusercontent.com/3992761/159565991-426bebfd-5e87-4a9b-a53e-276fa899bbd8.png">

Description for **unassign** option has been updated:
<img width="633" alt="image" src="https://user-images.githubusercontent.com/3992761/159566111-0ce1ceb7-ebf5-43fa-9135-888cc7e2b6b2.png">

Don't have user in the wait list after applying **self-study** option:
<img width="633" alt="image" src="https://user-images.githubusercontent.com/3992761/159566321-69f622f4-fde1-45cb-8100-f61901f21c9b.png">


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
