### PR TITLE
fix: remove horizontal scroll on PageLayoutSimple 

### DIFF
--- a/client/src/components/PageLayout.tsx
+++ b/client/src/components/PageLayout.tsx
@@ -35,7 +35,7 @@ export function PageLayoutSimple(props: Props) {
         ) : (
           <Spin spinning={props.loading}>
             <Row style={{ marginTop: 16 }}></Row>
-            <Row gutter={24}>
+            <Row>
               <Col flex={1} />
               <Col xs={20} sm={16} md={16} lg={12} xl={12}>
                 {props.children}


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[issue#1372](https://github.com/rolling-scopes/rsschool-app/issues/1372)

#### 💡 Background and solution

Tried to reproduce this bug on production (both Ubuntu/Windows 10, Chrome).
Haven't been able to reproduce vertical scroll, I think it's fixed already;

As for horizontal scroll - it caused by PageLayoutSimple component.
It is used on several pages, but I was able to check the fix only on this ones: 
- Expel/Unassign Student;
- #gratitude;
- Submit Scores;

Can't find this pages, not that familiar with interface (maybe I should be logged as mentor - don't know how): 
- /client/src/pages/course/mentor/submit-review;
- /client/src/pages/course/mentor/interview-technical-screening;
- /client/src/pages/course/mentor/interview-corejs;
- /client/src/pages/course/mentor/confirm;
- /client/src/modules/Mentor/pages/Students/index;
- /client/src/modules/Mentor/pages/StudentFeedback/index
- /client/src/modules/Interviews/pages/InterviewFeedback/index
 
![Screenshot from 2022-04-25 13-17-34](https://user-images.githubusercontent.com/67139199/165070253-6e770504-8565-4a40-aa2b-67ac9c894471.png)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
