### PR TITLE
feat: display score weight in schedule

### DIFF
--- a/client/src/components/Schedule/model.ts
+++ b/client/src/components/Schedule/model.ts
@@ -54,7 +54,7 @@ export const courseTaskToScheduleEvent = (courseTask: CourseTaskDetails): Schedu
   score: {
     total: courseTask.score ?? 0,
     max: courseTask.maxScore ?? 0,
-    weight: courseTask.scoreWeight ?? 2,
+    weight: courseTask.scoreWeight ?? 1,
     donePercent:
       courseTask.score && courseTask.maxScore ? Math.floor((courseTask.score / courseTask.maxScore) * 100) : 0,
   },

--- a/client/src/components/Schedule/model.ts
+++ b/client/src/components/Schedule/model.ts
@@ -17,6 +17,7 @@ export interface ScheduleEvent {
   score: {
     total: number;
     max: number;
+    weight: number;
     donePercent: number;
   } | null;
 }
@@ -53,6 +54,7 @@ export const courseTaskToScheduleEvent = (courseTask: CourseTaskDetails): Schedu
   score: {
     total: courseTask.score ?? 0,
     max: courseTask.maxScore ?? 0,
+    weight: courseTask.scoreWeight ?? 2,
     donePercent:
       courseTask.score && courseTask.maxScore ? Math.floor((courseTask.score / courseTask.maxScore) * 100) : 0,
   },

--- a/client/src/components/Table/renderers.tsx
+++ b/client/src/components/Table/renderers.tsx
@@ -159,15 +159,21 @@ export const urlRenderer = (url: string) =>
     </Tooltip>
   );
 
-export const scoreRenderer = (score: { total: number; max: number; donePercent: number } | null) => {
+export const scoreRenderer = (score: { total: number; max: number; donePercent: number; weight: number } | null) => {
   if (!score) return null;
 
-  const { total, max, donePercent } = score;
+  const { total, max, donePercent, weight } = score;
+  const formateWeight = Math.round(weight * 100) / 100;
 
   return (
     <Tooltip placement="topLeft" title={`Done: ${donePercent}%`}>
       <Text strong>
-        {total}/{max}
+        {total}/{max}{' '}
+        {formateWeight !== 1 ? (
+          <span style={{ color: 'gray', fontSize: '0.6rem', fontWeight: 'normal' }}>x{formateWeight}</span>
+        ) : (
+          ''
+        )}
       </Text>
     </Tooltip>
   );


### PR DESCRIPTION
Добавлено отображение множителя очков в табличном виде расписания. Отображается, если множитель отличен от единицы. В таком виде, думаю лучше, чем заводить отдельный столбец для этого поля. Информативно и не отнимает место.


#### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other


#### 🔗 Related issue link
#1391 


#### 💡 Background and solution

![weight_disp2](https://user-images.githubusercontent.com/83158288/169649399-01ce0b02-790b-409e-a035-b477bedad8f9.jpg)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Database migration is added or not needed
- [X] Documentation is updated/provided or not needed
- [X] Changes are tested locally
