### PR TITLE
feat: display calculated score with tooltip in score table

### DIFF
--- a/client/src/modules/Score/components/ScoreTable/index.tsx
+++ b/client/src/modules/Score/components/ScoreTable/index.tsx
@@ -1,5 +1,5 @@
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Popover, Table } from 'antd';
+import { Popover, Table, Tooltip } from 'antd';
 import { dateTimeRenderer } from 'components/Table';
 import { isUndefined } from 'lodash';
 import { getColumns } from 'modules/Score/data/getColumns';
@@ -195,7 +195,13 @@ function getTaskColumns(courseTasks: CourseTaskDto[]): IColumn[] {
     className: 'align-right',
     render: (_: any, d: StudentScore) => {
       const currentTask = d.taskResults.find(taskResult => taskResult.courseTaskId === courseTask.id);
-      return currentTask ? <div>{currentTask.score}</div> : 0;
+      return currentTask ? (
+        <Tooltip title={`Score: ${currentTask.score} / ${courseTask.maxScore}. Coefficient: ${courseTask.scoreWeight}`}>
+          <div>{currentTask.score * courseTask.scoreWeight}</div>
+        </Tooltip>
+      ) : (
+        0
+      );
     },
     name: courseTask.name,
   }));


### PR DESCRIPTION
Предлагаю в таблице отображать сразу итоговое число очков с учетом коэффициента. В текущем варианте, чтобы понять, сколько в реальности принесло очков выполнение той или иной задачи, приходится кликать на иконку с вопросом в заголовке, смотреть коэффициент и считать в уме. Лично для меня, как пользователя, для которого и предназначена эта таблица, это очень не удобно. Тем более, коэффициент может меняться прямо во время курса. 

При наведении курсора на очки показывается подробная информация в тултипе. Предлагаю обсудить, и если большинству понравится, принять доработку или предложить другую реализацию. Реализация может быть разной, мне она видится именно в таком виде. 

***
![Screenshot_17](https://user-images.githubusercontent.com/83158288/170323106-f1c38d40-f60f-4e95-8d57-280be574dca9.png)
***
![Screenshot_18](https://user-images.githubusercontent.com/83158288/170323141-07d01910-9c9d-4aa2-958a-db2a2362ce78.png)


#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [x] Other

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
