### PR TITLE
fix: score table bugs

### DIFF
--- a/client/src/modules/Score/components/ScoreTable/index.tsx
+++ b/client/src/modules/Score/components/ScoreTable/index.tsx
@@ -1,12 +1,12 @@
-import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Popover, Table } from 'antd';
-import { dateTimeRenderer } from 'components/Table';
+import { Table } from 'antd';
+import { ColumnsType } from 'antd/lib/table';
 import { isUndefined } from 'lodash';
 import { getColumns } from 'modules/Score/data/getColumns';
+import { getTaskColumns } from 'modules/Score/data/getTaskColumns';
 import { useScorePaging } from 'modules/Score/hooks/useScorePaging';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { CourseService, IColumn, StudentScore } from 'services/course';
+import { CourseService, StudentScore } from 'services/course';
 import { CoursePageProps } from 'services/models';
 import css from 'styled-jsx/css';
 import { IPaginationInfo } from 'common/types/pagination';
@@ -15,6 +15,7 @@ import { SettingsModal } from 'modules/Score/components/SettingsModal';
 import { Store } from 'rc-field-form/lib/interface';
 import { useLocalStorage } from 'react-use';
 import { CoursesTasksApi, CourseTaskDto } from 'api';
+import useWindowDimensions from 'utils/useWindowDimensions';
 
 type Props = CoursePageProps & {
   onLoading: (value: boolean) => void;
@@ -25,11 +26,16 @@ const courseTasksApi = new CoursesTasksApi();
 
 export function ScoreTable(props: Props) {
   const router = useRouter();
+  const { width } = useWindowDimensions();
   const { activeOnly } = props;
   const { ['mentor.githubId']: mentor, cityName } = router.query;
 
-  const courseService = useMemo(() => new CourseService(props.course.id), []);
-
+  const [isVisibleSetting, setIsVisibleSettings] = useState(false);
+  const [columns, setColumns] = useState<ColumnsType<StudentScore>>([]);
+  const [fixedColumn, setFixedColumn] = useState<boolean>(true);
+  const [courseTasks, setCourseTasks] = useState([] as CourseTaskDto[]);
+  const [loaded, setLoaded] = useState(false);
+  const [state, setState] = useState(['']);
   const [students, setStudents] = useState({
     content: [] as StudentScore[],
     pagination: { current: 1, pageSize: 100 } as IPaginationInfo,
@@ -37,9 +43,8 @@ export function ScoreTable(props: Props) {
     orderBy: { field: 'rank', direction: 'asc' },
   });
 
-  const [courseTasks, setCourseTasks] = useState([] as CourseTaskDto[]);
-  const [loaded, setLoaded] = useState(false);
-
+  const [notVisibleColumns, setNotVisibleColumns] = useLocalStorage<string[]>('notVisibleColumns', []);
+  const courseService = useMemo(() => new CourseService(props.course.id), []);
   const [getPagedData] = useScorePaging(router, courseService, activeOnly);
 
   const getCourseScore = async (pagination: IPaginationInfo, filters: ScoreTableFilters, order: ScoreOrder) => {
@@ -76,6 +81,14 @@ export function ScoreTable(props: Props) {
         }));
       setStudents({ ...students, content: courseScore.content, pagination: courseScore.pagination });
       setCourseTasks(sortedTasks);
+      setColumns(
+        getColumns({
+          cityName,
+          mentor,
+          handleSettings: () => setIsVisibleSettings(true),
+          taskColumns: getTaskColumns(sortedTasks),
+        }),
+      );
 
       setLoaded(true);
     } finally {
@@ -83,20 +96,7 @@ export function ScoreTable(props: Props) {
     }
   }, [activeOnly]);
 
-  useEffect(() => loadInitialData() as any, [activeOnly]);
-
-  const [isVisibleSetting, setIsVisibleSettings] = useState(false);
-
-  const columns = getColumns({
-    cityName,
-    mentor,
-    handleSettings: () => setIsVisibleSettings(true),
-    taskColumns: getTaskColumns(courseTasks),
-  });
-
   const getVisibleColumns = (columns: any[]) => columns.filter(column => !notVisibleColumns?.includes(column.name));
-
-  const [notVisibleColumns, setNotVisibleColumns] = useLocalStorage<string[]>('notVisibleColumns', []);
 
   const handleModalCancel = () => {
     setIsVisibleSettings(!isVisibleSetting);
@@ -107,7 +107,29 @@ export function ScoreTable(props: Props) {
     setIsVisibleSettings(!isVisibleSetting);
   };
 
-  const [state, setState] = useState(['']);
+  useEffect(() => {
+    loadInitialData();
+  }, [activeOnly]);
+
+  useEffect(() => {
+    if (width < 400) {
+      setFixedColumn(false);
+      return;
+    }
+
+    setFixedColumn(true);
+  }, [width]);
+
+  useEffect(() => {
+    setColumns(prevColumns => {
+      const githubColumn = prevColumns.find(el => el.key === 'githubId');
+      if (githubColumn) {
+        githubColumn.fixed = fixedColumn ? 'left' : false;
+      }
+
+      return prevColumns;
+    });
+  }, [fixedColumn, loaded]);
 
   if (!loaded) {
     return null;
@@ -118,7 +140,7 @@ export function ScoreTable(props: Props) {
       <Table<StudentScore>
         className="table-score"
         showHeader
-        scroll={{ x: getTableWidth(getVisibleColumns(columns).length), y: 'calc(100vh - 250px)' }}
+        scroll={{ x: getTableWidth(getVisibleColumns(columns).length), y: 'calc(95vh - 290px)' }}
         pagination={{ ...students.pagination, showTotal: total => `Total ${total} students` }}
         rowKey="githubId"
         rowClassName={record => (!record.isActive ? 'rs-table-row-disabled' : '')}
@@ -160,48 +182,6 @@ function getTableWidth(columnsCount: number) {
   return tableWidth;
 }
 
-function getTaskColumns(courseTasks: CourseTaskDto[]): IColumn[] {
-  const columns = courseTasks.map(courseTask => ({
-    dataIndex: courseTask.id.toString(),
-    title: () => {
-      const icon = (
-        <Popover
-          content={
-            <ul>
-              <li>Coefficient: {courseTask.scoreWeight}</li>
-              <li>Deadline: {dateTimeRenderer(courseTask.studentEndDate)}</li>
-              <li>Max. score: {courseTask.maxScore}</li>
-            </ul>
-          }
-          trigger="click"
-        >
-          <QuestionCircleOutlined title="Click for details" />
-        </Popover>
-      );
-      return courseTask.descriptionUrl ? (
-        <>
-          <a className="table-header-link" target="_blank" href={courseTask.descriptionUrl}>
-            {courseTask.name}
-          </a>{' '}
-          {icon}
-        </>
-      ) : (
-        <div>
-          {courseTask.name} {icon}
-        </div>
-      );
-    },
-    width: 100,
-    className: 'align-right',
-    render: (_: any, d: StudentScore) => {
-      const currentTask = d.taskResults.find(taskResult => taskResult.courseTaskId === courseTask.id);
-      return currentTask ? <div>{currentTask.score}</div> : 0;
-    },
-    name: courseTask.name,
-  }));
-  return columns;
-}
-
 const styles = css`
   :global(.rs-table-row-disabled) {
     opacity: 0.25;
@@ -212,5 +192,8 @@ const styles = css`
   }
   :global(.table-score td a) {
     line-height: 24px;
+  }
+  :global(.table-score .ant-table-body) {
+    min-height: 200px;
   }
 `;

--- a/client/src/modules/Score/data/getColumns.tsx
+++ b/client/src/modules/Score/data/getColumns.tsx
@@ -1,5 +1,6 @@
 import { SettingFilled } from '@ant-design/icons';
 import { Typography } from 'antd';
+import { ColumnsType } from 'antd/lib/table';
 import { GithubAvatar } from 'components/GithubAvatar';
 import { dateRenderer, getColumnSearchProps } from 'components/Table';
 import { isArray } from 'lodash';
@@ -20,7 +21,7 @@ const getSearchProps = (key: string) => ({
   onFilter: undefined,
 });
 
-export function getColumns(props: Props) {
+export function getColumns(props: Props): ColumnsType<StudentScore> {
   const { cityName, mentor, handleSettings, taskColumns } = props;
   return [
     {
@@ -55,7 +56,7 @@ export function getColumns(props: Props) {
       dataIndex: 'name',
       width: 150,
       sorter: 'name',
-      render: (value: any, record: StudentScore) => (
+      render: (value: string, record) => (
         <Link prefetch={false} href={`/profile?githubId=${record.githubId}`}>
           <a>{value}</a>
         </Link>

--- a/client/src/modules/Score/data/getTaskColumns.tsx
+++ b/client/src/modules/Score/data/getTaskColumns.tsx
@@ -1,0 +1,47 @@
+import { QuestionCircleOutlined } from '@ant-design/icons';
+import { Popover } from 'antd';
+import { CourseTaskDto } from 'api';
+import { dateTimeRenderer } from 'components/Table';
+import { IColumn, StudentScore } from 'services/course';
+
+export function getTaskColumns(courseTasks: CourseTaskDto[]): IColumn[] {
+  const columns = courseTasks.map(courseTask => ({
+    dataIndex: courseTask.id.toString(),
+    title: () => {
+      const icon = (
+        <Popover
+          content={
+            <ul>
+              <li>Coefficient: {courseTask.scoreWeight}</li>
+              <li>Deadline: {dateTimeRenderer(courseTask.studentEndDate)}</li>
+              <li>Max. score: {courseTask.maxScore}</li>
+            </ul>
+          }
+          trigger="click"
+        >
+          <QuestionCircleOutlined title="Click for details" />
+        </Popover>
+      );
+      return courseTask.descriptionUrl ? (
+        <>
+          <a className="table-header-link" target="_blank" href={courseTask.descriptionUrl}>
+            {courseTask.name}
+          </a>{' '}
+          {icon}
+        </>
+      ) : (
+        <div>
+          {courseTask.name} {icon}
+        </div>
+      );
+    },
+    width: 100,
+    className: 'align-right',
+    render: (_: any, d: StudentScore) => {
+      const currentTask = d.taskResults.find(taskResult => taskResult.courseTaskId === courseTask.id);
+      return currentTask ? <div>{currentTask.score}</div> : 0;
+    },
+    name: courseTask.name,
+  }));
+  return columns;
+}


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[issue#1420](https://github.com/rolling-scopes/rsschool-app/issues/1420)

#### 💡 Background and solution
This PR contains work that was done in [PR#1452](https://github.com/rolling-scopes/rsschool-app/pull/1452)
Extra changes: 
- setColumns() moved inside `loadInitialData` function (fixes absence of task columns in the score table);
- ordered code inside `ScoreTable` component: declare variables/state -> function expressions -> useEffect() calls -> return; 
- getTaskColumns() moved in separate file;

![Screenshot from 2022-05-31 15-52-15](https://user-images.githubusercontent.com/67139199/171177904-a1381bbc-92f9-4731-b3f9-50c3ce5de31c.png)
![Screenshot from 2022-05-31 15-56-19](https://user-images.githubusercontent.com/67139199/171178563-285caa6a-202b-4f2d-b853-3ab6ad3d1651.png)
![Screenshot from 2022-05-31 16-11-52](https://user-images.githubusercontent.com/67139199/171181476-77170365-2876-433f-950a-770fafea1a18.png)
![Screenshot from 2022-05-31 16-15-28](https://user-images.githubusercontent.com/67139199/171182210-0e0f0adc-5271-45a3-9743-c60c58920534.png)
![Screenshot from 2022-05-31 16-16-13](https://user-images.githubusercontent.com/67139199/171182318-de02fa0c-f50e-4869-b0bb-3105ab583f45.png)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
