### PR TITLE
fix: remove title icons from dashboard cards

### DIFF
--- a/client/src/modules/StudentDashboard/components/CommonDashboardCard.tsx
+++ b/client/src/modules/StudentDashboard/components/CommonDashboardCard.tsx
@@ -9,7 +9,6 @@ type Props = {
   isMoreContent?: boolean | undefined;
   noDataDescription?: string | undefined;
   title: string;
-  icon: any;
   content: any;
 };
 
@@ -24,13 +23,13 @@ class CommonCard extends React.Component<Props, State> {
   };
 
   render() {
-    const { title, icon, content, isMoreContent, noDataDescription } = this.props;
+    const { title, content, isMoreContent, noDataDescription } = this.props;
 
     return (
       <Card
         title={
           <Title level={2} ellipsis={true} style={{ fontSize: 16, marginBottom: 0 }}>
-            {icon} {title}
+            {title}
           </Title>
         }
         actions={isMoreContent ? [<FullscreenOutlined key="main-card-actions-more" />].filter(Boolean) : []}

--- a/client/src/modules/StudentDashboard/components/MentorCard.tsx
+++ b/client/src/modules/StudentDashboard/components/MentorCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Typography, List } from 'antd';
 import CommonCard from './CommonDashboardCard';
-import { TeamOutlined, GithubFilled, EnvironmentFilled } from '@ant-design/icons';
+import { GithubFilled, EnvironmentFilled } from '@ant-design/icons';
 import { MentorBasic } from 'common/models';
 import { GithubAvatar } from 'components/GithubAvatar';
 
@@ -60,7 +60,6 @@ export function MentorCard(props: Props) {
   return (
     <CommonCard
       title="Mentor"
-      icon={<TeamOutlined />}
       content={
         props.mentor ? (
           <div style={{ display: 'flex', justifyContent: 'space-around', flexWrap: 'wrap' }}>

--- a/client/src/modules/StudentDashboard/components/NextEventCard.tsx
+++ b/client/src/modules/StudentDashboard/components/NextEventCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useLocalStorage } from 'react-use';
 import CommonCard from './CommonDashboardCard';
-import { ScheduleOutlined, YoutubeOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { YoutubeOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { CourseEvent } from 'services/course';
 import { Row, Col, Tag, Typography, Tooltip, Select } from 'antd';
 import { dateTimeTimeZoneRenderer } from './renderers';
@@ -61,7 +61,6 @@ export function NextEventCard(props: Props) {
   return (
     <CommonCard
       title="Next event"
-      icon={<ScheduleOutlined />}
       content={
         nextEvents.length ? (
           <div style={{ display: 'flex', justifyContent: 'space-around', flexDirection: 'column' }}>

--- a/client/src/modules/StudentDashboard/components/RepositoryCard.tsx
+++ b/client/src/modules/StudentDashboard/components/RepositoryCard.tsx
@@ -59,7 +59,6 @@ export function RepositoryCard(props: Props) {
     <Spin spinning={loading}>
       <CommonCard
         title="Your repository"
-        icon={<GithubFilled />}
         content={
           <div style={{ display: 'flex', justifyContent: 'space-around', flexWrap: 'wrap', alignItems: 'center' }}>
             <Row>

--- a/client/src/modules/StudentDashboard/components/TasksStatsCard.tsx
+++ b/client/src/modules/StudentDashboard/components/TasksStatsCard.tsx
@@ -1,4 +1,3 @@
-import { AuditOutlined } from '@ant-design/icons';
 import { CourseTaskDto } from 'api';
 import { StudentStats } from 'common/models';
 import dynamic from 'next/dynamic';
@@ -123,7 +122,6 @@ export function TasksStatsCard(props: Props) {
       />
       <CommonCard
         title="Tasks statistics"
-        icon={<AuditOutlined />}
         content={
           <div style={{ minWidth: 200, maxWidth: 200, margin: 'auto' }}>
             <TasksChart data={data} colors={colors} onItemSelected={data => updateUrl(data.type)} />


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [x] Other

#### 🔗 Related issue link

[issue#1375](https://github.com/rolling-scopes/rsschool-app/issues/1375)

#### 💡 Background and solution

Previously the title icon was removed on dashboard stats widget, this PR removes icons on all other dashboard cards for consistency as it was discussed on the related issue.
![Screenshot from 2022-06-13 09-38-41](https://user-images.githubusercontent.com/67139199/173294211-1441a914-a74b-433a-a31b-91540932104e.png)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
