### PR TITLE
fix: cross-check sort and duplicate orderby param in api queries

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -4581,7 +4581,7 @@ export const CoursesTasksApiAxiosParamCreator = function (configuration?: Config
             }
 
             if (orderBy !== undefined) {        
-                Array.isArray(orderBy)?localVarQueryParameter['orderBy'] = orderBy[0]:localVarQueryParameter['orderBy'] = orderBy;                
+                localVarQueryParameter['orderBy'] = Array.isArray(orderBy) ? orderBy[0]: orderBy;                
             }
 
             if (orderDirection !== undefined) {

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -4580,8 +4580,8 @@ export const CoursesTasksApiAxiosParamCreator = function (configuration?: Config
                 localVarQueryParameter['current'] = current;
             }
 
-            if (orderBy !== undefined) {
-                localVarQueryParameter['orderBy'] = orderBy;
+            if (orderBy !== undefined) {        
+                Array.isArray(orderBy)?localVarQueryParameter['orderBy'] = orderBy[0]:localVarQueryParameter['orderBy'] = orderBy;                
             }
 
             if (orderDirection !== undefined) {


### PR DESCRIPTION
* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link
#1510 

#### 💡 Background and solution

I discovered, when sorting by some fields and application make request to API, the orderBy parameter was duplicated. 
I propose the following solution - to check if it is an array, and if true, sort by the last selected field.

![Screenshot_2](https://user-images.githubusercontent.com/83158288/173779827-4c04334d-ef9c-4abd-8502-d45fbf962f4c.png)

Now sorting in admin cross-check works. However, it doesn't hurt to check other places where the same API can be used.

![Video_22-06-15_11-14-27(1)](https://user-images.githubusercontent.com/83158288/173781673-db29f419-e03f-4598-8b1b-8d390404ef7a.gif)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
