### PR TITLE
fix: score table sorter

### DIFF
--- a/client/src/modules/Score/data/getColumns.tsx
+++ b/client/src/modules/Score/data/getColumns.tsx
@@ -1,74 +1,24 @@
 import { SettingFilled } from '@ant-design/icons';
 import { Typography } from 'antd';
-import { CompareFn } from 'antd/lib/table/interface';
 import { GithubAvatar } from 'components/GithubAvatar';
 import { dateRenderer, getColumnSearchProps } from 'components/Table';
 import { isArray } from 'lodash';
 import Link from 'next/link';
-import { ColumnTypeWithName, StudentScore, StudentScoreWithCrossCheckScore } from 'services/course';
+import { ColumnTypeWithName, StudentScoreWithCrossCheckScore } from 'services/course';
 
 const { Text } = Typography;
 
 type Props = {
-  taskColumns: ColumnTypeWithName<StudentScore>[];
+  taskColumns: Record<string, any>[];
   cityName?: string | string[];
   mentor?: string | string[];
   handleSettings: () => void;
 };
 
-type StringOrNumber = string | number;
-
 const getSearchProps = (key: string) => ({
   ...getColumnSearchProps(key),
   onFilter: undefined,
 });
-
-const sort = <T,>(a: T, b: T): number => {
-  if (a > b) {
-    return 1;
-  }
-
-  if (a < b) {
-    return -1;
-  }
-
-  return 0;
-};
-
-const sortByMentor = (a: StudentScore['mentor'], b: StudentScore['mentor']): number => {
-  if (!a) {
-    return 1;
-  }
-
-  if (!b) {
-    return -1;
-  }
-
-  const itemA = 'githubId' in a ? a.githubId : a.id;
-  const itemB = 'githubId' in b ? b.githubId : b.id;
-
-  return sort(itemA, itemB);
-};
-
-function sorter(prop: keyof StudentScoreWithCrossCheckScore): CompareFn<StudentScoreWithCrossCheckScore> {
-  const isPropADate = prop === 'totalScoreChangeDate' || prop === 'repositoryLastActivityDate';
-  const isPropAMentor = prop === 'mentor';
-
-  return (a: StudentScoreWithCrossCheckScore, b: StudentScoreWithCrossCheckScore) => {
-    const itemA = a[prop];
-    const itemB = b[prop];
-
-    if (isPropADate) {
-      return sort(new Date(itemA as string), new Date(itemB as string));
-    }
-
-    if (isPropAMentor) {
-      return sortByMentor(itemA as StudentScore['mentor'], itemB as StudentScore['mentor']);
-    }
-
-    return sort(itemA as StringOrNumber, itemB as StringOrNumber);
-  };
-}
 
 export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCrossCheckScore>[] {
   const { cityName, mentor, handleSettings, taskColumns } = props;
@@ -80,7 +30,7 @@ export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCro
       dataIndex: 'rank',
       key: 'rank',
       width: 50,
-      sorter: sorter('rank'),
+      sorter: 'rank',
       render: (value: number) => (value >= 999999 ? 'New' : value),
     },
     {
@@ -88,7 +38,7 @@ export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCro
       fixed: 'left',
       key: 'githubId',
       dataIndex: 'githubId',
-      sorter: sorter('githubId'),
+      sorter: 'githubId',
       width: 150,
       render: (value: string) => (
         <div>
@@ -105,7 +55,7 @@ export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCro
       title: 'Name',
       dataIndex: 'name',
       width: 150,
-      sorter: sorter('name'),
+      sorter: 'name',
       render: (value, record) => (
         <Link prefetch={false} href={`/profile?githubId=${record.githubId}`}>
           <a>{value}</a>
@@ -117,7 +67,7 @@ export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCro
       title: 'City',
       dataIndex: 'cityName',
       width: 150,
-      sorter: sorter('cityName'),
+      sorter: 'cityName',
       defaultFilteredValue: cityName ? (isArray(cityName) ? cityName : [cityName]) : undefined,
       ...getSearchProps('cityName'),
     },
@@ -125,14 +75,14 @@ export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCro
       title: 'Total',
       dataIndex: 'totalScore',
       width: 80,
-      sorter: sorter('totalScore'),
+      sorter: 'totalScore',
       render: (value: number) => <Text strong>{value}</Text>,
     },
     {
       title: 'Cross-Check',
       dataIndex: 'crossCheckScore',
       width: 90,
-      sorter: sorter('crossCheckScore'),
+      sorter: 'crossCheckScore',
       render: (value: number) => <Text strong>{value}</Text>,
     },
     ...taskColumns,
@@ -140,21 +90,21 @@ export function getColumns(props: Props): ColumnTypeWithName<StudentScoreWithCro
       title: 'Change Date',
       dataIndex: 'totalScoreChangeDate',
       width: 80,
-      sorter: sorter('totalScoreChangeDate'),
+      sorter: 'totalScoreChangeDate',
       render: dateRenderer,
     },
     {
       title: 'Last Commit Date',
       dataIndex: 'repositoryLastActivityDate',
       width: 80,
-      sorter: sorter('repositoryLastActivityDate'),
+      sorter: 'repositoryLastActivityDate',
       render: dateRenderer,
     },
     {
       title: 'Mentor',
       dataIndex: ['mentor', 'githubId'],
       width: 150,
-      sorter: sorter('mentor'),
+      sorter: 'mentor',
       defaultFilteredValue: mentor ? (isArray(mentor) ? mentor : [mentor]) : undefined,
       render: (value: string) => (
         <Link prefetch={false} href={`/profile?githubId=${value}`}>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[issue#1526](https://github.com/rolling-scopes/rsschool-app/issues/1526)
[PR#1481](https://github.com/rolling-scopes/rsschool-app/pull/1481)

#### 💡 Background and solution

I returned `taskColumns: any[]` type and `sorter` as it was before my PR, which most likely will fix the issue, I can't be certain, because there're only 9 students on test db, no way to test if it works. 

I still don't get it why sorter works with just a column dataIndex/key and why provided sorter will sort only within current pagination section

UPDATE: set `taskColumns: Record<string, any>[]`

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
