### PR TITLE
fix: handle onreset in markdown input

### DIFF
--- a/client/src/components/Forms/MarkdownInput.tsx
+++ b/client/src/components/Forms/MarkdownInput.tsx
@@ -1,11 +1,14 @@
-import * as React from 'react';
+import { FC } from 'react';
 import { Input, Form, Button, Typography } from 'antd';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-export default function MarkdownInput(props: { [key: string]: any; notRequired?: boolean }) {
-  const { notRequired, ...otherProps } = props;
+type Props = {
+  notRequired?: boolean;
+};
+
+const MarkdownInput: FC<Props> = ({ notRequired = false }) => {
   const [previewVisible, setPreviewVisible] = useState(false);
   const [text, setText] = useState('');
 
@@ -28,7 +31,10 @@ export default function MarkdownInput(props: { [key: string]: any; notRequired?:
     <div style={{ marginBottom: '20px' }}>
       <div style={{ display: previewVisible ? 'none' : 'block' }}>
         <Form.Item
-          {...otherProps}
+          onReset={() => {
+            setText('');
+            setPreviewVisible(false);
+          }}
           name="comment"
           label="Comment (markdown syntax is supported)"
           rules={notRequired ? [] : [{ required: true, message: 'Please leave a detailed comment', min: 30 }]}
@@ -51,4 +57,6 @@ export default function MarkdownInput(props: { [key: string]: any; notRequired?:
       )}
     </div>
   );
-}
+};
+
+export default MarkdownInput;


### PR DESCRIPTION
* [x] I followed naming convention rules

#### 🤔 This is a ...

- [x] Bug fix

#### 🔗 Related issue link

#1513 

#### 💡 Background and solution

Reset text in textarea and preview of markdown component, switch to write mode if reset method of parent form handled.
![Video_22-06-21_23-18-51](https://user-images.githubusercontent.com/83158288/174890670-c912901d-502e-4083-8f27-8f2b2026592f.gif)

Component refactored, removed unused props. In application there is not cases of using other properties (besides notRequired) for the CommentInput component on the basis of which MarkdownInput was created and in place of which it can be applied.


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
