### PR TITLE
Fix: remove courseId from request body

### DIFF
--- a/client/src/pages/course/admin/events.tsx
+++ b/client/src/pages/course/admin/events.tsx
@@ -1,4 +1,8 @@
 import { Button, DatePicker, Form, Input, message, Popconfirm, Select, Table } from 'antd';
+import moment from 'moment';
+import { useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+import { omit } from 'lodash';
 import { CommentInput, ModalForm } from 'components/Forms';
 import { GithubUserLink } from 'components/GithubUserLink';
 import { AdminPageLayout } from 'components/PageLayout';
@@ -6,9 +10,7 @@ import { dateRenderer, idFromArrayRenderer } from 'components/Table';
 import { UserSearch } from 'components/UserSearch';
 import withCourseData from 'components/withCourseData';
 import withSession from 'components/withSession';
-import moment from 'moment';
-import { useMemo, useState } from 'react';
-import { useAsync } from 'react-use';
+
 import { CourseEvent, CourseService } from 'services/course';
 import { Event, EventService } from 'services/event';
 import { formatTimezoneToUTC } from 'services/formatter';
@@ -77,7 +79,7 @@ function Page(props: Props) {
       setModalLoading(true);
       const data = createRecord(values);
       modalAction === 'update'
-        ? await service.updateCourseEvent(modalData!.id!, data)
+        ? await service.updateCourseEvent(modalData!.id!, omit(data, 'eventId'))
         : await service.createCourseEvent(data);
 
       await refreshData();

--- a/client/src/pages/course/admin/tasks.tsx
+++ b/client/src/pages/course/admin/tasks.tsx
@@ -75,12 +75,12 @@ function Page(props: CoursePageProps) {
   };
 
   const handleModalSubmit = async (values: any) => {
-    const record = createRecord(values, props.course.id);
+    const record = createRecord(values);
 
     if (modalAction === 'update') {
       await service.updateCourseTask(modalData!.id!, record);
     } else {
-      const { courseId, ...rest } = record;
+      const { ...rest } = record;
       await service.createCourseTask(rest);
     }
     await loadData();
@@ -332,11 +332,10 @@ function getColumns(getDropdownMenu: (record: CourseTaskDetails) => any, { tasks
   ];
 }
 
-function createRecord(values: any, courseId: number) {
+function createRecord(values: any) {
   const [startDate, endDate] = values.range;
 
   const data = {
-    courseId,
     studentStartDate: formatTimezoneToUTC(startDate, values.timeZone),
     studentEndDate: formatTimezoneToUTC(endDate, values.timeZone),
     crossCheckEndDate: values.crossCheckEndDate


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/1560

#### 💡 Background and solution

Root cause of the bug was presence of the `courseId` in request for update from client. `courseId` is unexpected in new UpdateCourseTaskDto so this led to BAD_REQUEST response

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
