### PR TITLE
feat: add amend button for historical comment

### DIFF
--- a/client/src/components/Forms/MarkdownInput.tsx
+++ b/client/src/components/Forms/MarkdownInput.tsx
@@ -13,7 +13,9 @@ export default function MarkdownInput({ historicalCommentSelected }: Props) {
   const [text, setText] = useState('');
 
   useEffect(() => {
-    setText(historicalCommentSelected);
+    if (historicalCommentSelected !== '') {
+      setText(historicalCommentSelected);
+    }
   }, [historicalCommentSelected]);
 
   const toggleView = () => {

--- a/client/src/components/Forms/MarkdownInput.tsx
+++ b/client/src/components/Forms/MarkdownInput.tsx
@@ -1,12 +1,20 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 import { Input, Form, Button, Typography } from 'antd';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-export default function MarkdownInput() {
+type Props = {
+  historicalCommentSelected: string;
+};
+
+export default function MarkdownInput({ historicalCommentSelected }: Props) {
   const [previewVisible, setPreviewVisible] = useState(false);
   const [text, setText] = useState('');
+
+  useEffect(() => {
+    setText(historicalCommentSelected);
+  }, [historicalCommentSelected]);
 
   const toggleView = () => {
     setPreviewVisible(!previewVisible);
@@ -37,7 +45,7 @@ export default function MarkdownInput() {
           rules={[{ required: true, message: 'Please leave a detailed comment', min: 30 }]}
           onReset={resetText}
         >
-          <Input.TextArea value={text} onChange={({ currentTarget: { value } }) => setText(value)} rows={5} />
+          <Input.TextArea onChange={({ currentTarget: { value } }) => setText(value)} rows={5} />
         </Form.Item>
         <Button onClick={toggleView}>Preview</Button> {link}
       </div>

--- a/client/src/pages/course/student/cross-check-review.tsx
+++ b/client/src/pages/course/student/cross-check-review.tsx
@@ -158,7 +158,10 @@ function Page(props: CoursePageProps) {
   const { value: courseTasks = [] } = useAsync(() => courseService.getCourseCrossCheckTasks(), [props.course.id]);
 
   useEffect(() => {
-    form.setFieldsValue({ comment: historicalCommentSelected });
+    if (historicalCommentSelected !== '') {
+      form.setFieldsValue({ comment: historicalCommentSelected });
+      setHistoricalCommentSelected('');
+    }
   }, [historicalCommentSelected]);
 
   const handleSubmit = async (values: any) => {

--- a/client/src/pages/course/student/cross-check-review.tsx
+++ b/client/src/pages/course/student/cross-check-review.tsx
@@ -5,6 +5,8 @@ import {
   EyeTwoTone,
   EyeFilled,
   StarTwoTone,
+  EditOutlined,
+  EditFilled,
 } from '@ant-design/icons';
 import { Button, Checkbox, Col, Form, message, Row, Spin, Timeline, Typography } from 'antd';
 import CopyToClipboardButton from 'components/CopyToClipboardButton';
@@ -15,7 +17,7 @@ import { PageLayout } from 'components/PageLayout';
 import { UserSearch } from 'components/UserSearch';
 import withCourseData from 'components/withCourseData';
 import withSession, { CourseRole } from 'components/withSession';
-import { useEffect, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { useAsync, useLocalStorage } from 'react-use';
 import { CourseService } from 'services/course';
 import { formatDateTime } from 'services/formatter';
@@ -30,7 +32,12 @@ type Assignment = { student: StudentBasic; url: string };
 type HistoryItem = { comment: string; score: number; dateTime: number; anonymous: boolean };
 const colSizes = { xs: 24, sm: 18, md: 12, lg: 10 };
 
-function CrossCheckHistory(props: { githubId: string | null; courseId: number; courseTaskId: number | null }) {
+function CrossCheckHistory(props: {
+  githubId: string | null;
+  courseId: number;
+  courseTaskId: number | null;
+  setHistoricalCommentSelected: Dispatch<SetStateAction<string>>;
+}) {
   if (props.githubId == null || props.courseTaskId == null) {
     return null;
   }
@@ -49,6 +56,11 @@ function CrossCheckHistory(props: { githubId: string | null; courseId: number; c
   useEffect(() => {
     loadStudentScoreHistory(githubId);
   }, [githubId]);
+
+  const handleClickAmendButton = (historicalComment: string) => {
+    const commentWithoutMarkdownLabel = historicalComment.slice(markdownLabel.length);
+    props.setHistoricalCommentSelected(commentWithoutMarkdownLabel);
+  };
 
   return (
     <Spin spinning={state.loading}>
@@ -83,6 +95,17 @@ function CrossCheckHistory(props: { githubId: string | null; courseId: number; c
             </div>
             <div>
               <PreparedComment text={historyItem.comment} />
+            </div>
+            <div>
+              <Button
+                size="middle"
+                type={i === 0 ? 'primary' : 'default'}
+                htmlType="button"
+                icon={i === 0 ? <EditFilled /> : <EditOutlined />}
+                onClick={() => handleClickAmendButton(historyItem.comment)}
+              >
+                Amend
+              </Button>
             </div>
           </Timeline.Item>
         ))}
@@ -127,11 +150,16 @@ function Page(props: CoursePageProps) {
   const [githubId, setGithubId] = useState<string | null>(null);
   const [assignments, setAssignments] = useState<Assignment[]>([]);
   const [submissionDisabled, setSubmissionDisabled] = useState<boolean>(true);
+  const [historicalCommentSelected, setHistoricalCommentSelected] = useState<string>(form.getFieldValue('comment'));
   const [isUsernameVisible = false, setIsUsernameVisible] = useLocalStorage<boolean>(LocalStorage.IsUsernameVisible);
 
   const courseService = useMemo(() => new CourseService(props.course.id), [props.course.id]);
 
   const { value: courseTasks = [] } = useAsync(() => courseService.getCourseCrossCheckTasks(), [props.course.id]);
+
+  useEffect(() => {
+    form.setFieldsValue({ comment: historicalCommentSelected });
+  }, [historicalCommentSelected]);
 
   const handleSubmit = async (values: any) => {
     if (!values.githubId || loading) {
@@ -199,7 +227,7 @@ function Page(props: CoursePageProps) {
               <CrossCheckAssignmentLink assignment={assignment} />
             </Form.Item>
             <ScoreInput courseTask={courseTask} />
-            <MarkdownInput />
+            <MarkdownInput historicalCommentSelected={historicalCommentSelected} />
             <Form.Item name="visibleName" valuePropName="checked" initialValue={isUsernameVisible}>
               <Checkbox onChange={handleUsernameVisibilityChange}>Make my name visible in feedback</Checkbox>
             </Form.Item>
@@ -221,7 +249,12 @@ function Page(props: CoursePageProps) {
           </Form>
         </Col>
         <Col {...colSizes}>
-          <CrossCheckHistory githubId={githubId} courseId={props.course.id} courseTaskId={courseTaskId} />
+          <CrossCheckHistory
+            githubId={githubId}
+            courseId={props.course.id}
+            courseTaskId={courseTaskId}
+            setHistoricalCommentSelected={setHistoricalCommentSelected}
+          />
         </Col>
       </Row>
     </PageLayout>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#### 💡 Background and solution

При проверки работ на кросс-чеке нет возможности дополнить комментарий с разметкой markdown. Если необходимо дополнить комментарий, то не получится полностью скопировать его через `ctrl + c`. И приходится заново находить форму и проставлять крестики в выполненных пунктах.
Предлагаю добавить в комментарии кнопку , которая позволит по клику перенести комментарии в заполняемую проверяющим форму.
Кнопка с синим фоном появляется на самом свежем комментарии.
Кнопка с прозрачным фоном появляется на всех остальных.

![button](https://user-images.githubusercontent.com/48645737/177389498-12a4454f-219d-4b8a-ac27-29ba4c56e9b4.png)

<details>
  <summary>Before (GIF)</summary>

![Desktop 2022 07 05 - 20 51 59 01](https://user-images.githubusercontent.com/48645737/177389218-98901392-8dcb-4e5d-aa09-82571e1eb6de.gif)

</details>

<details>
  <summary>After (GIF)</summary>

![Desktop 2022 07 05 - 21 01 01 02](https://user-images.githubusercontent.com/48645737/177389324-d1d32d2d-3862-4383-9e4e-0c54cec7688d.gif)

</details>


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
