### PR TITLE
fix: fix incorrect display of score at zero points

### DIFF
--- a/client/src/components/CrossCheckComments.tsx
+++ b/client/src/components/CrossCheckComments.tsx
@@ -1,5 +1,5 @@
 import { UserOutlined } from '@ant-design/icons';
-import { Col, Comment, Divider, Row } from 'antd';
+import { Col, Comment, Divider, Row, Typography } from 'antd';
 import { GithubUserLink } from 'components/GithubUserLink';
 import PreparedComment from './Forms/PreparedComment';
 
@@ -31,11 +31,7 @@ export function CrossCheckComments(props: Props) {
             avatar={<UserOutlined />}
             content={
               <>
-                {score ? (
-                  <p>
-                    <b>Score: {score}</b>
-                  </p>
-                ) : null}
+                <Typography.Paragraph strong>Score: {score}</Typography.Paragraph>
                 <PreparedComment text={comment} />
               </>
             }

--- a/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
+++ b/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
@@ -11,12 +11,12 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              5
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            5
+          </Paragraph>
           <PreparedComment
             text="Awful job, you better quit programming and learn to cross stitch."
           />
@@ -38,12 +38,12 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              5
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            5
+          </Paragraph>
           <PreparedComment
             text="Awful job, you better quit programming and learn to cross stitch."
           />
@@ -65,12 +65,12 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              5
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            5
+          </Paragraph>
           <PreparedComment
             text="Awful job, you better quit programming and learn to cross stitch."
           />
@@ -97,12 +97,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              5
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            5
+          </Paragraph>
           <PreparedComment
             text="Awful job, you better quit programming and learn to cross stitch."
           />
@@ -124,12 +124,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              5
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            5
+          </Paragraph>
           <PreparedComment
             text="Awful job, you better quit programming and learn to cross stitch."
           />
@@ -155,12 +155,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              100
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            100
+          </Paragraph>
           <PreparedComment
             text="Great job, you better quit cross stitching and start programming."
           />
@@ -186,12 +186,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              100
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            100
+          </Paragraph>
           <PreparedComment
             text="Great job, you better quit cross stitching and start programming."
           />
@@ -213,12 +213,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              5
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            5
+          </Paragraph>
           <PreparedComment
             text="Awful job, you better quit programming and learn to cross stitch."
           />
@@ -249,12 +249,12 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              100
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            100
+          </Paragraph>
           <PreparedComment
             text="Great job, you better quit cross stitching and start programming."
           />
@@ -280,12 +280,12 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              100
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            100
+          </Paragraph>
           <PreparedComment
             text="Great job, you better quit cross stitching and start programming."
           />
@@ -311,12 +311,12 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       avatar={<ForwardRef(UserOutlined) />}
       content={
         <React.Fragment>
-          <p>
-            <b>
-              Score: 
-              100
-            </b>
-          </p>
+          <Paragraph
+            strong={true}
+          >
+            Score: 
+            100
+          </Paragraph>
           <PreparedComment
             text="Great job, you better quit cross stitching and start programming."
           />


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#### 💡 Background and solution

Если выставить оценку 0 на кросс-чеке, то оценка не отображается у проверяемого студента.

Изменил условие для отображения оценки

<details>
 <summary>(IMG)</summary>

![pull](https://user-images.githubusercontent.com/48645737/178575412-ac97b80f-c6ba-4a41-8cd7-28c781eaa386.png)

 </details>


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
