### PR TITLE
fix: cross-check table sorters

### DIFF
--- a/client/src/pages/course/admin/cross-check-table.tsx
+++ b/client/src/pages/course/admin/cross-check-table.tsx
@@ -9,10 +9,10 @@ import withCourseData from 'components/withCourseData';
 import { withSession } from 'components/withSession';
 import { isArray, omit } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { CourseService, CourseTaskDetails, CrossCheckPairs } from 'services/course';
+import { CourseService, CourseTaskDetails } from 'services/course';
 import { CoursePageProps } from 'services/models';
 import css from 'styled-jsx/css';
-import { CoursesTasksApi } from 'api';
+import { CoursesTasksApi, CrossCheckPairDto } from 'api';
 import PreparedComment from 'components/Forms/PreparedComment';
 
 const { Text } = Typography;
@@ -57,7 +57,7 @@ export function Page(props: CoursePageProps) {
   const [loading, setLoading] = useState(false);
   const [courseTasks, setCourseTasks] = useState<CourseTaskDetails[]>([]);
   const [crossCheckList, setCrossCheckList] = useState({
-    content: [] as CrossCheckPairs[],
+    content: [] as CrossCheckPairDto[],
     pagination: { current: 1, pageSize: 100 } as IPaginationInfo,
     orderBy: { field: DEFAULT_ORDER_BY, order: DEFAULT_ORDER_DIRECTION },
   });
@@ -92,7 +92,7 @@ export function Page(props: CoursePageProps) {
     async (
       pagination: TablePaginationConfig,
       filters: Record<keyof Filters, FilterValue | null>,
-      sorter: Sorter<CrossCheckPairs>,
+      sorter: Sorter<CrossCheckPairDto>,
     ) => {
       if (isArray(sorter)) {
         return;
@@ -109,7 +109,7 @@ export function Page(props: CoursePageProps) {
           courseId,
           pagination.pageSize as IPaginationInfo['pageSize'],
           pagination.current as IPaginationInfo['current'],
-          orderBy.field.toString(),
+          orderBy.field,
           orderBy.order,
           filters.checker?.toString(),
           filters.student?.toString(),
@@ -120,7 +120,7 @@ export function Page(props: CoursePageProps) {
           content: data.items,
           pagination: data.pagination,
           orderBy: {
-            field: orderBy.field.toString(),
+            field: orderBy.field,
             order: orderBy.order,
           },
         });
@@ -163,7 +163,7 @@ export function Page(props: CoursePageProps) {
   );
 }
 
-const getColumns = (viewComment: (value: CrossCheckPairs) => void): CustomColumnType<CrossCheckPairs>[] => [
+const getColumns = (viewComment: (value: CrossCheckPairDto) => void): CustomColumnType<CrossCheckPairDto>[] => [
   {
     title: 'Task',
     fixed: 'left',
@@ -270,14 +270,14 @@ const getColumns = (viewComment: (value: CrossCheckPairs) => void): CustomColumn
 
 function renderTable(
   loaded: boolean,
-  crossCheckPairs: CrossCheckPairs[],
+  crossCheckPairs: CrossCheckPairDto[],
   pagination: TablePaginationConfig,
   handleChange: (
     pagination: TablePaginationConfig,
     filters: Record<keyof Filters, FilterValue | null>,
-    sorter: Sorter<CrossCheckPairs>,
+    sorter: Sorter<CrossCheckPairDto>,
   ) => void,
-  viewComment: (value: CrossCheckPairs) => void,
+  viewComment: (value: CrossCheckPairDto) => void,
 ) {
   if (!loaded) {
     return null;
@@ -285,7 +285,7 @@ function renderTable(
   // where 800 is approximate sum of basic columns (GitHub, Name, etc.)
   const tableWidth = 800;
   return (
-    <Table<CrossCheckPairs>
+    <Table<CrossCheckPairDto>
       className="table-score"
       showHeader
       scroll={{ x: tableWidth, y: 'calc(100vh - 250px)' }}

--- a/client/src/pages/course/admin/cross-check-table.tsx
+++ b/client/src/pages/course/admin/cross-check-table.tsx
@@ -1,13 +1,13 @@
-import { Button, Modal, Table, Typography } from 'antd';
+import { Button, Modal, Table, TablePaginationConfig, Typography } from 'antd';
+import { ColumnType, FilterValue, SorterResult } from 'antd/lib/table/interface';
 import { IPaginationInfo } from 'common/types/pagination';
-import { ScoreOrder } from 'common/types/score';
 import { BadReviewControllers } from 'components/BadReview/BadReviewControllers';
 import { GithubAvatar } from 'components/GithubAvatar';
 import { AdminPageLayout } from 'components/PageLayout';
 import { dateTimeRenderer, getColumnSearchProps } from 'components/Table';
 import withCourseData from 'components/withCourseData';
 import { withSession } from 'components/withSession';
-import { omit } from 'lodash';
+import { isArray, omit } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CourseService, CourseTaskDetails, CrossCheckPairs } from 'services/course';
 import { CoursePageProps } from 'services/models';
@@ -17,15 +17,7 @@ import PreparedComment from 'components/Forms/PreparedComment';
 
 const { Text } = Typography;
 
-export type CrossCheckFieldsTypes = {
-  task: string;
-  checkerStudent: string;
-  student: string;
-  url: string;
-  score: string;
-};
-
-export const fields = {
+const fields = {
   task: 'task',
   checker: 'checker',
   student: 'student',
@@ -34,6 +26,18 @@ export const fields = {
   submittedDate: 'submittedDate',
   reviewedDate: 'reviewedDate',
 };
+
+interface CustomColumnType<RecordType> extends ColumnType<RecordType> {
+  sorterField?: string;
+}
+
+interface CustomSorterResult<RecordType> extends SorterResult<RecordType> {
+  column?: CustomColumnType<RecordType>;
+}
+
+type Sorter<RecordType> = CustomSorterResult<RecordType> | CustomSorterResult<RecordType>[];
+
+type Filters = Omit<typeof fields, 'score' | 'submittedDate' | 'reviewedDate'>;
 
 enum OrderDirection {
   ASC = 'ASC',
@@ -85,29 +89,38 @@ export function Page(props: CoursePageProps) {
   }, []);
 
   const getCourseScore = useCallback(
-    async (pagination: IPaginationInfo, filters: typeof fields, order: ScoreOrder) => {
+    async (
+      pagination: TablePaginationConfig,
+      filters: Record<keyof Filters, FilterValue | null>,
+      sorter: Sorter<CrossCheckPairs>,
+    ) => {
+      if (isArray(sorter)) {
+        return;
+      }
+
       const orderBy = {
-        field: order.field ?? DEFAULT_ORDER_BY,
-        order: order.order === 'ascend' ? OrderDirection.ASC : OrderDirection.DESC,
+        field: sorter.column?.sorterField ?? DEFAULT_ORDER_BY,
+        order: sorter.order === 'descend' ? OrderDirection.DESC : OrderDirection.ASC,
       };
+
       setLoading(true);
       try {
         const { data } = await api.getCrossCheckPairs(
           courseId,
-          pagination.pageSize,
-          pagination.current,
-          orderBy.field,
+          pagination.pageSize as IPaginationInfo['pageSize'],
+          pagination.current as IPaginationInfo['current'],
+          orderBy.field.toString(),
           orderBy.order,
-          filters.checker ?? '',
-          filters.student ?? '',
-          filters.url ?? '',
-          filters.task ?? '',
+          filters.checker?.toString(),
+          filters.student?.toString(),
+          filters.url?.toString(),
+          filters.task?.toString(),
         );
         setCrossCheckList({
           content: data.items,
           pagination: data.pagination,
           orderBy: {
-            field: orderBy.field,
+            field: orderBy.field.toString(),
             order: orderBy.order,
           },
         });
@@ -150,11 +163,120 @@ export function Page(props: CoursePageProps) {
   );
 }
 
+const getColumns = (viewComment: (value: CrossCheckPairs) => void): CustomColumnType<CrossCheckPairs>[] => [
+  {
+    title: 'Task',
+    fixed: 'left',
+    dataIndex: ['task', 'name'],
+    key: fields.task,
+    width: 100,
+    sorter: true,
+    sorterField: 'task',
+    ...omit(getColumnSearchProps(['task', 'name']), 'onFilter'),
+  },
+  {
+    title: 'Checker',
+    fixed: 'left',
+    key: fields.checker,
+    dataIndex: ['checker', 'githubId'],
+    sorter: true,
+    sorterField: 'checker',
+    width: 150,
+    render: (value: string) => (
+      <div>
+        {value ? (
+          <>
+            <GithubAvatar githubId={value} size={24} />
+            &nbsp;
+            <a target="_blank" href={`https://github.com/${value}`}>
+              {value}
+            </a>
+          </>
+        ) : null}
+      </div>
+    ),
+    ...omit(getColumnSearchProps(['checkerStudent', 'githubId']), 'onFilter'),
+  },
+  {
+    title: 'Student',
+    key: fields.student,
+    dataIndex: ['student', 'githubId'],
+    sorter: true,
+    sorterField: 'student',
+    width: 150,
+    render: (value: string) => (
+      <div>
+        {value ? (
+          <>
+            <GithubAvatar githubId={value} size={24} />
+            &nbsp;
+            <a target="_blank" href={`https://github.com/${value}`}>
+              {value}
+            </a>
+          </>
+        ) : null}
+      </div>
+    ),
+    ...omit(getColumnSearchProps(['student', 'githubId']), 'onFilter'),
+  },
+  {
+    title: 'Url',
+    dataIndex: 'url',
+    key: fields.url,
+    width: 150,
+    sorter: true,
+    sorterField: 'url',
+    ...getColumnSearchProps('url'),
+  },
+  {
+    title: 'Score',
+    dataIndex: 'score',
+    key: fields.score,
+    width: 80,
+    sorter: true,
+    sorterField: 'score',
+    render: value => <Text strong>{value ?? '(Empty)'}</Text>,
+  },
+  {
+    title: 'Submitted Date',
+    dataIndex: 'submittedDate',
+    key: fields.submittedDate,
+    width: 80,
+    sorter: true,
+    sorterField: 'submittedDate',
+    render: dateTimeRenderer,
+  },
+  {
+    title: 'Reviewed Date',
+    dataIndex: 'reviewedDate',
+    key: fields.reviewedDate,
+    width: 80,
+    sorter: true,
+    sorterField: 'reviewedDate',
+    render: dateTimeRenderer,
+  },
+  {
+    title: 'Comment',
+    dataIndex: 'comment',
+    key: 'comment',
+    width: 60,
+    render: (_, record) => (
+      <Button onClick={() => viewComment(record)} type="link" size="small">
+        Show
+      </Button>
+    ),
+  },
+];
+
 function renderTable(
   loaded: boolean,
   crossCheckPairs: CrossCheckPairs[],
-  pagination: IPaginationInfo,
-  handleChange: (pagination: IPaginationInfo, filters: typeof fields, order: ScoreOrder) => void,
+  pagination: TablePaginationConfig,
+  handleChange: (
+    pagination: TablePaginationConfig,
+    filters: Record<keyof Filters, FilterValue | null>,
+    sorter: Sorter<CrossCheckPairs>,
+  ) => void,
   viewComment: (value: CrossCheckPairs) => void,
 ) {
   if (!loaded) {
@@ -169,105 +291,9 @@ function renderTable(
       scroll={{ x: tableWidth, y: 'calc(100vh - 250px)' }}
       pagination={pagination}
       dataSource={crossCheckPairs}
-      onChange={handleChange as any}
+      onChange={handleChange}
       key="id"
-      columns={[
-        {
-          title: 'Task',
-          fixed: 'left',
-          dataIndex: ['task', 'name'],
-          key: fields.task,
-          width: 100,
-          sorter: true,
-          ...omit(getColumnSearchProps(['task', 'name']), 'onFilter'),
-        },
-        {
-          title: 'Checker',
-          fixed: 'left',
-          key: fields.checker,
-          dataIndex: ['checker', 'githubId'],
-          sorter: true,
-          width: 150,
-          render: (value: string) => (
-            <div>
-              {value ? (
-                <>
-                  <GithubAvatar githubId={value} size={24} />
-                  &nbsp;
-                  <a target="_blank" href={`https://github.com/${value}`}>
-                    {value}
-                  </a>
-                </>
-              ) : null}
-            </div>
-          ),
-          ...omit(getColumnSearchProps(['checkerStudent', 'githubId']), 'onFilter'),
-        },
-        {
-          title: 'Student',
-          key: fields.student,
-          dataIndex: ['student', 'githubId'],
-          sorter: true,
-          width: 150,
-          render: (value: string) => (
-            <div>
-              {value ? (
-                <>
-                  <GithubAvatar githubId={value} size={24} />
-                  &nbsp;
-                  <a target="_blank" href={`https://github.com/${value}`}>
-                    {value}
-                  </a>
-                </>
-              ) : null}
-            </div>
-          ),
-          ...omit(getColumnSearchProps(['student', 'githubId']), 'onFilter'),
-        },
-        {
-          title: 'Url',
-          dataIndex: 'url',
-          key: fields.url,
-          width: 150,
-          sorter: true,
-          ...getColumnSearchProps('url'),
-        },
-        {
-          title: 'Score',
-          dataIndex: 'score',
-          key: fields.score,
-          width: 80,
-          sorter: true,
-          render: value => <Text strong>{value ?? '(Empty)'}</Text>,
-        },
-        {
-          title: 'Submitted Date',
-          dataIndex: 'submittedDate',
-          key: fields.submittedDate,
-          width: 80,
-          sorter: true,
-          render: dateTimeRenderer,
-        },
-        {
-          title: 'Reviewed Date',
-          dataIndex: 'reviewedDate',
-          key: fields.reviewedDate,
-          width: 80,
-          sorter: true,
-          render: dateTimeRenderer,
-        },
-        {
-          title: 'Comment',
-          dataIndex: 'comment',
-          key: 'comment',
-          width: 60,
-          render: (_, record) => (
-            <Button onClick={() => viewComment(record)} type="link" size="small">
-              Show
-            </Button>
-          ),
-        },
-      ]}
+      columns={getColumns(viewComment)}
     />
   );
 }

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -762,24 +762,3 @@ export interface TaskSolution {
   comments?: CrossCheckComment[];
   studentId: number;
 }
-
-export interface CrossCheckPairs {
-  checker: {
-    githubId: string;
-    id: number;
-  };
-  task: {
-    name: string;
-    id: number;
-  };
-  student: {
-    githubId: string;
-    id: number;
-  };
-  url: string;
-  comment: string;
-  score: number;
-  id: number;
-  submittedDate: string;
-  reviewedDate: string;
-}

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -780,4 +780,6 @@ export interface CrossCheckPairs {
   comment: string;
   score: number;
   id: number;
+  submittedDate: string;
+  reviewedDate: string;
 }


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[issue#1510](https://github.com/rolling-scopes/rsschool-app/issues/1510)

#### 💡 Background and solution

As was mentioned in [this PR](https://github.com/rolling-scopes/rsschool-app/pull/1522) problem caused by `orderBy` been an array, therefore request contains two orderBy queries and backend expects single value, so I figured it must be a client side problem and fixed it there. 

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
