### PR TITLE
feat: implement opening profile by clicking on discord name

### DIFF
--- a/client/src/components/CrossCheck/CrossCheckAssignmentLink.tsx
+++ b/client/src/components/CrossCheck/CrossCheckAssignmentLink.tsx
@@ -22,7 +22,9 @@ export function CrossCheckAssignmentLink({ assignment }: { assignment?: Assignme
         Student Discord:{' '}
         {discordUsername ? (
           <>
-            <Typography.Text strong>{discordUsername}</Typography.Text>{' '}
+            <Typography.Link target="_blank" href={`https://discordapp.com/users/${discord?.id}`}>
+              {discordUsername}
+            </Typography.Link>{' '}
             <CopyToClipboardButton value={discordUsername} />
           </>
         ) : (
@@ -31,9 +33,9 @@ export function CrossCheckAssignmentLink({ assignment }: { assignment?: Assignme
       </Typography.Paragraph>
       <Typography.Paragraph>
         Solution:{' '}
-        <a target="_blank" href={solutionUrl}>
+        <Typography.Link target="_blank" href={solutionUrl}>
           {solutionUrl}
-        </a>
+        </Typography.Link>
       </Typography.Paragraph>
     </div>
   );


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#### 💡 Background and solution

При проверки работ на кросс-чеке, если кликнуть на никнейм, то откроется профиль студента в дискорде.

![result](https://user-images.githubusercontent.com/48645737/185905181-b8b95820-3389-4e22-bb03-0e81c03760a9.png)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
