### PR TITLE
feat(cross-check): add check date, maximum score, contacts, switch of contact visibility, score icon

### DIFF
--- a/client/src/components/CopyToClipboardButton.tsx
+++ b/client/src/components/CopyToClipboardButton.tsx
@@ -1,4 +1,3 @@
-import React, { useRef, useCallback } from 'react';
 import { Button } from 'antd';
 import { CopyTwoTone } from '@ant-design/icons';
 
@@ -7,35 +6,9 @@ type Props = {
 };
 
 export default function CopyToClipboardButton({ value }: Props) {
-  const textAreaRef = useRef(null);
+  const copyToClipboard = () => {
+    window.navigator.clipboard.writeText(value);
+  };
 
-  const copyToClipboard = useCallback(
-    (event: any) => {
-      const textArea = textAreaRef?.current as HTMLTextAreaElement | null;
-      if (textArea) {
-        textArea.select();
-        document.execCommand('copy');
-        event.target.focus();
-      }
-    },
-    [textAreaRef.current],
-  );
-
-  return document.queryCommandSupported('copy') ? (
-    <>
-      <Button type="dashed" icon={<CopyTwoTone />} htmlType="button" onClick={copyToClipboard} />
-      <textarea className="visually-hidden" ref={textAreaRef} value={value} />
-      <style jsx>{`
-        .visually-hidden {
-          position: absolute;
-          clip: rect(0 0 0 0);
-          width: 1px;
-          height: 1px;
-          margin: -1px;
-        }
-      `}</style>
-    </>
-  ) : (
-    <></>
-  );
+  return <Button type="dashed" icon={<CopyTwoTone />} onClick={copyToClipboard} />;
 }

--- a/client/src/components/CopyToClipboardButton.tsx
+++ b/client/src/components/CopyToClipboardButton.tsx
@@ -1,14 +1,18 @@
-import { Button } from 'antd';
+import { Button, notification } from 'antd';
 import { CopyTwoTone } from '@ant-design/icons';
+import { useCopyToClipboard } from 'react-use';
 
 type Props = {
   value: string;
 };
 
 export default function CopyToClipboardButton({ value }: Props) {
-  const copyToClipboard = () => {
-    window.navigator.clipboard.writeText(value);
+  const [, copyToClipboard] = useCopyToClipboard();
+
+  const handleClick = () => {
+    copyToClipboard(value);
+    notification.success({ message: 'Copied to clipboard' });
   };
 
-  return <Button type="dashed" icon={<CopyTwoTone />} onClick={copyToClipboard} />;
+  return <Button type="dashed" icon={<CopyTwoTone />} onClick={handleClick} />;
 }

--- a/client/src/components/CrossCheck/CrossCheckAssignmentLink.tsx
+++ b/client/src/components/CrossCheck/CrossCheckAssignmentLink.tsx
@@ -1,6 +1,6 @@
 import { Typography } from 'antd';
-import CopyToClipboardButton from 'components/CopyToClipboardButton';
 import { StudentBasic } from 'services/models';
+import { StudentContacts } from './StudentContacts';
 
 export type AssignmentLink = { student: StudentBasic; url: string };
 
@@ -14,24 +14,10 @@ export function CrossCheckAssignmentLink({ assignment }: { assignment?: Assignme
     url: solutionUrl,
   } = assignment;
 
-  const discordUsername = discord ? `@${discord.username}#${discord.discriminator}` : null;
-
   return (
     <div style={{ marginTop: 16 }}>
-      <Typography.Paragraph>
-        Student Discord:{' '}
-        {discordUsername ? (
-          <>
-            <Typography.Link target="_blank" href={`https://discordapp.com/users/${discord?.id}`}>
-              {discordUsername}
-            </Typography.Link>{' '}
-            <CopyToClipboardButton value={discordUsername} />
-          </>
-        ) : (
-          'unknown'
-        )}
-      </Typography.Paragraph>
-      <Typography.Paragraph>
+      <StudentContacts discord={discord} />
+      <Typography.Paragraph style={{ marginTop: 14 }}>
         Solution:{' '}
         <Typography.Link target="_blank" href={solutionUrl}>
           {solutionUrl}

--- a/client/src/components/CrossCheck/StudentContacts.tsx
+++ b/client/src/components/CrossCheck/StudentContacts.tsx
@@ -1,0 +1,27 @@
+import { Typography } from 'antd';
+import { Discord } from 'api';
+import CopyToClipboardButton from 'components/CopyToClipboardButton';
+
+type Props = {
+  discord: Discord | null;
+};
+
+export function StudentContacts({ discord }: Props) {
+  const discordUsername = discord ? `@${discord.username}#${discord.discriminator}` : null;
+
+  return (
+    <Typography.Paragraph style={{ margin: 0 }}>
+      Student Discord:{' '}
+      {discordUsername ? (
+        <>
+          <Typography.Link target="_blank" href={`https://discordapp.com/users/${discord?.id}`}>
+            {discordUsername}
+          </Typography.Link>{' '}
+          <CopyToClipboardButton value={discordUsername} />
+        </>
+      ) : (
+        'unknown'
+      )}
+    </Typography.Paragraph>
+  );
+}

--- a/client/src/components/CrossCheckComments.tsx
+++ b/client/src/components/CrossCheckComments.tsx
@@ -83,7 +83,7 @@ export function CrossCheckComments({ feedback, maxScore }: Props) {
                   </Typography.Text>
                 </Row>
 
-                <Row gutter={2} align="middle">
+                <Row gutter={4} align="middle">
                   <Col>
                     <ScoreIcon maxScore={maxScore} score={score} />
                   </Col>

--- a/client/src/components/CrossCheckComments.tsx
+++ b/client/src/components/CrossCheckComments.tsx
@@ -1,42 +1,112 @@
+import { Fragment } from 'react';
 import { UserOutlined } from '@ant-design/icons';
-import { Col, Comment, Divider, Row, Typography } from 'antd';
+import { ScoreIcon } from './Icons/ScoreIcon';
+import { Avatar, Col, Comment, Divider, Row, Switch, Typography } from 'antd';
+import { useLocalStorage } from 'react-use';
+import { Feedback } from 'services/course';
+import { formatDateTime } from 'services/formatter';
 import { GithubUserLink } from 'components/GithubUserLink';
 import PreparedComment from './Forms/PreparedComment';
+import { StudentContacts } from './CrossCheck/StudentContacts';
+
+enum LocalStorage {
+  AreStudentContactsVisible = 'crossCheckAreStudentContactsVisible',
+}
 
 type Props = {
-  comments: {
-    comment: string;
-    score: number;
-    author: {
-      name: string;
-      githubId: string;
-    } | null;
-  }[];
+  feedback: Feedback | null;
+  maxScore?: number;
 };
 
-export function CrossCheckComments(props: Props) {
-  const { comments } = props;
-  if (!comments || comments.length === 0) {
+export function CrossCheckComments({ feedback, maxScore }: Props) {
+  if (!feedback || !feedback.comments || feedback.comments.length === 0) {
     return null;
   }
-  const style = { margin: 16 };
+
+  const { comments } = feedback;
+  const [areStudentContactsVisible = true, setAreStudentContactsHidden] = useLocalStorage<boolean>(
+    LocalStorage.AreStudentContactsVisible,
+  );
+
+  const handleStudentContactsVisibilityChange = () => {
+    setAreStudentContactsHidden(!areStudentContactsVisible);
+  };
+
   return (
     <Col>
-      {comments.map(({ comment, author, score }, i) => (
-        <Row key={i}>
-          <Divider />
+      <Row gutter={8} style={{ margin: '8px 0' }}>
+        <Col>
+          <Typography.Text>Student Contacts</Typography.Text>
+        </Col>
+        <Col>
+          <Switch
+            size={'small'}
+            defaultChecked={areStudentContactsVisible}
+            onChange={handleStudentContactsVisibilityChange}
+          />
+        </Col>
+      </Row>
+
+      {comments.map(({ comment, updatedDate, author, score }, i) => (
+        <Fragment key={i}>
+          <Row>
+            <Divider style={{ margin: '8px 0' }} />
+          </Row>
+
           <Comment
-            style={style}
-            author={author ? <GithubUserLink value={author.githubId} /> : `Student ${i + 1}`}
             avatar={<UserOutlined />}
             content={
               <>
-                <Typography.Paragraph strong>Score: {score}</Typography.Paragraph>
-                <PreparedComment text={comment} />
+                <Row align="middle" gutter={3}>
+                  {areStudentContactsVisible && author ? (
+                    <Col>
+                      <GithubUserLink value={author.githubId} />
+                    </Col>
+                  ) : (
+                    <>
+                      <Col>
+                        <Avatar size={24} src="/static/svg/badges/ThankYou.svg" />
+                      </Col>
+                      <Col>
+                        <Typography.Text>
+                          {'Student'} {i + 1}
+                          {!areStudentContactsVisible && author && ' (hidden)'}
+                        </Typography.Text>
+                      </Col>
+                    </>
+                  )}
+                </Row>
+
+                <Row>
+                  <Typography.Text type="secondary" style={{ marginBottom: 8, fontSize: 12 }}>
+                    {formatDateTime(updatedDate)}
+                  </Typography.Text>
+                </Row>
+
+                <Row gutter={2} align="middle">
+                  <Col>
+                    <ScoreIcon maxScore={maxScore} score={score} />
+                  </Col>
+                  <Col>
+                    <Typography.Text>{score}</Typography.Text>
+                  </Col>
+                </Row>
+
+                <Row style={{ marginBottom: 24 }}>
+                  <Typography.Text style={{ fontSize: 12, lineHeight: '12px' }} type="secondary">
+                    maximum score: {maxScore ?? 'unknown'}
+                  </Typography.Text>
+                </Row>
+
+                <Row>
+                  <PreparedComment text={comment} />
+                </Row>
+
+                <Row>{areStudentContactsVisible && author && <StudentContacts discord={author.discord} />}</Row>
               </>
             }
           />
-        </Row>
+        </Fragment>
       ))}
     </Col>
   );

--- a/client/src/components/CrossCheckComments.tsx
+++ b/client/src/components/CrossCheckComments.tsx
@@ -1,7 +1,8 @@
 import { Fragment } from 'react';
-import { UserOutlined } from '@ant-design/icons';
+import { CDN_AVATARS_URL } from 'configs/cdn';
 import { ScoreIcon } from './Icons/ScoreIcon';
 import { Avatar, Col, Comment, Divider, Row, Switch, Typography } from 'antd';
+import css from 'styled-jsx/css';
 import { useLocalStorage } from 'react-use';
 import { Feedback } from 'services/course';
 import { formatDateTime } from 'services/formatter';
@@ -54,26 +55,26 @@ export function CrossCheckComments({ feedback, maxScore }: Props) {
           </Row>
 
           <Comment
-            avatar={<UserOutlined />}
+            avatar={
+              <Avatar
+                size={32}
+                src={
+                  areStudentContactsVisible && author
+                    ? `${CDN_AVATARS_URL}/${author.githubId}.png?size=48`
+                    : '/static/svg/badges/ThankYou.svg'
+                }
+              />
+            }
             content={
               <>
-                <Row align="middle" gutter={3}>
+                <Row>
                   {areStudentContactsVisible && author ? (
-                    <Col>
-                      <GithubUserLink value={author.githubId} />
-                    </Col>
+                    <GithubUserLink value={author.githubId} isUserIconHidden={true} />
                   ) : (
-                    <>
-                      <Col>
-                        <Avatar size={24} src="/static/svg/badges/ThankYou.svg" />
-                      </Col>
-                      <Col>
-                        <Typography.Text>
-                          {'Student'} {i + 1}
-                          {!areStudentContactsVisible && author && ' (hidden)'}
-                        </Typography.Text>
-                      </Col>
-                    </>
+                    <Typography.Text>
+                      {'Student'} {i + 1}
+                      {!areStudentContactsVisible && author && ' (hidden)'}
+                    </Typography.Text>
                   )}
                 </Row>
 
@@ -108,6 +109,20 @@ export function CrossCheckComments({ feedback, maxScore }: Props) {
           />
         </Fragment>
       ))}
+      <style jsx>{styles}</style>
     </Col>
   );
 }
+
+const styles = css`
+  :global(.ant-comment-avatar) {
+    position: sticky;
+    top: 16px;
+    align-self: start;
+  }
+
+  :global(.ant-comment-avatar img) {
+    width: 100%;
+    height: 100%;
+  }
+`;

--- a/client/src/components/CrossCheckComments.tsx
+++ b/client/src/components/CrossCheckComments.tsx
@@ -2,7 +2,6 @@ import { Fragment } from 'react';
 import { CDN_AVATARS_URL } from 'configs/cdn';
 import { ScoreIcon } from './Icons/ScoreIcon';
 import { Avatar, Col, Comment, Divider, Row, Switch, Typography } from 'antd';
-import css from 'styled-jsx/css';
 import { useLocalStorage } from 'react-use';
 import { Feedback } from 'services/course';
 import { formatDateTime } from 'services/formatter';
@@ -109,20 +108,18 @@ export function CrossCheckComments({ feedback, maxScore }: Props) {
           />
         </Fragment>
       ))}
-      <style jsx>{styles}</style>
+      <style jsx>{`
+        :global(.ant-comment-avatar) {
+          position: sticky;
+          top: 16px;
+          align-self: start;
+        }
+
+        :global(.ant-comment-avatar img) {
+          width: 100%;
+          height: 100%;
+        }
+      `}</style>
     </Col>
   );
 }
-
-const styles = css`
-  :global(.ant-comment-avatar) {
-    position: sticky;
-    top: 16px;
-    align-self: start;
-  }
-
-  :global(.ant-comment-avatar img) {
-    width: 100%;
-    height: 100%;
-  }
-`;

--- a/client/src/components/GithubUserLink.tsx
+++ b/client/src/components/GithubUserLink.tsx
@@ -1,19 +1,28 @@
 import { GithubFilled } from '@ant-design/icons';
 import { CDN_AVATARS_URL } from 'configs/cdn';
 
-export function GithubUserLink(props: { value: string }) {
+type Props = {
+  value: string;
+  isUserIconHidden?: boolean;
+};
+
+export function GithubUserLink({ value, isUserIconHidden = false }: Props) {
   const imgProps: any = { loading: 'lazy' };
   return (
     <div className="link-user">
-      <a target="_blank" className="link-user-profile" href={`/profile?githubId=${props.value}`}>
-        <img
-          {...imgProps}
-          style={{ height: '24px', width: '24px', borderRadius: '12px' }}
-          src={`${CDN_AVATARS_URL}/${props.value}.png?size=48`}
-        />{' '}
-        {props.value}
+      <a target="_blank" className="link-user-profile" href={`/profile?githubId=${value}`}>
+        {!isUserIconHidden && (
+          <>
+            <img
+              {...imgProps}
+              style={{ height: '24px', width: '24px', borderRadius: '12px' }}
+              src={`${CDN_AVATARS_URL}/${value}.png?size=48`}
+            />{' '}
+          </>
+        )}
+        {value}
       </a>{' '}
-      <a target="_blank" className="link-user-github" href={`https://github.com/${props.value}`}>
+      <a target="_blank" className="link-user-github" href={`https://github.com/${value}`}>
         <GithubFilled />
       </a>
       <style jsx>{`

--- a/client/src/components/Icons/ScoreIcon.tsx
+++ b/client/src/components/Icons/ScoreIcon.tsx
@@ -1,0 +1,28 @@
+import { StarTwoTone } from '@ant-design/icons';
+
+enum Score {
+  Outdated = 'gray',
+  Min = '#ff0000',
+  Average = '#ffa940',
+  Max = '#52c41a',
+  Undefined = '#13c2c2',
+}
+
+type Props = {
+  score: number;
+  maxScore: number | undefined;
+  isOutdatedScore?: boolean;
+};
+
+export function ScoreIcon(props: Props) {
+  const color = getColor(props);
+  return <StarTwoTone twoToneColor={color} />;
+}
+
+function getColor({ maxScore, score, isOutdatedScore = false }: Props) {
+  if (typeof maxScore === 'undefined') return Score.Undefined;
+  if (isOutdatedScore) return Score.Outdated;
+  if (score <= 0) return Score.Min;
+  if (score === maxScore) return Score.Max;
+  return Score.Average;
+}

--- a/client/src/components/__tests__/CrossCheckComments.test.tsx
+++ b/client/src/components/__tests__/CrossCheckComments.test.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { Feedback } from 'services/course';
+import { markdownLabel } from 'components/Forms/PreparedComment';
 import { CrossCheckComments } from '../CrossCheckComments';
 
 describe('CrossCheckComments', () => {
   describe('Should render correctly', () => {
     const anonComment = {
-      comment: 'Awful job, you better quit programming and learn to cross stitch.',
+      updatedDate: '2022-08-30T13:35:14.866Z',
+      comment: `${markdownLabel}Awful job, you better quit programming and learn to cross stitch.`,
       score: 5,
       author: null,
     };
 
     const signedComment = {
-      comment: 'Great job, you better quit cross stitching and start programming.',
+      updatedDate: '2022-08-27T09:51:34.615Z',
+      comment: `${markdownLabel}Great job, you better quit cross stitching and start programming.`,
       score: 100,
       author: {
         name: 'Linus Torvalds',
         githubId: 'torvalds',
+        discord: {
+          id: +'123456789012345678',
+          username: 'LinusTorvalds',
+          discriminator: 1234,
+        },
       },
     };
 
@@ -27,20 +36,42 @@ describe('CrossCheckComments', () => {
 
     const mixedComments = [anonComment, anonComment, signedComment, signedComment, anonComment];
 
+    const feedbackWithEmptyComments: Feedback = {
+      url: 'https://rolling-scopes-school.github.io/torvalds-JSFE2021Q3/async-race/',
+      comments: emptyComments,
+    };
+
+    const feedbackWithAnonComments: Feedback = {
+      url: 'https://rolling-scopes-school.github.io/torvalds-JSFE2021Q3/async-race/',
+      comments: anonComments,
+    };
+
+    const feedbackWithSignedComments: Feedback = {
+      url: 'https://rolling-scopes-school.github.io/torvalds-JSFE2021Q3/async-race/',
+      comments: signedComments,
+    };
+
+    const feedbackWithMixedComments: Feedback = {
+      url: 'https://rolling-scopes-school.github.io/torvalds-JSFE2021Q3/async-race/',
+      comments: mixedComments,
+    };
+
+    const maxScore = 100;
+
     it("if there's no comments", () => {
-      const output = render(<CrossCheckComments comments={emptyComments} />);
+      const output = render(<CrossCheckComments feedback={feedbackWithEmptyComments} maxScore={maxScore} />);
       expect(output.container).toMatchSnapshot();
     });
     it('if there are anonymous comments', () => {
-      const output = render(<CrossCheckComments comments={anonComments} />);
+      const output = render(<CrossCheckComments feedback={feedbackWithAnonComments} maxScore={maxScore} />);
       expect(output.container).toMatchSnapshot();
     });
     it('if there are signed comments', () => {
-      const output = render(<CrossCheckComments comments={signedComments} />);
+      const output = render(<CrossCheckComments feedback={feedbackWithSignedComments} maxScore={maxScore} />);
       expect(output.container).toMatchSnapshot();
     });
     it('if there are both types of comments', () => {
-      const output = render(<CrossCheckComments comments={mixedComments} />);
+      const output = render(<CrossCheckComments feedback={feedbackWithMixedComments} maxScore={maxScore} />);
       expect(output.container).toMatchSnapshot();
     });
   });

--- a/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
+++ b/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
@@ -57,23 +57,12 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="/static/svg/badges/ThankYou.svg"
+            />
           </span>
         </div>
         <div
@@ -83,34 +72,15 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+              <span
+                class="ant-typography"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
-                >
-                  <img
-                    src="/static/svg/badges/ThankYou.svg"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
-              >
-                <span
-                  class="ant-typography"
-                >
-                  Student
-                   
-                  1
-                </span>
-              </div>
+                Student
+                 
+                1
+              </span>
             </div>
             <div
               class="ant-row"
@@ -215,23 +185,12 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="/static/svg/badges/ThankYou.svg"
+            />
           </span>
         </div>
         <div
@@ -241,34 +200,15 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+              <span
+                class="ant-typography"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
-                >
-                  <img
-                    src="/static/svg/badges/ThankYou.svg"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
-              >
-                <span
-                  class="ant-typography"
-                >
-                  Student
-                   
-                  2
-                </span>
-              </div>
+                Student
+                 
+                2
+              </span>
             </div>
             <div
               class="ant-row"
@@ -373,23 +313,12 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="/static/svg/badges/ThankYou.svg"
+            />
           </span>
         </div>
         <div
@@ -399,34 +328,15 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+              <span
+                class="ant-typography"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
-                >
-                  <img
-                    src="/static/svg/badges/ThankYou.svg"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
-              >
-                <span
-                  class="ant-typography"
-                >
-                  Student
-                   
-                  3
-                </span>
-              </div>
+                Student
+                 
+                3
+              </span>
             </div>
             <div
               class="ant-row"
@@ -512,6 +422,20 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
         </div>
       </div>
     </div>
+    <style>
+      
+        :global(.ant-comment-avatar) {
+          position: sticky;
+          top: 16px;
+          align-self: start;
+        }
+
+        :global(.ant-comment-avatar img) {
+          width: 100%;
+          height: 100%;
+        }
+      
+    </style>
   </div>
 </div>
 `;
@@ -573,23 +497,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="/static/svg/badges/ThankYou.svg"
+            />
           </span>
         </div>
         <div
@@ -599,34 +512,15 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+              <span
+                class="ant-typography"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
-                >
-                  <img
-                    src="/static/svg/badges/ThankYou.svg"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
-              >
-                <span
-                  class="ant-typography"
-                >
-                  Student
-                   
-                  1
-                </span>
-              </div>
+                Student
+                 
+                1
+              </span>
             </div>
             <div
               class="ant-row"
@@ -731,23 +625,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="/static/svg/badges/ThankYou.svg"
+            />
           </span>
         </div>
         <div
@@ -757,34 +640,15 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+              <span
+                class="ant-typography"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
-                >
-                  <img
-                    src="/static/svg/badges/ThankYou.svg"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
-              >
-                <span
-                  class="ant-typography"
-                >
-                  Student
-                   
-                  2
-                </span>
-              </div>
+                Student
+                 
+                2
+              </span>
             </div>
             <div
               class="ant-row"
@@ -889,23 +753,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="https://cdn.rs.school/torvalds.png?size=48"
+            />
           </span>
         </div>
         <div
@@ -915,57 +768,46 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
               <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+                class="link-user"
               >
-                <div
-                  class="link-user"
+                <a
+                  class="link-user-profile"
+                  href="/profile?githubId=torvalds"
+                  target="_blank"
                 >
-                  <a
-                    class="link-user-profile"
-                    href="/profile?githubId=torvalds"
-                    target="_blank"
+                  torvalds
+                </a>
+                 
+                <a
+                  class="link-user-github"
+                  href="https://github.com/torvalds"
+                  target="_blank"
+                >
+                  <span
+                    aria-label="github"
+                    class="anticon anticon-github"
+                    role="img"
                   >
-                    <img
-                      loading="lazy"
-                      src="https://cdn.rs.school/torvalds.png?size=48"
-                      style="height: 24px; width: 24px; border-radius: 12px;"
-                    />
-                     
-                    torvalds
-                  </a>
-                   
-                  <a
-                    class="link-user-github"
-                    href="https://github.com/torvalds"
-                    target="_blank"
-                  >
-                    <span
-                      aria-label="github"
-                      class="anticon anticon-github"
-                      role="img"
+                    <svg
+                      aria-hidden="true"
+                      data-icon="github"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
                     >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="github"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                  <style>
-                    
+                      <path
+                        d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <style>
+                  
         .link-user {
           display: inline-block;
         }
@@ -980,8 +822,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           visibility: visible;
         }
       
-                  </style>
-                </div>
+                </style>
               </div>
             </div>
             <div
@@ -1137,23 +978,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="https://cdn.rs.school/torvalds.png?size=48"
+            />
           </span>
         </div>
         <div
@@ -1163,57 +993,46 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
               <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+                class="link-user"
               >
-                <div
-                  class="link-user"
+                <a
+                  class="link-user-profile"
+                  href="/profile?githubId=torvalds"
+                  target="_blank"
                 >
-                  <a
-                    class="link-user-profile"
-                    href="/profile?githubId=torvalds"
-                    target="_blank"
+                  torvalds
+                </a>
+                 
+                <a
+                  class="link-user-github"
+                  href="https://github.com/torvalds"
+                  target="_blank"
+                >
+                  <span
+                    aria-label="github"
+                    class="anticon anticon-github"
+                    role="img"
                   >
-                    <img
-                      loading="lazy"
-                      src="https://cdn.rs.school/torvalds.png?size=48"
-                      style="height: 24px; width: 24px; border-radius: 12px;"
-                    />
-                     
-                    torvalds
-                  </a>
-                   
-                  <a
-                    class="link-user-github"
-                    href="https://github.com/torvalds"
-                    target="_blank"
-                  >
-                    <span
-                      aria-label="github"
-                      class="anticon anticon-github"
-                      role="img"
+                    <svg
+                      aria-hidden="true"
+                      data-icon="github"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
                     >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="github"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                  <style>
-                    
+                      <path
+                        d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <style>
+                  
         .link-user {
           display: inline-block;
         }
@@ -1228,8 +1047,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           visibility: visible;
         }
       
-                  </style>
-                </div>
+                </style>
               </div>
             </div>
             <div
@@ -1385,23 +1203,12 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="/static/svg/badges/ThankYou.svg"
+            />
           </span>
         </div>
         <div
@@ -1411,34 +1218,15 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+              <span
+                class="ant-typography"
               >
-                <span
-                  class="ant-avatar ant-avatar-circle ant-avatar-image"
-                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
-                >
-                  <img
-                    src="/static/svg/badges/ThankYou.svg"
-                  />
-                </span>
-              </div>
-              <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
-              >
-                <span
-                  class="ant-typography"
-                >
-                  Student
-                   
-                  5
-                </span>
-              </div>
+                Student
+                 
+                5
+              </span>
             </div>
             <div
               class="ant-row"
@@ -1524,6 +1312,20 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
         </div>
       </div>
     </div>
+    <style>
+      
+        :global(.ant-comment-avatar) {
+          position: sticky;
+          top: 16px;
+          align-self: start;
+        }
+
+        :global(.ant-comment-avatar img) {
+          width: 100%;
+          height: 100%;
+        }
+      
+    </style>
   </div>
 </div>
 `;
@@ -1585,23 +1387,12 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="https://cdn.rs.school/torvalds.png?size=48"
+            />
           </span>
         </div>
         <div
@@ -1611,57 +1402,46 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
               <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+                class="link-user"
               >
-                <div
-                  class="link-user"
+                <a
+                  class="link-user-profile"
+                  href="/profile?githubId=torvalds"
+                  target="_blank"
                 >
-                  <a
-                    class="link-user-profile"
-                    href="/profile?githubId=torvalds"
-                    target="_blank"
+                  torvalds
+                </a>
+                 
+                <a
+                  class="link-user-github"
+                  href="https://github.com/torvalds"
+                  target="_blank"
+                >
+                  <span
+                    aria-label="github"
+                    class="anticon anticon-github"
+                    role="img"
                   >
-                    <img
-                      loading="lazy"
-                      src="https://cdn.rs.school/torvalds.png?size=48"
-                      style="height: 24px; width: 24px; border-radius: 12px;"
-                    />
-                     
-                    torvalds
-                  </a>
-                   
-                  <a
-                    class="link-user-github"
-                    href="https://github.com/torvalds"
-                    target="_blank"
-                  >
-                    <span
-                      aria-label="github"
-                      class="anticon anticon-github"
-                      role="img"
+                    <svg
+                      aria-hidden="true"
+                      data-icon="github"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
                     >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="github"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                  <style>
-                    
+                      <path
+                        d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <style>
+                  
         .link-user {
           display: inline-block;
         }
@@ -1676,8 +1456,7 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
           visibility: visible;
         }
       
-                  </style>
-                </div>
+                </style>
               </div>
             </div>
             <div
@@ -1833,23 +1612,12 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="https://cdn.rs.school/torvalds.png?size=48"
+            />
           </span>
         </div>
         <div
@@ -1859,57 +1627,46 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
               <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+                class="link-user"
               >
-                <div
-                  class="link-user"
+                <a
+                  class="link-user-profile"
+                  href="/profile?githubId=torvalds"
+                  target="_blank"
                 >
-                  <a
-                    class="link-user-profile"
-                    href="/profile?githubId=torvalds"
-                    target="_blank"
+                  torvalds
+                </a>
+                 
+                <a
+                  class="link-user-github"
+                  href="https://github.com/torvalds"
+                  target="_blank"
+                >
+                  <span
+                    aria-label="github"
+                    class="anticon anticon-github"
+                    role="img"
                   >
-                    <img
-                      loading="lazy"
-                      src="https://cdn.rs.school/torvalds.png?size=48"
-                      style="height: 24px; width: 24px; border-radius: 12px;"
-                    />
-                     
-                    torvalds
-                  </a>
-                   
-                  <a
-                    class="link-user-github"
-                    href="https://github.com/torvalds"
-                    target="_blank"
-                  >
-                    <span
-                      aria-label="github"
-                      class="anticon anticon-github"
-                      role="img"
+                    <svg
+                      aria-hidden="true"
+                      data-icon="github"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
                     >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="github"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                  <style>
-                    
+                      <path
+                        d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <style>
+                  
         .link-user {
           display: inline-block;
         }
@@ -1924,8 +1681,7 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
           visibility: visible;
         }
       
-                  </style>
-                </div>
+                </style>
               </div>
             </div>
             <div
@@ -2081,23 +1837,12 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
           class="ant-comment-avatar"
         >
           <span
-            aria-label="user"
-            class="anticon anticon-user"
-            role="img"
+            class="ant-avatar ant-avatar-circle ant-avatar-image"
+            style="width: 32px; height: 32px; line-height: 32px; font-size: 18px;"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="user"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-              />
-            </svg>
+            <img
+              src="https://cdn.rs.school/torvalds.png?size=48"
+            />
           </span>
         </div>
         <div
@@ -2107,57 +1852,46 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
             class="ant-comment-content-detail"
           >
             <div
-              class="ant-row ant-row-middle"
-              style="margin-left: -1.5px; margin-right: -1.5px;"
+              class="ant-row"
             >
               <div
-                class="ant-col"
-                style="padding-left: 1.5px; padding-right: 1.5px;"
+                class="link-user"
               >
-                <div
-                  class="link-user"
+                <a
+                  class="link-user-profile"
+                  href="/profile?githubId=torvalds"
+                  target="_blank"
                 >
-                  <a
-                    class="link-user-profile"
-                    href="/profile?githubId=torvalds"
-                    target="_blank"
+                  torvalds
+                </a>
+                 
+                <a
+                  class="link-user-github"
+                  href="https://github.com/torvalds"
+                  target="_blank"
+                >
+                  <span
+                    aria-label="github"
+                    class="anticon anticon-github"
+                    role="img"
                   >
-                    <img
-                      loading="lazy"
-                      src="https://cdn.rs.school/torvalds.png?size=48"
-                      style="height: 24px; width: 24px; border-radius: 12px;"
-                    />
-                     
-                    torvalds
-                  </a>
-                   
-                  <a
-                    class="link-user-github"
-                    href="https://github.com/torvalds"
-                    target="_blank"
-                  >
-                    <span
-                      aria-label="github"
-                      class="anticon anticon-github"
-                      role="img"
+                    <svg
+                      aria-hidden="true"
+                      data-icon="github"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
                     >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="github"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                  <style>
-                    
+                      <path
+                        d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <style>
+                  
         .link-user {
           display: inline-block;
         }
@@ -2172,8 +1906,7 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
           visibility: visible;
         }
       
-                  </style>
-                </div>
+                </style>
               </div>
             </div>
             <div
@@ -2310,6 +2043,20 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
         </div>
       </div>
     </div>
+    <style>
+      
+        :global(.ant-comment-avatar) {
+          position: sticky;
+          top: 16px;
+          align-self: start;
+        }
+
+        :global(.ant-comment-avatar img) {
+          width: 100%;
+          height: 100%;
+        }
+      
+    </style>
   </div>
 </div>
 `;

--- a/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
+++ b/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
@@ -7,72 +7,191 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
   >
     <div
       class="ant-row"
+      style="margin: 8px 0px;"
+    >
+      <div
+        class="ant-col"
+        style="padding-left: 4px; padding-right: 4px;"
+      >
+        <span
+          class="ant-typography"
+        >
+          Student Contacts
+        </span>
+      </div>
+      <div
+        class="ant-col"
+        style="padding-left: 4px; padding-right: 4px;"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-small ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="ant-row"
     >
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
-            >
-              <span
-                class="ant-comment-content-author-name"
-              >
-                Student 1
-              </span>
-            </div>
-            <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
-                <strong>
-                  Score: 
-                  5
-                </strong>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-image"
+                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
+                >
+                  <img
+                    src="/static/svg/badges/ThankYou.svg"
+                  />
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  Student
+                   
+                  1
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-30 13:35
+              </span>
+            </div>
+            <div
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
+            >
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#fffbf0"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#ffa940"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Awful job, you better quit programming and learn to cross stitch.
-                </div>
+                </p>
               </span>
             </div>
+            <div
+              class="ant-row"
+            />
           </div>
         </div>
       </div>
@@ -83,68 +202,154 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
-            >
-              <span
-                class="ant-comment-content-author-name"
-              >
-                Student 2
-              </span>
-            </div>
-            <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
-                <strong>
-                  Score: 
-                  5
-                </strong>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-image"
+                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
+                >
+                  <img
+                    src="/static/svg/badges/ThankYou.svg"
+                  />
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  Student
+                   
+                  2
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-30 13:35
+              </span>
+            </div>
+            <div
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
+            >
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#fffbf0"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#ffa940"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Awful job, you better quit programming and learn to cross stitch.
-                </div>
+                </p>
               </span>
             </div>
+            <div
+              class="ant-row"
+            />
           </div>
         </div>
       </div>
@@ -155,68 +360,154 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
-            >
-              <span
-                class="ant-comment-content-author-name"
-              >
-                Student 3
-              </span>
-            </div>
-            <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
-                <strong>
-                  Score: 
-                  5
-                </strong>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-image"
+                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
+                >
+                  <img
+                    src="/static/svg/badges/ThankYou.svg"
+                  />
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  Student
+                   
+                  3
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-30 13:35
+              </span>
+            </div>
+            <div
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
+            >
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#fffbf0"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#ffa940"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Awful job, you better quit programming and learn to cross stitch.
-                </div>
+                </p>
               </span>
             </div>
+            <div
+              class="ant-row"
+            />
           </div>
         </div>
       </div>
@@ -232,72 +523,191 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
   >
     <div
       class="ant-row"
+      style="margin: 8px 0px;"
+    >
+      <div
+        class="ant-col"
+        style="padding-left: 4px; padding-right: 4px;"
+      >
+        <span
+          class="ant-typography"
+        >
+          Student Contacts
+        </span>
+      </div>
+      <div
+        class="ant-col"
+        style="padding-left: 4px; padding-right: 4px;"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-small ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="ant-row"
     >
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
-            >
-              <span
-                class="ant-comment-content-author-name"
-              >
-                Student 1
-              </span>
-            </div>
-            <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
-                <strong>
-                  Score: 
-                  5
-                </strong>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-image"
+                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
+                >
+                  <img
+                    src="/static/svg/badges/ThankYou.svg"
+                  />
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  Student
+                   
+                  1
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-30 13:35
+              </span>
+            </div>
+            <div
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
+            >
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#fffbf0"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#ffa940"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Awful job, you better quit programming and learn to cross stitch.
-                </div>
+                </p>
               </span>
             </div>
+            <div
+              class="ant-row"
+            />
           </div>
         </div>
       </div>
@@ -308,68 +718,154 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
-            >
-              <span
-                class="ant-comment-content-author-name"
-              >
-                Student 2
-              </span>
-            </div>
-            <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
-                <strong>
-                  Score: 
-                  5
-                </strong>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-image"
+                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
+                >
+                  <img
+                    src="/static/svg/badges/ThankYou.svg"
+                  />
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  Student
+                   
+                  2
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-30 13:35
+              </span>
+            </div>
+            <div
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
+            >
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#fffbf0"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#ffa940"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Awful job, you better quit programming and learn to cross stitch.
-                </div>
+                </p>
               </span>
             </div>
+            <div
+              class="ant-row"
+            />
           </div>
         </div>
       </div>
@@ -380,45 +876,51 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
-              <span
-                class="ant-comment-content-author-name"
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
                 <div
                   class="link-user"
@@ -480,26 +982,137 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       
                   </style>
                 </div>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-27 09:51
               </span>
             </div>
             <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
               >
-                <strong>
-                  Score: 
-                  100
-                </strong>
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#f6ffed"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#52c41a"
+                    />
+                  </svg>
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  100
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Great job, you better quit cross stitching and start programming.
-                </div>
+                </p>
               </span>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-typography"
+                style="margin: 0px;"
+              >
+                Student Discord:
+                 
+                <a
+                  class="ant-typography"
+                  href="https://discordapp.com/users/123456789012345680"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  @LinusTorvalds#1234
+                </a>
+                 
+                <button
+                  class="ant-btn ant-btn-dashed ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    class="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M232 706h142c22.1 0 40 17.9 40 40v142h250V264H232v442z"
+                        fill="#e6f7ff"
+                      />
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32z"
+                        fill="#1890ff"
+                      />
+                      <path
+                        d="M704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                        fill="#1890ff"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -511,45 +1124,51 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
-              <span
-                class="ant-comment-content-author-name"
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
                 <div
                   class="link-user"
@@ -611,26 +1230,137 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       
                   </style>
                 </div>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-27 09:51
               </span>
             </div>
             <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
               >
-                <strong>
-                  Score: 
-                  100
-                </strong>
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#f6ffed"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#52c41a"
+                    />
+                  </svg>
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  100
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Great job, you better quit cross stitching and start programming.
-                </div>
+                </p>
               </span>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-typography"
+                style="margin: 0px;"
+              >
+                Student Discord:
+                 
+                <a
+                  class="ant-typography"
+                  href="https://discordapp.com/users/123456789012345680"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  @LinusTorvalds#1234
+                </a>
+                 
+                <button
+                  class="ant-btn ant-btn-dashed ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    class="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M232 706h142c22.1 0 40 17.9 40 40v142h250V264H232v442z"
+                        fill="#e6f7ff"
+                      />
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32z"
+                        fill="#1890ff"
+                      />
+                      <path
+                        d="M704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                        fill="#1890ff"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -642,68 +1372,154 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
-            >
-              <span
-                class="ant-comment-content-author-name"
-              >
-                Student 5
-              </span>
-            </div>
-            <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
-                <strong>
-                  Score: 
-                  5
-                </strong>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-image"
+                  style="width: 24px; height: 24px; line-height: 24px; font-size: 18px;"
+                >
+                  <img
+                    src="/static/svg/badges/ThankYou.svg"
+                  />
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  Student
+                   
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-30 13:35
+              </span>
+            </div>
+            <div
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
+            >
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#fffbf0"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#ffa940"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  5
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Awful job, you better quit programming and learn to cross stitch.
-                </div>
+                </p>
               </span>
             </div>
+            <div
+              class="ant-row"
+            />
           </div>
         </div>
       </div>
@@ -719,49 +1535,88 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
   >
     <div
       class="ant-row"
+      style="margin: 8px 0px;"
+    >
+      <div
+        class="ant-col"
+        style="padding-left: 4px; padding-right: 4px;"
+      >
+        <span
+          class="ant-typography"
+        >
+          Student Contacts
+        </span>
+      </div>
+      <div
+        class="ant-col"
+        style="padding-left: 4px; padding-right: 4px;"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-small ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="ant-row"
     >
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
-              <span
-                class="ant-comment-content-author-name"
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
                 <div
                   class="link-user"
@@ -823,26 +1678,137 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       
                   </style>
                 </div>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-27 09:51
               </span>
             </div>
             <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
               >
-                <strong>
-                  Score: 
-                  100
-                </strong>
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#f6ffed"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#52c41a"
+                    />
+                  </svg>
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  100
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Great job, you better quit cross stitching and start programming.
-                </div>
+                </p>
               </span>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-typography"
+                style="margin: 0px;"
+              >
+                Student Discord:
+                 
+                <a
+                  class="ant-typography"
+                  href="https://discordapp.com/users/123456789012345680"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  @LinusTorvalds#1234
+                </a>
+                 
+                <button
+                  class="ant-btn ant-btn-dashed ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    class="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M232 706h142c22.1 0 40 17.9 40 40v142h250V264H232v442z"
+                        fill="#e6f7ff"
+                      />
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32z"
+                        fill="#1890ff"
+                      />
+                      <path
+                        d="M704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                        fill="#1890ff"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -854,45 +1820,51 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
-              <span
-                class="ant-comment-content-author-name"
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
                 <div
                   class="link-user"
@@ -954,26 +1926,137 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       
                   </style>
                 </div>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-27 09:51
               </span>
             </div>
             <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
               >
-                <strong>
-                  Score: 
-                  100
-                </strong>
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#f6ffed"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#52c41a"
+                    />
+                  </svg>
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  100
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Great job, you better quit cross stitching and start programming.
-                </div>
+                </p>
               </span>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-typography"
+                style="margin: 0px;"
+              >
+                Student Discord:
+                 
+                <a
+                  class="ant-typography"
+                  href="https://discordapp.com/users/123456789012345680"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  @LinusTorvalds#1234
+                </a>
+                 
+                <button
+                  class="ant-btn ant-btn-dashed ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    class="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M232 706h142c22.1 0 40 17.9 40 40v142h250V264H232v442z"
+                        fill="#e6f7ff"
+                      />
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32z"
+                        fill="#1890ff"
+                      />
+                      <path
+                        d="M704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                        fill="#1890ff"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -985,45 +2068,51 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       <div
         class="ant-divider ant-divider-horizontal"
         role="separator"
+        style="margin: 8px 0px;"
       />
+    </div>
+    <div
+      class="ant-comment"
+    >
       <div
-        class="ant-comment"
-        style="margin: 16px;"
+        class="ant-comment-inner"
       >
         <div
-          class="ant-comment-inner"
+          class="ant-comment-avatar"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-comment-content"
         >
           <div
-            class="ant-comment-avatar"
-          >
-            <span
-              aria-label="user"
-              class="anticon anticon-user"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="user"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            class="ant-comment-content"
+            class="ant-comment-content-detail"
           >
             <div
-              class="ant-comment-content-author"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1.5px; margin-right: -1.5px;"
             >
-              <span
-                class="ant-comment-content-author-name"
+              <div
+                class="ant-col"
+                style="padding-left: 1.5px; padding-right: 1.5px;"
               >
                 <div
                   class="link-user"
@@ -1085,26 +2174,137 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
       
                   </style>
                 </div>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="margin-bottom: 8px; font-size: 12px;"
+              >
+                2022-08-27 09:51
               </span>
             </div>
             <div
-              class="ant-comment-content-detail"
+              class="ant-row ant-row-middle"
+              style="margin-left: -1px; margin-right: -1px;"
             >
               <div
-                class="ant-typography"
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
               >
-                <strong>
-                  Score: 
-                  100
-                </strong>
+                <span
+                  aria-label="star"
+                  class="anticon anticon-star"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="star"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512.5 190.4l-94.4 191.3-211.2 30.7 152.8 149-36.1 210.3 188.9-99.3 188.9 99.2-36.1-210.3 152.8-148.9-211.2-30.7z"
+                      fill="#f6ffed"
+                    />
+                    <path
+                      d="M908.6 352.8l-253.9-36.9L541.2 85.8c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L370.3 315.9l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1L239 839.4a31.95 31.95 0 0046.4 33.7l227.1-119.4 227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3zM665.3 561.3l36.1 210.3-188.9-99.2-188.9 99.3 36.1-210.3-152.8-149 211.2-30.7 94.4-191.3 94.4 191.3 211.2 30.7-152.8 148.9z"
+                      fill="#52c41a"
+                    />
+                  </svg>
+                </span>
               </div>
+              <div
+                class="ant-col"
+                style="padding-left: 1px; padding-right: 1px;"
+              >
+                <span
+                  class="ant-typography"
+                >
+                  100
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-row"
+              style="margin-bottom: 24px;"
+            >
+              <span
+                class="ant-typography ant-typography-secondary"
+                style="font-size: 12px; line-height: 12px;"
+              >
+                maximum score: 
+                100
+              </span>
+            </div>
+            <div
+              class="ant-row"
+            >
               <span
                 class="ant-typography"
               >
-                <div>
+                <p>
                   Great job, you better quit cross stitching and start programming.
-                </div>
+                </p>
               </span>
+            </div>
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-typography"
+                style="margin: 0px;"
+              >
+                Student Discord:
+                 
+                <a
+                  class="ant-typography"
+                  href="https://discordapp.com/users/123456789012345680"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  @LinusTorvalds#1234
+                </a>
+                 
+                <button
+                  class="ant-btn ant-btn-dashed ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    class="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M232 706h142c22.1 0 40 17.9 40 40v142h250V264H232v442z"
+                        fill="#e6f7ff"
+                      />
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32z"
+                        fill="#1890ff"
+                      />
+                      <path
+                        d="M704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                        fill="#1890ff"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
+++ b/client/src/components/__tests__/__snapshots__/CrossCheckComments.test.tsx.snap
@@ -124,11 +124,11 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -157,7 +157,7 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -282,11 +282,11 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -315,7 +315,7 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -440,11 +440,11 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -473,7 +473,7 @@ exports[`CrossCheckComments Should render correctly if there are anonymous comme
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -640,11 +640,11 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -673,7 +673,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -798,11 +798,11 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -831,7 +831,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -996,11 +996,11 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -1029,7 +1029,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -1244,11 +1244,11 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -1277,7 +1277,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -1452,11 +1452,11 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -1485,7 +1485,7 @@ exports[`CrossCheckComments Should render correctly if there are both types of c
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -1692,11 +1692,11 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -1725,7 +1725,7 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -1940,11 +1940,11 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -1973,7 +1973,7 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"
@@ -2188,11 +2188,11 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
             </div>
             <div
               class="ant-row ant-row-middle"
-              style="margin-left: -1px; margin-right: -1px;"
+              style="margin-left: -2px; margin-right: -2px;"
             >
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   aria-label="star"
@@ -2221,7 +2221,7 @@ exports[`CrossCheckComments Should render correctly if there are signed comments
               </div>
               <div
                 class="ant-col"
-                style="padding-left: 1px; padding-right: 1px;"
+                style="padding-left: 2px; padding-right: 2px;"
               >
                 <span
                   class="ant-typography"

--- a/client/src/modules/Course/pages/Student/CrossCheckSubmit/index.tsx
+++ b/client/src/modules/Course/pages/Student/CrossCheckSubmit/index.tsx
@@ -26,7 +26,7 @@ const colSizes = { xs: 24, sm: 18, md: 12, lg: 10 };
 export function CrossCheckSubmit(props: CoursePageProps) {
   const [form] = Form.useForm();
   const courseService = useMemo(() => new CourseService(props.course.id), [props.course.id]);
-  const [feedback, setFeedback] = useState<Feedback>();
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [submittedSolution, setSubmittedSolution] = useState(null as TaskSolution | null);
   const router = useRouter();
   const queryTaskId = router.query.taskId ? +router.query.taskId : null;
@@ -111,7 +111,7 @@ export function CrossCheckSubmit(props: CoursePageProps) {
   }
 
   const handleTaskChange = async (value: number) => {
-    setFeedback(undefined);
+    setFeedback(null);
     const courseTaskId = Number(value);
     const courseTask = courseTasks.find(t => t.id === courseTaskId);
     if (courseTask == null) {
@@ -147,8 +147,8 @@ export function CrossCheckSubmit(props: CoursePageProps) {
     setNewComments(comments);
   };
 
-  const feedbackComments = feedback?.comments ?? [];
   const task = courseTasks.find(task => task.id === courseTaskId);
+  const maxScore = task?.maxScore;
   const taskExists = !!task;
   const submitAllowed = taskExists && !submitDeadlinePassed;
   const newCrossCheck = criteria.length > 0;
@@ -235,7 +235,7 @@ export function CrossCheckSubmit(props: CoursePageProps) {
         </Col>
       </Row>
       <Row>
-        <CrossCheckComments comments={feedbackComments} />
+        <CrossCheckComments feedback={feedback} maxScore={maxScore} />
       </Row>
     </PageLayout>
   );

--- a/client/src/pages/course/student/cross-check-review.tsx
+++ b/client/src/pages/course/student/cross-check-review.tsx
@@ -4,10 +4,10 @@ import {
   EyeInvisibleFilled,
   EyeTwoTone,
   EyeFilled,
-  StarTwoTone,
   EditOutlined,
   EditFilled,
 } from '@ant-design/icons';
+import { ScoreIcon } from 'components/Icons/ScoreIcon';
 import { Button, Checkbox, Col, Form, message, Row, Spin, Timeline, Typography } from 'antd';
 import { CourseTaskSelect, ScoreInput } from 'components/Forms';
 import MarkdownInput from 'components/Forms/MarkdownInput';
@@ -35,6 +35,7 @@ function CrossCheckHistory(props: {
   githubId: string | null;
   courseId: number;
   courseTaskId: number | null;
+  maxScore: number | undefined;
   setHistoricalCommentSelected: Dispatch<SetStateAction<string>>;
 }) {
   if (props.githubId == null || props.courseTaskId == null) {
@@ -75,7 +76,7 @@ function CrossCheckHistory(props: {
           >
             <div>{formatDateTime(historyItem.dateTime)}</div>
             <div>
-              <StarTwoTone twoToneColor={i === 0 ? '#52c41a' : 'gray'} />{' '}
+              <ScoreIcon maxScore={props.maxScore} score={historyItem.score} isOutdatedScore={!!i} />{' '}
               <Typography.Text>{historyItem.score}</Typography.Text>
             </div>
             <div>
@@ -183,6 +184,7 @@ function Page(props: CoursePageProps) {
   };
 
   const courseTask = courseTasks.find(t => t.id === courseTaskId);
+  const maxScore = courseTask?.maxScore;
   const assignment = assignments.find(({ student }) => student.githubId === form.getFieldValue('githubId'));
 
   return (
@@ -227,6 +229,7 @@ function Page(props: CoursePageProps) {
             githubId={githubId}
             courseId={props.course.id}
             courseTaskId={courseTaskId}
+            maxScore={maxScore}
             setHistoricalCommentSelected={setHistoricalCommentSelected}
           />
         </Col>

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -16,6 +16,7 @@ import {
   CreateCourseEventDto,
   StudentsScoreApi,
   CreateCourseTaskDtoCheckerEnum,
+  Discord,
 } from 'api';
 import { optionalQueryString } from 'utils/optionalQueryString';
 
@@ -28,10 +29,12 @@ export enum CrossCheckStatus {
 export type Feedback = {
   url?: string;
   comments?: {
+    updatedDate: string;
     comment: string;
     author: {
       name: string;
       githubId: string;
+      discord: Discord | null;
     } | null;
     score: number;
   }[];

--- a/server/src/services/taskResults.service.ts
+++ b/server/src/services/taskResults.service.ts
@@ -183,7 +183,7 @@ export async function getTaskSolutionFeedback(studentId: number, courseTaskId: n
   const comments = (
     await getRepository(TaskSolutionResult)
       .createQueryBuilder('tsr')
-      .select(['tsr.comment', 'tsr.anonymous', 'tsr.score'])
+      .select(['tsr.updatedDate', 'tsr.comment', 'tsr.anonymous', 'tsr.score'])
       .innerJoin('tsr.checker', 'checker')
       .innerJoin('checker.user', 'user')
       .addSelect(['checker.id', ...getPrimaryUserFields('user')])
@@ -195,10 +195,12 @@ export async function getTaskSolutionFeedback(studentId: number, courseTaskId: n
       ? {
           name: createName(c.checker.user),
           githubId: c.checker.user.githubId,
+          discord: c.checker.user.discord,
         }
       : null;
     return {
       author,
+      updatedDate: c.updatedDate,
       comment: c.comment,
       score: c.score,
     };


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [x] Refactoring
- [x] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#719

#### 💡 Background and solution

Из issues #719 реализовал 2 пункт (`Добавить отображения даты проверки`). 1 пункт уже есть в rs app в виде блокирующей кнопки.

Реализовано:
- Кнопка показать / скрыть контакты
- Отображения даты последней проверки
- Иконка с разным цветом в зависимости от количество баллов
- Максимальная оценка за таск
- Дискорд аккаунт проверяющего
- sticky аватарка

<details> 
<summary>Устаревший IMG</summary>

![result](https://user-images.githubusercontent.com/48645737/187741861-fd393cb3-3701-4c02-bbd5-cb53e7c0008d.png)

</details> 

UPD:

![result2](https://user-images.githubusercontent.com/48645737/187942534-912b97c7-7dde-4efd-908b-a99c553e5d07.png)

Sticky аватарка:
![sticky](https://user-images.githubusercontent.com/48645737/188125659-11608065-5736-48e9-ad6f-5b81e3f8e87c.gif)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
