### PR TITLE
Fix: score columns filtering on Enter keypress

### DIFF
--- a/client/src/modules/Score/components/ScoreTable/index.tsx
+++ b/client/src/modules/Score/components/ScoreTable/index.tsx
@@ -1,22 +1,22 @@
-import { ColumnType, TableProps } from 'antd/lib/table';
 import { Table, TablePaginationConfig } from 'antd';
+import { ColumnType, TableProps } from 'antd/lib/table';
+import { FilterValue, SorterResult } from 'antd/lib/table/interface';
+import { Store } from 'rc-field-form/lib/interface';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocalStorage } from 'react-use';
 import { isUndefined } from 'lodash';
+import { useRouter } from 'next/router';
+import css from 'styled-jsx/css';
+import { CoursesTasksApi, CourseTaskDto, ScoreStudentDto } from 'api';
 import { getColumns } from 'modules/Score/data/getColumns';
 import { getTaskColumns } from 'modules/Score/data/getTaskColumns';
 import { useScorePaging } from 'modules/Score/hooks/useScorePaging';
-import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SettingsModal } from 'modules/Score/components/SettingsModal';
 import { CourseService } from 'services/course';
 import { CoursePageProps } from 'services/models';
-import css from 'styled-jsx/css';
 import { IPaginationInfo } from 'common/types/pagination';
 import { ScoreOrder, ScoreTableFilters } from 'common/types/score';
-import { SettingsModal } from 'modules/Score/components/SettingsModal';
-import { Store } from 'rc-field-form/lib/interface';
-import { useLocalStorage } from 'react-use';
-import { CoursesTasksApi, CourseTaskDto, ScoreStudentDto } from 'api';
 import useWindowDimensions from 'utils/useWindowDimensions';
-import { FilterValue, SorterResult } from 'antd/lib/table/interface';
 
 type Props = CoursePageProps & {
   onLoading: (value: boolean) => void;


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/1681

#### 💡 Background and solution

Root cause of the bug is Antd behaviour when after pressing Enter key antd fires 2 consequent `change` events - with `filter` and `sort` actions. In this case sort action receives outdated filters which leads to request for old data. This bug (feature?) already submitted to antd repo https://github.com/ant-design/ant-design/issues/37334 .
Fix provides workaround for this behaviour.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
