### PR TITLE
fix(auto-test): update table sizes, remove ellipsis

### DIFF
--- a/client/src/pages/course/student/auto-test.tsx
+++ b/client/src/pages/course/student/auto-test.tsx
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { CheckSquareTwoTone, CloseSquareTwoTone, ReloadOutlined, UploadOutlined } from '@ant-design/icons';
-import { Button, Checkbox, Col, Form, message, notification, Radio, Row, Table, Typography, Upload } from 'antd';
+import { Button, Checkbox, Col, Form, message, notification, Radio, Row, Table, Typography, Upload, Grid } from 'antd';
 import { UploadFile } from 'antd/lib/upload/interface';
 import {
   CoursesTasksApi,
@@ -32,6 +32,8 @@ import {
 import { FilesService } from 'services/files';
 import { CoursePageProps } from 'services/models';
 
+const { useBreakpoint } = Grid;
+
 const courseTasksApi = new CoursesTasksApi();
 
 const parseCourseTask = (courseTask: CourseTaskDetailedDto) => {
@@ -60,6 +62,8 @@ function Page(props: CoursePageProps) {
   const [courseTaskId, setCourseTaskId] = useState(null as number | null);
 
   const [isModified, setIsModified] = useState(false);
+
+  const screens = useBreakpoint();
 
   useBeforeUnload(isModified, 'You have changes in test! Do you realy want to close this page?');
 
@@ -197,7 +201,7 @@ function Page(props: CoursePageProps) {
             </Row>
           </Form>
         </Col>
-        <Col xs={24} sm={20} md={18} lg={14}>
+        <Col xs={24} sm={24} md={24} lg={14}>
           <Row justify="space-between">
             <Typography.Title type="secondary" level={4}>
               Verification Results
@@ -215,23 +219,22 @@ function Page(props: CoursePageProps) {
                 title: 'Date/Time',
                 dataIndex: 'createdDate',
                 render: shortDateTimeRenderer,
-                width: 100,
+                width: '12%',
               },
               {
                 title: 'Status',
                 dataIndex: 'status',
-                width: 100,
+                width: '12%',
               },
               {
                 title: 'Task Name',
                 dataIndex: ['courseTask', 'task', 'name'],
-                ellipsis: true,
-                width: 150,
+                width: '17%',
               },
               {
                 title: 'Score',
                 dataIndex: 'score',
-                width: 60,
+                width: '8%',
               },
               {
                 title: 'Details',

--- a/client/src/pages/course/student/auto-test.tsx
+++ b/client/src/pages/course/student/auto-test.tsx
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { CheckSquareTwoTone, CloseSquareTwoTone, ReloadOutlined, UploadOutlined } from '@ant-design/icons';
-import { Button, Checkbox, Col, Form, message, notification, Radio, Row, Table, Typography, Upload, Grid } from 'antd';
+import { Button, Checkbox, Col, Form, message, notification, Radio, Row, Table, Typography, Upload } from 'antd';
 import { UploadFile } from 'antd/lib/upload/interface';
 import {
   CoursesTasksApi,
@@ -32,8 +32,6 @@ import {
 import { FilesService } from 'services/files';
 import { CoursePageProps } from 'services/models';
 
-const { useBreakpoint } = Grid;
-
 const courseTasksApi = new CoursesTasksApi();
 
 const parseCourseTask = (courseTask: CourseTaskDetailedDto) => {
@@ -62,8 +60,6 @@ function Page(props: CoursePageProps) {
   const [courseTaskId, setCourseTaskId] = useState(null as number | null);
 
   const [isModified, setIsModified] = useState(false);
-
-  const screens = useBreakpoint();
 
   useBeforeUnload(isModified, 'You have changes in test! Do you realy want to close this page?');
 


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[Auto-tests: Поломалась верстка авто-тестов в мобильной версии](https://github.com/rolling-scopes/rsschool-app/issues/1708)

#### 💡 Background and solution

* `ellipsis: true` breaks layout for mobile resolution
* changed width in px to % to make more responsive for mobile resolutions

##### Mobile:

* Empty state:
  ![image](https://user-images.githubusercontent.com/28038704/191037019-5324a85c-6e39-4e3f-9008-bfba95bcb3c6.png)

* With data:
![image](https://user-images.githubusercontent.com/28038704/191037234-fc9d2708-e353-4c81-9808-b3caebeefb61.png)

##### Desktop:

* Empty state:
![image](https://user-images.githubusercontent.com/28038704/191037301-e02b6189-7cc9-40b5-8743-751388c54b3d.png)

* With data:
![image](https://user-images.githubusercontent.com/28038704/191037348-871d89c7-d0be-4b42-b3e7-2ba6236a07a5.png)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
