### PR TITLE
fix: change tooltip placement

### DIFF
--- a/client/src/components/Icons/DeadlineIcon.tsx
+++ b/client/src/components/Icons/DeadlineIcon.tsx
@@ -21,7 +21,7 @@ export function DeadlineIcon({ group, endDate }: Props) {
   const color = getColor(endDate);
 
   return (
-    <Tooltip title={title} placement="bottomRight">
+    <Tooltip title={title} placement="topRight">
       <ClockCircleOutlined style={{ fontSize: '14px', color }} />
     </Tooltip>
   );


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#### 💡 Background and solution

При просмотре несколько дедлайнов сверху вниз, tooltip перекрывает следующий дедлайн.

![result](https://user-images.githubusercontent.com/48645737/191980347-35779dda-154b-466c-b90a-3da792054566.png)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
