### PR TITLE
fix(table-view): should not break page when filter is null

### DIFF
--- a/client/src/modules/Schedule/components/TableView/TableView.test.tsx
+++ b/client/src/modules/Schedule/components/TableView/TableView.test.tsx
@@ -177,6 +177,18 @@ describe('TableView', () => {
     const checkbox = within(menuItem).getByRole('checkbox');
     expect(checkbox).toBeChecked();
   });
+
+  it('should not render filtered tags when tagFilter is null', () => {
+    jest
+      .spyOn(ReactUse, 'useLocalStorage')
+      // Mock useLocalStorage for tagFilter
+      .mockReturnValueOnce([null, jest.fn(), jest.fn()]);
+    render(<TableView settings={PROPS_SETTINGS_MOCK} data={generateCourseData()} />);
+
+    const tag = screen.queryByText(/Tag: /);
+
+    expect(tag).not.toBeInTheDocument();
+  });
 });
 
 function generateCourseData(

--- a/client/src/modules/Schedule/components/TableView/TableView.tsx
+++ b/client/src/modules/Schedule/components/TableView/TableView.tsx
@@ -51,7 +51,7 @@ const getColumns = ({
           </a>
         );
       },
-      filteredValue: filteredInfo.name,
+      filteredValue: filteredInfo.name || null,
       ...getColumnSearchProps('name'),
     },
     {
@@ -61,8 +61,8 @@ const getColumns = ({
       render: (tag: CourseScheduleItemDto['tag']) => renderTagWithStyle(tag, tagColors),
       filters: TAGS.map(status => ({ text: renderTagWithStyle(status.value, tagColors), value: status.value })),
       defaultFilteredValue: tagFilter,
-      filtered: tagFilter.length > 0,
-      filteredValue: tagFilter,
+      filtered: tagFilter?.length > 0,
+      filteredValue: tagFilter || null,
     },
     {
       key: ColumnKey.StartDate,
@@ -93,7 +93,7 @@ const getColumns = ({
       title: ColumnName.Organizer,
       dataIndex: ['organizer', 'githubId'],
       render: (value: string) => !!value && <GithubUserLink value={value} />,
-      filteredValue: filteredInfo.organizer,
+      filteredValue: filteredInfo.organizer || null,
       ...getColumnSearchProps('organizer.githubId'),
     },
     {


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

Fix for: #1737 

#### 💡 Background and solution

- When click "Reset" in tags filter, page is broken

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
