### PR TITLE
Change students pages background

### DIFF
--- a/client/src/pages/course/student/auto-test.tsx
+++ b/client/src/pages/course/student/auto-test.tsx
@@ -186,8 +186,14 @@ function Page(props: CoursePageProps) {
   };
 
   return (
-    <PageLayout loading={loading} title="Auto-Test" courseName={props.course.name} githubId={props.session.githubId}>
-      <Row gutter={24}>
+    <PageLayout
+      loading={loading}
+      title="Auto-Test"
+      background="#F0F2F5"
+      courseName={props.course.name}
+      githubId={props.session.githubId}
+    >
+      <Row gutter={24} style={{ minHeight: '85vh' }}>
         <Col style={{ marginBottom: 32 }} xs={24} sm={18} md={12} lg={10}>
           <Form form={form} onFinish={handleSubmit} layout="vertical" onChange={() => setIsModified(true)}>
             <CourseTaskSelect onChange={handleCourseTaskChange} groupBy="deadline" data={courseTasks} />

--- a/client/src/pages/course/student/dashboard.tsx
+++ b/client/src/pages/course/student/dashboard.tsx
@@ -149,12 +149,13 @@ function Page(props: CoursePageProps) {
     <PageLayout
       loading={loading}
       title="Student dashboard"
+      background="#F0F2F5"
       githubId={props.session.githubId}
       courseName={props.course.name}
     >
       <LoadingScreen show={loading}>
         {studentSummary ? (
-          <div>
+          <>
             <Masonry
               breakpointCols={{
                 default: 4,
@@ -173,11 +174,9 @@ function Page(props: CoursePageProps) {
             </Masonry>
             {masonryStyles}
             {masonryColumnStyles}
-          </div>
-        ) : (
-          <>
-            <Result status={'403'} title="You have no access to this page" />
           </>
+        ) : (
+          <Result status={'403'} title="You have no access to this page" />
         )}
       </LoadingScreen>
     </PageLayout>
@@ -190,6 +189,7 @@ const { className: masonryClassName, styles: masonryStyles } = css.resolve`
     display: flex;
     margin-left: -${gapSize}px;
     width: auto;
+    min-height: 85vh;
   }
 `;
 const { className: masonryColumnClassName, styles: masonryColumnStyles } = css.resolve`

--- a/client/src/pages/course/student/interviews.tsx
+++ b/client/src/pages/course/student/interviews.tsx
@@ -87,8 +87,14 @@ function Page(props: CoursePageProps) {
   };
 
   return (
-    <PageLayout loading={loading} title="Interviews" githubId={props.session.githubId} courseName={props.course.name}>
-      <Row gutter={24}>
+    <PageLayout
+      loading={loading}
+      title="Interviews"
+      background="#F0F2F5"
+      githubId={props.session.githubId}
+      courseName={props.course.name}
+    >
+      <Row gutter={24} style={{ minHeight: '85vh' }}>
         {interviews.map(interview => {
           const items = data.filter(d => d.name === interview.name);
           return (


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [x] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/1704

#### 💡 Background and solution

Changed the background color for the required pages + increased the size of the page content for better visual appearance.

- Dashboard page  
  - Before  
![dashboard-before](https://user-images.githubusercontent.com/34455330/194700222-1601aabe-4431-49f4-8f72-71b2e2692f0a.JPG)

  - After  
![dashboard-after](https://user-images.githubusercontent.com/34455330/194700227-0cd97dda-39fd-4dce-a86a-74bee47b0ffe.JPG)

- Interviews page  
  - Before  
![interviews-before](https://user-images.githubusercontent.com/34455330/194700233-631f54a3-fe68-4c34-9a4e-5f6b4f417d66.JPG)

  - After  
![interviews-after](https://user-images.githubusercontent.com/34455330/194700236-dafa3eea-551c-41dd-b439-caa96e6079c2.JPG)

- Auto-tests page  
  - Before  
![auto-test-before](https://user-images.githubusercontent.com/34455330/194700240-2afceb3c-c1ba-4433-b8e8-71ca00c53ea4.JPG)

  - After  
![auto-test-after](https://user-images.githubusercontent.com/34455330/194700244-5b69805e-9d57-4b6b-8bbb-d2d2edc5fe4c.JPG)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
