### PR TITLE
fix: default time for creating course tasks

### DIFF
--- a/client/src/modules/CourseManagement/components/CourseTaskModal/index.tsx
+++ b/client/src/modules/CourseManagement/components/CourseTaskModal/index.tsx
@@ -116,7 +116,7 @@ export function CourseTaskModal(props: Props) {
             label="Start Date - End Date"
             rules={[{ required: true, type: 'array', message: 'Please enter start and end date' }]}
           >
-            <DatePicker.RangePicker format="YYYY-MM-DD HH:mm" showTime={{ format: 'HH:mm' }} />
+            <DatePicker.RangePicker format="YYYY-MM-DD HH:mm" showTime={{ format: 'HH:mm', defaultValue: [moment().hour(0).minute(0), moment().hour(23).minute(59)] }} />
           </Form.Item>
         </Col>
         <Col span={6}>

--- a/client/src/modules/CourseManagement/components/CourseTaskModal/index.tsx
+++ b/client/src/modules/CourseManagement/components/CourseTaskModal/index.tsx
@@ -116,7 +116,10 @@ export function CourseTaskModal(props: Props) {
             label="Start Date - End Date"
             rules={[{ required: true, type: 'array', message: 'Please enter start and end date' }]}
           >
-            <DatePicker.RangePicker format="YYYY-MM-DD HH:mm" showTime={{ format: 'HH:mm', defaultValue: [moment().hour(0).minute(0), moment().hour(23).minute(59)] }} />
+            <DatePicker.RangePicker
+              format="YYYY-MM-DD HH:mm"
+              showTime={{ format: 'HH:mm', defaultValue: [moment().hour(0).minute(0), moment().hour(23).minute(59)] }}
+            />
           </Form.Item>
         </Col>
         <Col span={6}>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[_Describe the source of requirement, like related issue link._](https://github.com/rolling-scopes/rsschool-app/issues/1800)

#### 💡 Background and solution

Set default time for startDate - 00:00 and 23:59 for endDate while task creation
_Describe the big picture of your changes here_

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
