### PR TITLE
Fix cross check items flow

### DIFF
--- a/nestjs/package.json
+++ b/nestjs/package.json
@@ -114,7 +114,8 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "^@entities(.*)$": "<rootDir>/../../server/src/models/$1"
+      "^@entities(.*)$": "<rootDir>/../../server/src/models/$1",
+      "^src/(.*)$": "<rootDir>/$1"
     },
     "clearMocks": true
   },

--- a/nestjs/src/courses/course-schedule/course-schedule.service.spec.ts
+++ b/nestjs/src/courses/course-schedule/course-schedule.service.spec.ts
@@ -146,6 +146,9 @@ describe('CourseScheduleService', () => {
           id: mockCrossCheckCourseTask.taskOwner?.id,
           name: `${mockCrossCheckCourseTask.taskOwner?.firstName} ${mockCrossCheckCourseTask.taskOwner?.lastName}`,
         },
+        scoreWeight: mockCrossCheckCourseTask.scoreWeight,
+        score: null,
+        maxScore: mockCrossCheckCourseTask.maxScore,
       });
 
       expect(reviewItem).toEqual({
@@ -162,6 +165,9 @@ describe('CourseScheduleService', () => {
           id: mockCrossCheckCourseTask.taskOwner?.id,
           name: `${mockCrossCheckCourseTask.taskOwner?.firstName} ${mockCrossCheckCourseTask.taskOwner?.lastName}`,
         },
+        scoreWeight: mockCrossCheckCourseTask.scoreWeight,
+        score: null,
+        maxScore: mockCrossCheckCourseTask.maxScore,
       });
     });
   });

--- a/nestjs/src/courses/course-schedule/course-schedule.service.spec.ts
+++ b/nestjs/src/courses/course-schedule/course-schedule.service.spec.ts
@@ -1,0 +1,301 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CourseScheduleItemStatus, CourseScheduleItemTag, CourseScheduleService } from './course-schedule.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Course } from '@entities/course';
+import {
+  CourseEvent,
+  CourseTask,
+  StageInterview,
+  TaskChecker,
+  TaskInterviewResult,
+  TaskResult,
+  TaskSolution,
+} from '@entities/index';
+
+const MOCK_CURRENT_TIME = new Date('2022-03-22T00:00:00.000Z');
+
+enum MockDate {
+  DateBefore = '2022-03-21T00:00:00.000Z',
+  DateAfter = '2022-03-23T00:00:00.000Z',
+}
+
+const mockCrossCheckCourseTask = {
+  id: 111,
+  createdDate: '2022-10-29T15:28:29.054Z',
+  updatedDate: '2022-11-01T14:33:47.015Z',
+  taskId: 222,
+  courseId: 333,
+  studentStartDate: '2022-10-27T17:27:00.000Z',
+  studentEndDate: '2022-10-31T17:28:00.000Z',
+  crossCheckEndDate: '2022-11-05T23:59:00.000Z',
+  mentorStartDate: null,
+  mentorEndDate: null,
+  maxScore: 100,
+  scoreWeight: 1,
+  checker: 'crossCheck',
+  taskOwnerId: 999,
+  pairsCount: 3,
+  type: 'jstask',
+  disabled: false,
+  crossCheckStatus: 'initial',
+  submitText: 'Some text',
+  validations: { githubIdInUrl: false },
+  task: {
+    id: 222,
+    createdDate: ' 2020-02-21T10:24:38.588Z',
+    updatedDate: '2020-02-21T10:24:38.588Z',
+    name: 'Singolo',
+    descriptionUrl: 'https://github.com/rolling-scopes-school/tasks/tree/master/tasks/markups/level-2/singolo',
+    description: null,
+    githubPrRequired: false,
+    verification: 'manual',
+    githubRepoName: null,
+    sourceGithubRepoUrl: null,
+    type: 'htmltask',
+    useJury: false,
+    allowStudentArtefacts: false,
+    tags: ['stage1', 'html'],
+    skills: [],
+    disciplineId: null,
+    attributes: {},
+  },
+  taskOwner: {
+    id: 98765,
+    firstName: 'John',
+    lastName: 'Doe',
+    githubId: 'john-doe',
+  },
+} as unknown as CourseTask;
+
+describe('CourseScheduleService', () => {
+  let service: CourseScheduleService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CourseScheduleService,
+        {
+          provide: getRepositoryToken(Course),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(CourseTask),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(CourseEvent),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(TaskResult),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(TaskInterviewResult),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(StageInterview),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(TaskSolution),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(TaskChecker),
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    service = module.get<CourseScheduleService>(CourseScheduleService);
+  });
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should have getCrossCheckItemStatus method', () => {
+    expect(service).toHaveProperty('getCrossCheckItemStatus');
+  });
+
+  it('should have transformCrossCheckTask method', () => {
+    expect(service).toHaveProperty('transformCrossCheckTask');
+  });
+
+  describe('transformCrossCheckTask', () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+    it('should create 2 items from task', () => {
+      const mockStatus = CourseScheduleItemStatus.Available;
+      jest.spyOn(service, 'getCrossCheckItemStatus').mockReturnValue(mockStatus);
+      const [submitItem, reviewItem] = service.transformCrossCheckTask(mockCrossCheckCourseTask, true, null, 12345);
+
+      expect(submitItem).toEqual({
+        id: mockCrossCheckCourseTask.id,
+        name: mockCrossCheckCourseTask.task.name,
+        courseId: mockCrossCheckCourseTask.courseId,
+        startDate: mockCrossCheckCourseTask.studentStartDate,
+        endDate: mockCrossCheckCourseTask.studentEndDate,
+        status: mockStatus,
+        tag: CourseScheduleItemTag.CrossCheckSubmit,
+        descriptionUrl: mockCrossCheckCourseTask.task.descriptionUrl,
+        organizer: {
+          githubId: mockCrossCheckCourseTask.taskOwner?.githubId,
+          id: mockCrossCheckCourseTask.taskOwner?.id,
+          name: `${mockCrossCheckCourseTask.taskOwner?.firstName} ${mockCrossCheckCourseTask.taskOwner?.lastName}`,
+        },
+      });
+
+      expect(reviewItem).toEqual({
+        id: mockCrossCheckCourseTask.id,
+        name: mockCrossCheckCourseTask.task.name,
+        courseId: mockCrossCheckCourseTask.courseId,
+        startDate: mockCrossCheckCourseTask.studentEndDate,
+        endDate: mockCrossCheckCourseTask.crossCheckEndDate,
+        status: mockStatus,
+        tag: CourseScheduleItemTag.CrossCheckReview,
+        descriptionUrl: mockCrossCheckCourseTask.task.descriptionUrl,
+        organizer: {
+          githubId: mockCrossCheckCourseTask.taskOwner?.githubId,
+          id: mockCrossCheckCourseTask.taskOwner?.id,
+          name: `${mockCrossCheckCourseTask.taskOwner?.firstName} ${mockCrossCheckCourseTask.taskOwner?.lastName}`,
+        },
+      });
+    });
+  });
+
+  describe('getCrossCheckItemStatus', () => {
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(MOCK_CURRENT_TIME);
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    const testCases = [
+      {
+        description: 'should define item as Archived if no startTime is provided',
+        input: [
+          {
+            startTime: null,
+            endTime: MockDate.DateAfter,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          undefined,
+        ],
+        expectedStatus: CourseScheduleItemStatus.Archived,
+      },
+      {
+        description: 'should define item as Archived if no endTime is provided',
+        input: [
+          {
+            startTime: MockDate.DateAfter,
+            endTime: null,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          undefined,
+        ],
+        expectedStatus: CourseScheduleItemStatus.Archived,
+      },
+      {
+        description: 'should define item as Future',
+        input: [
+          {
+            startTime: MockDate.DateAfter,
+            endTime: MockDate.DateAfter,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          undefined,
+        ],
+        expectedStatus: CourseScheduleItemStatus.Future,
+      },
+      {
+        description: 'should define review item as Done if score is present',
+        input: [
+          {
+            startTime: MockDate.DateBefore,
+            endTime: MockDate.DateBefore,
+          },
+          CourseScheduleItemTag.CrossCheckReview,
+          { currentScore: 100 },
+        ],
+        expectedStatus: CourseScheduleItemStatus.Done,
+      },
+      {
+        description: 'should define submit item as Done if score is present',
+        input: [
+          {
+            startTime: MockDate.DateBefore,
+            endTime: MockDate.DateBefore,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          { currentScore: 100 },
+        ],
+        expectedStatus: CourseScheduleItemStatus.Done,
+      },
+      {
+        description: 'should define submit item as Done if score is not present but task was submitted',
+        input: [
+          {
+            startTime: MockDate.DateBefore,
+            endTime: MockDate.DateBefore,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          { currentScore: null, submitted: true },
+        ],
+        expectedStatus: CourseScheduleItemStatus.Done,
+      },
+      {
+        description: 'should define item as Available if task is in progress',
+        input: [
+          {
+            startTime: MockDate.DateBefore,
+            endTime: MockDate.DateAfter,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          { currentScore: null, submitted: true },
+        ],
+        expectedStatus: CourseScheduleItemStatus.Available,
+      },
+      {
+        description: 'should define review item as Missed if there is no score after submit',
+        input: [
+          {
+            startTime: MockDate.DateBefore,
+            endTime: MockDate.DateBefore,
+          },
+          CourseScheduleItemTag.CrossCheckReview,
+          { currentScore: null, submitted: true },
+        ],
+        expectedStatus: CourseScheduleItemStatus.Missed,
+      },
+      {
+        description: 'should define submit item as Missed if there is no score after submit and there was no submit',
+        input: [
+          {
+            startTime: MockDate.DateBefore,
+            endTime: MockDate.DateBefore,
+          },
+          CourseScheduleItemTag.CrossCheckSubmit,
+          { currentScore: null, submitted: false },
+        ],
+        expectedStatus: CourseScheduleItemStatus.Missed,
+      },
+    ] as {
+      description: string;
+      input: [
+        { startTime: string | Date | null; endTime: string | Date | null },
+        CourseScheduleItemTag,
+        { currentScore: number | null; submitted: boolean } | undefined,
+      ];
+      expectedStatus: CourseScheduleItemStatus;
+    }[];
+
+    test.each(testCases)('$description', ({ input: [range, tag, studentData], expectedStatus }) => {
+      expect(service.getCrossCheckItemStatus(range, tag, studentData)).toBe(expectedStatus);
+    });
+  });
+});

--- a/nestjs/src/courses/course-schedule/course-schedule.service.ts
+++ b/nestjs/src/courses/course-schedule/course-schedule.service.ts
@@ -7,7 +7,7 @@ import { TaskResult } from '@entities/taskResult';
 import { TaskSolution } from '@entities/taskSolution';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { PersonDto } from 'src/core/dto';
+import { PersonDto } from '../../core/dto';
 import { Repository } from 'typeorm';
 import { EventType } from '../course-events/dto/course-event.dto';
 import { Course } from '@entities/course';
@@ -148,8 +148,8 @@ export class CourseScheduleService {
 
   public getCourseTaskSubmitted(courseTaskId: number, taskSolutions: TaskSolution[], taskCheckers: TaskChecker[]) {
     return (
-      taskSolutions.some(courseTask => courseTask.id === courseTaskId) ||
-      taskCheckers.some(courseTask => courseTask.id === courseTaskId)
+      taskSolutions.some(solution => solution.courseTaskId === courseTaskId) ||
+      taskCheckers.some(checker => checker.courseTaskId === courseTaskId)
     );
   }
 
@@ -168,7 +168,11 @@ export class CourseScheduleService {
       courseId: crossCheckTask.courseId,
       startDate: crossCheckTask.studentStartDate,
       endDate: crossCheckTask.studentEndDate,
-      status: this.getCourseTaskStatus(submitRange, studentId ? { currentScore, submitted } : undefined),
+      status: this.getCrossCheckItemStatus(
+        submitRange,
+        CourseScheduleItemTag.CrossCheckSubmit,
+        studentId ? { currentScore, submitted } : undefined,
+      ),
       tag: CourseScheduleItemTag.CrossCheckSubmit,
       descriptionUrl: crossCheckTask.task.descriptionUrl,
       organizer: crossCheckTask.taskOwner ? new PersonDto(crossCheckTask.taskOwner) : null,
@@ -180,13 +184,46 @@ export class CourseScheduleService {
       courseId: crossCheckTask.courseId,
       startDate: crossCheckTask.studentEndDate,
       endDate: crossCheckTask.crossCheckEndDate,
-      status: this.getCourseTaskStatus(reviewRange, studentId ? { currentScore, submitted } : undefined),
+      status: this.getCrossCheckItemStatus(
+        reviewRange,
+        CourseScheduleItemTag.CrossCheckReview,
+        studentId ? { currentScore, submitted } : undefined,
+      ),
       tag: CourseScheduleItemTag.CrossCheckReview,
       descriptionUrl: crossCheckTask.task.descriptionUrl,
       organizer: crossCheckTask.taskOwner ? new PersonDto(crossCheckTask.taskOwner) : null,
     };
 
     return [submitItem, reviewItem] as CourseScheduleItem[];
+  }
+
+  public getCrossCheckItemStatus(
+    range: { startTime: string | Date | null; endTime: string | Date | null },
+    tag: CourseScheduleItemTag,
+    studentData?: { currentScore: number | null; submitted: boolean },
+  ) {
+    if (!range.startTime || !range.endTime) {
+      return CourseScheduleItemStatus.Archived;
+    }
+
+    const startTime = new Date(range.startTime).getTime();
+    const endTime = new Date(range.endTime).getTime();
+    const { currentScore = null, submitted = false } = studentData ?? {};
+    const now = Date.now();
+
+    if (startTime > now) {
+      return CourseScheduleItemStatus.Future;
+    }
+
+    if (currentScore != null || (endTime < now && tag === CourseScheduleItemTag.CrossCheckSubmit && submitted)) {
+      return CourseScheduleItemStatus.Done;
+    }
+
+    if (startTime <= now && endTime >= now) {
+      return CourseScheduleItemStatus.Available;
+    }
+
+    return studentData ? CourseScheduleItemStatus.Missed : CourseScheduleItemStatus.Archived;
   }
 
   public async copyFromTo(fromCourseId: number, toCourseId: number) {

--- a/nestjs/src/courses/course-schedule/course-schedule.service.ts
+++ b/nestjs/src/courses/course-schedule/course-schedule.service.ts
@@ -176,6 +176,9 @@ export class CourseScheduleService {
       tag: CourseScheduleItemTag.CrossCheckSubmit,
       descriptionUrl: crossCheckTask.task.descriptionUrl,
       organizer: crossCheckTask.taskOwner ? new PersonDto(crossCheckTask.taskOwner) : null,
+      scoreWeight: crossCheckTask.scoreWeight,
+      score: currentScore,
+      maxScore: crossCheckTask.maxScore,
     };
 
     const reviewItem = {
@@ -192,6 +195,9 @@ export class CourseScheduleService {
       tag: CourseScheduleItemTag.CrossCheckReview,
       descriptionUrl: crossCheckTask.task.descriptionUrl,
       organizer: crossCheckTask.taskOwner ? new PersonDto(crossCheckTask.taskOwner) : null,
+      scoreWeight: crossCheckTask.scoreWeight,
+      score: currentScore,
+      maxScore: crossCheckTask.maxScore,
     };
 
     return [submitItem, reviewItem] as CourseScheduleItem[];


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [x] Refactoring
- [x] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#1816 
#1822 
#1824 

#### 💡 Background and solution

1. Implemented cross-check schedule items status calculation according to [schema](https://www.figma.com/file/D31S4jMK4EQfnpvguVjc8W/RS-Redesign_Ant-design?node-id=131180%3A442782)
2. Covered it with tests
3. Fixed bug when cross-check items were without score-related data

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
