### PR TITLE
fix(auto-test): redirection to login when student

### DIFF
--- a/nestjs/src/courses/course-tasks/course-tasks.controller.ts
+++ b/nestjs/src/courses/course-tasks/course-tasks.controller.ts
@@ -42,8 +42,7 @@ export class CourseTasksController {
   @ApiForbiddenResponse()
   @ApiBadRequestResponse()
   @ApiOperation({ operationId: 'getCourseTasksDetailed' })
-  @UseGuards(CourseGuard, RoleGuard)
-  @RequiredRoles([Role.Admin, CourseRole.Manager, CourseRole.Supervisor])
+  @UseGuards(CourseGuard)
   public async getAllExtended(
     @Req() _: CurrentRequest,
     @Param('courseId', ParseIntPipe) courseId: number,


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

#1712 

#### 💡 Background and solution

New auto-test page requires detailed task data on main page (`public` field from `attributes` json of task), but api `getCourseTasksDetailed` route was under RoleGuard and students were redirecting to `/login` page when open this new auto-test page.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [x] Changes are tested locally
