### PR TITLE
refactor(cross-check): delete unnecessary score

### DIFF
--- a/client/src/modules/CrossCheck/components/CrossCheckCriteriaForm.tsx
+++ b/client/src/modules/CrossCheck/components/CrossCheckCriteriaForm.tsx
@@ -32,7 +32,6 @@ export interface CriteriaFormProps {
   countStar: CountState[];
   setCountStar: (newCount: CountState[]) => void;
   criteriaData: CrossCheckCriteriaData[];
-  totalPoints?: number;
   penalty: CountState[];
   setPenalty: (newPenalty: CountState[]) => void;
   criteriaComment: CommentState[];
@@ -43,7 +42,6 @@ export function CrossCheckCriteriaForm({
   countStar,
   setCountStar,
   criteriaData,
-  totalPoints,
   penalty,
   setPenalty,
   criteriaComment,
@@ -52,10 +50,6 @@ export function CrossCheckCriteriaForm({
   const form = Form.useFormInstance();
   const penaltyData: CrossCheckCriteriaData[] =
     criteriaData?.filter(item => item.type.toLowerCase() === TaskType.Penalty).map(item => omit(item, ['point'])) ?? [];
-
-  useEffect(() => {
-    form.setFieldValue('score', totalPoints);
-  }, [totalPoints]);
 
   useEffect(() => {
     if (!criteriaData.length) return;

--- a/client/src/modules/CrossCheck/hooks/useCriteriaState.ts
+++ b/client/src/modules/CrossCheck/hooks/useCriteriaState.ts
@@ -6,7 +6,6 @@ import { CommentState, CountState } from '../components/CrossCheckCriteriaForm';
 interface CriteriaSetState {
   setCountStar: (newCount: CountState[]) => void;
   setCriteriaData: (newCriteria: CrossCheckCriteriaData[]) => void;
-  setScore: (newPoint?: number) => void;
   setPenalty: (newPenalty: CountState[]) => void;
   setComment: (newComment: CommentState[]) => void;
 }
@@ -14,7 +13,6 @@ interface CriteriaSetState {
 interface CriteriaState {
   countStar: CountState[];
   criteriaData: CrossCheckCriteriaData[];
-  score?: number;
   penalty: CountState[];
   criteriaComment: CommentState[];
 }
@@ -23,11 +21,10 @@ export function useCriteriaState(): [CriteriaState, CriteriaSetState] {
   const [countStar, setCountStar] = useState<CountState[]>([]);
   const [penalty, setPenalty] = useState<CountState[]>([]);
   const [criteriaData, setCriteriaData] = useState([] as CrossCheckCriteriaData[]);
-  const [score, setScore] = useState<number | undefined>(undefined);
   const [criteriaComment, setComment] = useState<CommentState[]>([]);
 
   return [
-    { countStar, penalty, criteriaData, score, criteriaComment },
-    { setCountStar, setPenalty, setCriteriaData, setScore, setComment },
+    { countStar, penalty, criteriaData, criteriaComment },
+    { setCountStar, setPenalty, setCriteriaData, setComment },
   ];
 }

--- a/client/src/pages/course/student/cross-check-review.tsx
+++ b/client/src/pages/course/student/cross-check-review.tsx
@@ -56,8 +56,8 @@ function Page(props: CoursePageProps) {
   });
 
   const [
-    { countStar, penalty, criteriaData, score, criteriaComment },
-    { setCountStar, setPenalty, setCriteriaData, setScore, setComment },
+    { countStar, penalty, criteriaData, criteriaComment },
+    { setCountStar, setPenalty, setCriteriaData, setComment },
   ] = useCriteriaState();
 
   const courseService = useMemo(() => new CourseService(props.course.id), [props.course.id]);
@@ -76,7 +76,7 @@ function Page(props: CoursePageProps) {
 
     setCriteriaData(taskCriteriaData.criteria ?? []);
     resetCriterias();
-    form.resetFields(['comment']);
+    form.resetFields(['comment', 'score']);
 
     if (!result) {
       return setState({ loading: false, data: [] });
@@ -111,7 +111,7 @@ function Page(props: CoursePageProps) {
   };
 
   const loadInitialCriteria = (data: SolutionReviewType) => {
-    setScore(data.score);
+    form.setFieldValue('score', data.score);
     if (!data.criteria) return;
     setCriteriaData(data.criteria);
     const newCountState = data.criteria
@@ -148,7 +148,6 @@ function Page(props: CoursePageProps) {
     setCountStar([]);
     setComment([]);
     setPenalty([]);
-    setScore(undefined);
   };
 
   const submitReview = withLoading(async values => {
@@ -279,7 +278,6 @@ function Page(props: CoursePageProps) {
                 countStar={countStar}
                 setCountStar={setCountStar}
                 criteriaData={criteriaData}
-                totalPoints={score}
                 setPenalty={setPenalty}
                 penalty={penalty}
                 criteriaComment={criteriaComment}


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [x] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

_Describe the source of requirement, like related issue link._

#### 💡 Background and solution

Удалил `score` из хука `useCriteriaState` т.к. он не сохраняет актуальное количество очков при проверки работ через форму. И можно спутать `score` из хука  с `score` в отправляемой форме на сервер.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
