### PR TITLE
Allow course manager to see profiles of mentors from registry

### DIFF
--- a/nestjs/src/courses/mentors/mentors.controller.ts
+++ b/nestjs/src/courses/mentors/mentors.controller.ts
@@ -34,7 +34,7 @@ export class MentorsController {
   @ApiForbiddenResponse()
   @ApiNotFoundResponse()
   @RequiredRoles([CourseRole.Mentor])
-  public async getMentoroptions(
+  public async getMentorOptions(
     @Param('mentorId', ParseIntPipe) mentorId: number,
     @Param('courseId', ParseIntPipe) courseId: number,
     @Req() req: CurrentRequest,


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/2051

#### 💡 Background and solution

After this fix course managers will be able to see profiles of users that are applied as mentors for course manager's course but not applied yet.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
