### PR TITLE
Show mentors by discipline

### DIFF
--- a/nestjs/src/disciplines/disciplines.controller.test.ts
+++ b/nestjs/src/disciplines/disciplines.controller.test.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DisciplinesController } from './disciplines.controller';
+import { DisciplinesService } from './disciplines.service';
+import { CreateDisciplineDto, DisciplineDto, UpdateDisciplineDto } from './dto';
+
+const mockId = 1;
+
+const mockDiscipline = {
+  id: mockId,
+  name: 'NodeJs',
+  createdDate: '1684609801766',
+  updatedDate: '1684609810052',
+  deletedDate: '1684609892046',
+};
+
+const mockCreate = jest.fn(() => Promise.resolve(mockDiscipline));
+const mockGetAll = jest.fn(() => Promise.resolve([mockDiscipline, mockDiscipline]));
+const mockDelete = jest.fn(() => Promise.resolve());
+const mockUpdate = jest.fn(() => Promise.resolve(mockDiscipline));
+
+const mockDisciplinesServiceFactory = jest.fn(() => ({
+  create: mockCreate,
+  getAll: mockGetAll,
+  delete: mockDelete,
+  update: mockUpdate,
+}));
+
+describe('DisciplinesController', () => {
+  let controller: DisciplinesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DisciplinesController],
+      providers: [{ provide: DisciplinesService, useFactory: mockDisciplinesServiceFactory }],
+    }).compile();
+
+    controller = module.get<DisciplinesController>(DisciplinesController);
+  });
+
+  describe('create', () => {
+    it('should create a new discipline', async () => {
+      const mockCreateDisciplineDto = new CreateDisciplineDto();
+
+      const result = await controller.create(mockCreateDisciplineDto);
+
+      expect(result).toEqual(new DisciplineDto(mockDiscipline));
+      expect(mockCreate).toHaveBeenCalledWith(mockCreateDisciplineDto);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should get all disciplines', async () => {
+      const result = await controller.getAll();
+
+      expect(result).toEqual([new DisciplineDto(mockDiscipline), new DisciplineDto(mockDiscipline)]);
+      expect(mockGetAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a discipline', async () => {
+      await controller.delete(mockId);
+
+      expect(mockDelete).toHaveBeenCalledWith(mockId);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a discipline', async () => {
+      const mockUpdateDisciplineDto = new UpdateDisciplineDto();
+
+      const result = await controller.update(mockId, mockUpdateDisciplineDto);
+
+      expect(result).toEqual(new DisciplineDto(mockDiscipline));
+      expect(mockUpdate).toHaveBeenCalledWith(mockId, mockUpdateDisciplineDto);
+    });
+  });
+});

--- a/nestjs/src/disciplines/disciplines.module.ts
+++ b/nestjs/src/disciplines/disciplines.module.ts
@@ -8,5 +8,6 @@ import { DisciplinesService } from './disciplines.service';
   imports: [TypeOrmModule.forFeature([Discipline])],
   controllers: [DisciplinesController],
   providers: [DisciplinesService],
+  exports: [DisciplinesService],
 })
 export class DisciplinesModule {}

--- a/nestjs/src/disciplines/disciplines.service.test.ts
+++ b/nestjs/src/disciplines/disciplines.service.test.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FindOptionsWhere, In } from 'typeorm';
+import { DisciplinesService } from './disciplines.service';
+import { Discipline } from '@entities/discipline';
+import { CreateDisciplineDto, UpdateDisciplineDto } from './dto';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+const mockDiscipline = {
+  foo: 'bar',
+} as unknown as Discipline;
+
+const mockFindResponse = [mockDiscipline, mockDiscipline];
+const mockFindOneByResponse = mockDiscipline;
+const mockSaveResponse = { id: 1 };
+const mockSoftDeleteResponse = { a: 1 };
+
+const mockId = 1;
+
+const mockFind = jest.fn(() => Promise.resolve(mockFindResponse));
+const mockFindOneBy = jest.fn(() => Promise.resolve(mockFindOneByResponse));
+const mockFindOneByOrFail = jest.fn(() => Promise.resolve(mockFindOneByResponse));
+const mockSave = jest.fn(() => Promise.resolve(mockSaveResponse));
+const mockUpdate = jest.fn(() => Promise.resolve(mockSaveResponse));
+const mockSoftDelete = jest.fn(() => Promise.resolve(mockSoftDeleteResponse));
+
+const mockDisciplinesRepositoryFactory = jest.fn(() => ({
+  find: mockFind,
+  findOneBy: mockFindOneBy,
+  findOneByOrFail: mockFindOneByOrFail,
+  save: mockSave,
+  update: mockUpdate,
+  softDelete: mockSoftDelete,
+}));
+describe('DisciplinesService', () => {
+  let service: DisciplinesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DisciplinesService,
+        {
+          provide: getRepositoryToken(Discipline),
+          useFactory: mockDisciplinesRepositoryFactory,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DisciplinesService>(DisciplinesService);
+  });
+
+  describe('getAll', () => {
+    it('should return all disciplines', async () => {
+      const result = await service.getAll();
+
+      expect(mockFind).toHaveBeenCalled();
+      expect(result).toEqual(mockFindResponse);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return a discipline by id', async () => {
+      const result = await service.getById(mockId);
+
+      expect(result).toEqual(mockFindOneByResponse);
+      expect(mockFindOneBy).toHaveBeenCalledWith({ id: mockId });
+    });
+  });
+
+  describe('getByIds', () => {
+    it('should return disciplines by ids', async () => {
+      const mockIds = [1, 2];
+      const mockFilter = { bar: 'baz' } as FindOptionsWhere<Discipline>;
+
+      const result = await service.getByIds(mockIds, mockFilter);
+
+      expect(result).toEqual(mockFindResponse);
+      expect(mockFind).toHaveBeenCalledWith({
+        where: { id: In(mockIds), ...mockFilter },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new discipline', async () => {
+      const mockData = {} as CreateDisciplineDto;
+
+      const result = await service.create(mockData);
+
+      expect(result).toEqual(mockDiscipline);
+      expect(mockSave).toHaveBeenCalledWith(mockData);
+      expect(mockFindOneByOrFail).toHaveBeenCalledWith({ id: mockSaveResponse.id });
+    });
+  });
+
+  describe('update', () => {
+    it('should update a discipline', async () => {
+      const mockData = {} as UpdateDisciplineDto;
+
+      const result = await service.update(mockId, mockData);
+
+      expect(result).toEqual(mockDiscipline);
+      expect(mockUpdate).toHaveBeenCalledWith(mockId, mockData);
+      expect(mockFindOneByOrFail).toHaveBeenCalledWith({ id: mockId });
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a discipline', async () => {
+      await service.delete(mockId);
+
+      expect(mockSoftDelete).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/disciplines/disciplines.service.ts
+++ b/nestjs/src/disciplines/disciplines.service.ts
@@ -1,7 +1,7 @@
 import { Discipline } from '@entities/discipline';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, In, Repository } from 'typeorm';
 import { CreateDisciplineDto, UpdateDisciplineDto } from './dto';
 
 @Injectable()
@@ -17,6 +17,15 @@ export class DisciplinesService {
 
   public async getById(id: number) {
     return this.repository.findOneBy({ id });
+  }
+
+  public async getByIds(ids: number[], filter?: FindOptionsWhere<Discipline>) {
+    return this.repository.find({
+      where: {
+        id: In(ids),
+        ...filter,
+      },
+    });
   }
 
   public async create(data: CreateDisciplineDto) {

--- a/nestjs/src/registry/registry.controller.ts
+++ b/nestjs/src/registry/registry.controller.ts
@@ -1,16 +1,24 @@
 import { Body, Controller, Get, Param, Put, Req, UseGuards } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { uniq } from 'lodash';
 import { CourseRole, CurrentRequest, DefaultGuard, RequiredRoles, Role, RoleGuard } from 'src/auth';
 import { UserNotificationsService } from 'src/users-notifications/users.notifications.service';
 import { ApproveMentorDto } from './dto/approve-mentor.dto';
 import { MentorRegistryDto } from './dto/mentor-registry.dto';
 import { RegistryService } from './registry.service';
+import { CoursesService } from 'src/courses/courses.service';
+import { DisciplinesService } from 'src/disciplines/disciplines.service';
 
 @Controller('registry')
 @ApiTags('registry')
 @UseGuards(DefaultGuard, RoleGuard)
 export class RegistryController {
-  constructor(private mentorsService: RegistryService, private notificationService: UserNotificationsService) {}
+  constructor(
+    private mentorsService: RegistryService,
+    private notificationService: UserNotificationsService,
+    private coursesService: CoursesService,
+    private disciplinesService: DisciplinesService,
+  ) {}
 
   @Put('mentor/:githubId')
   @ApiOperation({ operationId: 'approveMentor' })
@@ -43,7 +51,11 @@ export class RegistryController {
       const coursesIds = Object.entries(req.user.courses)
         .filter(([_, value]) => value.roles.includes(CourseRole.Manager) || value.roles.includes(CourseRole.Supervisor))
         .map(([key]) => Number(key));
-      const data = await this.mentorsService.findMentorRegistriesByCourseIds(coursesIds);
+      const courses = await this.coursesService.getByIds(coursesIds);
+      const disciplineIds = uniq(courses.map(course => course.disciplineId).filter(Boolean)) as number[];
+      const disciplines = await this.disciplinesService.getByIds(disciplineIds);
+      const disciplineNames = disciplines.map(discipline => discipline.name);
+      const data = await this.mentorsService.findMentorRegistriesByCourseIdsAndDisciplines(coursesIds, disciplineNames);
       return data.map(el => new MentorRegistryDto(el));
     }
   }

--- a/nestjs/src/registry/registry.module.ts
+++ b/nestjs/src/registry/registry.module.ts
@@ -6,9 +6,16 @@ import { UsersModule } from 'src/users';
 import { UsersNotificationsModule } from 'src/users-notifications/users-notifications.module';
 import { RegistryController } from './registry.controller';
 import { RegistryService } from './registry.service';
+import { DisciplinesModule } from 'src/disciplines';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MentorRegistry]), UsersModule, UsersNotificationsModule, CoursesModule],
+  imports: [
+    TypeOrmModule.forFeature([MentorRegistry]),
+    UsersModule,
+    UsersNotificationsModule,
+    CoursesModule,
+    DisciplinesModule,
+  ],
   controllers: [RegistryController],
   providers: [RegistryService],
 })

--- a/nestjs/src/registry/registry.service.ts
+++ b/nestjs/src/registry/registry.service.ts
@@ -52,9 +52,10 @@ export class RegistryService {
     return mentorRegistries;
   }
 
-  public async findMentorRegistriesByCourseIds(coursesIds: number[]) {
+  public async findMentorRegistriesByCourseIdsAndDisciplines(coursesIds: number[], disciplines: string[]) {
     const mentorRegistries = await this.getPreparedMentorRegistriesQuery()
       .where(`string_to_array(mentorRegistry.preferedCourses, ',') && :ids`, { ids: coursesIds })
+      .orWhere(`string_to_array(mentorRegistry.technicalMentoring, ',') && :disciplines`, { disciplines })
       .andWhere('mentorRegistry.canceled = false')
       .getMany();
     return mentorRegistries;


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [x] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/2095

#### 💡 Background and solution

First part of mentors visibility: course managers and supervisors are able to see mentors that submitted to mentorship by discipline without prefered course.
For example:
1. **John Doe** is supervisor/manager of Node.js course
2. **Flavie Toy** has submitted as mentor for Node.js **discipline** without selection of preferred **course**
3. **Anjali Dooley**  has submitted as mentor for Node.js **course** without selection of **discipline**

Before:  
**John Doe** sees **Anjali Dooley** in mentors list and **Anjali Dooley's** profile is visible, **Flavie Toy** is not in mentors list and profile is not visible

After:  
**John Doe** sees **Flavie Toy** and **Anjali Dooley** in mentors list and their profiles are visible

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
