### PR TITLE
feat: add validation error tooltip to auto test submit button

### DIFF
--- a/client/src/components/TooltipedButton.tsx
+++ b/client/src/components/TooltipedButton.tsx
@@ -1,0 +1,21 @@
+import { Button, Tooltip } from "antd";
+
+export type TooltipedButtonProps = {
+  tooltipTitle: string;
+  buttonText: string;
+  open: boolean;
+  loading: boolean;
+  disabled: boolean;
+}
+
+export function TooltipedButton(props: TooltipedButtonProps) {
+  const { tooltipTitle, open, loading, disabled, buttonText } = props;
+
+  return (
+    <Tooltip title={tooltipTitle} open={open}>
+      <Button loading={loading} type="primary" htmlType="submit" disabled={disabled}>
+        {buttonText}
+      </Button>
+    </Tooltip>
+  )
+}

--- a/client/src/components/TooltipedButton.tsx
+++ b/client/src/components/TooltipedButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from "antd";
+import { Button, Tooltip } from 'antd';
 
 export type TooltipedButtonProps = {
   tooltipTitle: string;
@@ -6,7 +6,7 @@ export type TooltipedButtonProps = {
   open: boolean;
   loading: boolean;
   disabled: boolean;
-}
+};
 
 export function TooltipedButton(props: TooltipedButtonProps) {
   const { tooltipTitle, open, loading, disabled, buttonText } = props;
@@ -17,5 +17,5 @@ export function TooltipedButton(props: TooltipedButtonProps) {
         {buttonText}
       </Button>
     </Tooltip>
-  )
+  );
 }

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -32,11 +32,10 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
     try {
       await form.validateFields();
       setValidationError(false);
-    }
-    catch {
+    } catch {
       setValidationError(true);
     }
-  }
+  };
 
   const getExercise = () => {
     switch (courseTask?.type) {
@@ -57,7 +56,15 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
   return (
     <Row style={{ background: 'white', padding: '0 24px 24px' }} gutter={[0, 24]} justify="center">
       <Col {...responsiveColumns(courseTask.type)}>
-        <Form form={form} layout="vertical" requiredMark={false} onFinish={submit} onFinishFailed={() => setValidationError(true)} onChange={change} onValuesChange={onValuesChange}>
+        <Form
+          form={form}
+          layout="vertical"
+          requiredMark={false}
+          onFinish={submit}
+          onFinishFailed={() => setValidationError(true)}
+          onChange={change}
+          onValuesChange={onValuesChange}
+        >
           {getExercise()}
           <Row justify="center">
             <Button loading={loading} type="primary" htmlType="submit" disabled={loading || validationError}>

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -3,7 +3,7 @@ import { CourseTaskDetailedDtoTypeEnum } from 'api';
 import { Button, Col, ColProps, Form, Row } from 'antd';
 import { useCourseTaskSubmit } from 'modules/AutoTest/hooks';
 import { CourseTaskVerifications } from 'modules/AutoTest/types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type ExerciseProps = {
   githubId: string;
@@ -28,14 +28,18 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
   const { form, loading, submit, change } = useCourseTaskSubmit(courseId, courseTask, finishTask);
   const [validationError, setValidationError] = useState(false);
 
-  const onValuesChange = async () => {
-    try {
-      await form.validateFields();
-      setValidationError(false);
-    } catch {
-      setValidationError(true);
-    }
-  };
+  const values = Form.useWatch([], form);
+
+  useEffect(() => {
+    form.validateFields({ validateOnly: true }).then(
+      () => {
+        setValidationError(false);
+      },
+      () => {
+        setValidationError(true);
+      },
+    );
+  }, [values]);
 
   const getExercise = () => {
     switch (courseTask?.type) {

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -57,7 +57,7 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
   return (
     <Row style={{ background: 'white', padding: '0 24px 24px' }} gutter={[0, 24]} justify="center">
       <Col {...responsiveColumns(courseTask.type)}>
-        <Form form={form} layout="vertical" requiredMark={false} onFinish={submit} onChange={change} onValuesChange={onValuesChange}>
+        <Form form={form} layout="vertical" requiredMark={false} onFinish={submit} onFinishFailed={() => setValidationError(true)} onChange={change} onValuesChange={onValuesChange}>
           {getExercise()}
           <Row justify="center">
             <Button loading={loading} type="primary" htmlType="submit" disabled={loading || validationError}>

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -1,6 +1,6 @@
 import { Coding, JupyterNotebook, SelfEducation } from 'modules/AutoTest/components';
 import { CourseTaskDetailedDtoTypeEnum } from 'api';
-import { Button, Col, ColProps, Form, Row } from 'antd';
+import { Button, Col, ColProps, Form, Row, Tooltip } from 'antd';
 import { useCourseTaskSubmit } from 'modules/AutoTest/hooks';
 import { CourseTaskVerifications } from 'modules/AutoTest/types';
 import { useEffect, useState } from 'react';
@@ -31,6 +31,10 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
   const values = Form.useWatch([], form);
 
   useEffect(() => {
+    if(!values || !Object.values(values).every(Boolean)){
+      return;
+    }
+
     form.validateFields({ validateOnly: true }).then(
       () => {
         setValidationError(false);
@@ -67,13 +71,16 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
           onFinish={submit}
           onFinishFailed={() => setValidationError(true)}
           onChange={change}
-          onValuesChange={onValuesChange}
         >
           {getExercise()}
           <Row justify="center">
-            <Button loading={loading} type="primary" htmlType="submit" disabled={loading || validationError}>
-              Submit
-            </Button>
+            <Tooltip title="Form has validation errors! Check that all required fields are filled!"
+              open={validationError}
+            >
+              <Button loading={loading} type="primary" htmlType="submit" disabled={loading}>
+                Submit
+              </Button>
+            </Tooltip>
           </Row>
         </Form>
       </Col>

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -1,6 +1,6 @@
 import { Coding, JupyterNotebook, SelfEducation } from 'modules/AutoTest/components';
 import { CourseTaskDetailedDtoTypeEnum } from 'api';
-import { Button, Col, ColProps, Form, Row, Tooltip } from 'antd';
+import { Col, ColProps, Form, Row } from 'antd';
 import { useCourseTaskSubmit } from 'modules/AutoTest/hooks';
 import { CourseTaskVerifications } from 'modules/AutoTest/types';
 import { useEffect, useState } from 'react';
@@ -32,7 +32,7 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
   const values = Form.useWatch([], form);
 
   useEffect(() => {
-    if(!values || !Object.values(values).every(Boolean)){
+    if (!values || !Object.values(values).every(Boolean)) {
       return;
     }
 
@@ -75,11 +75,13 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
         >
           {getExercise()}
           <Row justify="center">
-            <TooltipedButton tooltipTitle="Form has validation errors! Check that all required fields are filled!"
+            <TooltipedButton
+              tooltipTitle="Form has validation errors! Check that all required fields are filled!"
               open={validationError}
               buttonText="Submit"
               loading={loading}
-              disabled={loading}></TooltipedButton>
+              disabled={loading}
+            ></TooltipedButton>
           </Row>
         </Form>
       </Col>

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -3,6 +3,7 @@ import { CourseTaskDetailedDtoTypeEnum } from 'api';
 import { Button, Col, ColProps, Form, Row } from 'antd';
 import { useCourseTaskSubmit } from 'modules/AutoTest/hooks';
 import { CourseTaskVerifications } from 'modules/AutoTest/types';
+import { useState } from 'react';
 
 type ExerciseProps = {
   githubId: string;
@@ -25,6 +26,17 @@ function responsiveColumns(type: CourseTaskDetailedDtoTypeEnum): ColProps | unde
 
 function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps) {
   const { form, loading, submit, change } = useCourseTaskSubmit(courseId, courseTask, finishTask);
+  const [validationError, setValidationError] = useState(false);
+
+  const onValuesChange = async () => {
+    try {
+      await form.validateFields();
+      setValidationError(false);
+    }
+    catch {
+      setValidationError(true);
+    }
+  }
 
   const getExercise = () => {
     switch (courseTask?.type) {
@@ -45,10 +57,10 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
   return (
     <Row style={{ background: 'white', padding: '0 24px 24px' }} gutter={[0, 24]} justify="center">
       <Col {...responsiveColumns(courseTask.type)}>
-        <Form form={form} layout="vertical" requiredMark={false} onFinish={submit} onChange={change}>
+        <Form form={form} layout="vertical" requiredMark={false} onFinish={submit} onChange={change} onValuesChange={onValuesChange}>
           {getExercise()}
           <Row justify="center">
-            <Button loading={loading} type="primary" htmlType="submit" disabled={loading}>
+            <Button loading={loading} type="primary" htmlType="submit" disabled={loading || validationError}>
               Submit
             </Button>
           </Row>

--- a/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
+++ b/client/src/modules/AutoTest/components/Exercise/Exercise.tsx
@@ -4,6 +4,7 @@ import { Button, Col, ColProps, Form, Row, Tooltip } from 'antd';
 import { useCourseTaskSubmit } from 'modules/AutoTest/hooks';
 import { CourseTaskVerifications } from 'modules/AutoTest/types';
 import { useEffect, useState } from 'react';
+import { TooltipedButton } from 'components/TooltipedButton';
 
 type ExerciseProps = {
   githubId: string;
@@ -74,13 +75,11 @@ function Exercise({ githubId, courseId, courseTask, finishTask }: ExerciseProps)
         >
           {getExercise()}
           <Row justify="center">
-            <Tooltip title="Form has validation errors! Check that all required fields are filled!"
+            <TooltipedButton tooltipTitle="Form has validation errors! Check that all required fields are filled!"
               open={validationError}
-            >
-              <Button loading={loading} type="primary" htmlType="submit" disabled={loading}>
-                Submit
-              </Button>
-            </Tooltip>
+              buttonText="Submit"
+              loading={loading}
+              disabled={loading}></TooltipedButton>
           </Row>
         </Form>
       </Col>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

_Describe the source of requirement, like related issue link._

#### 💡 Background and solution

Add validation error tooltip to auto test submit button
![chrome_VGNyHSJDjH](https://github.com/rolling-scopes/rsschool-app/assets/17920285/03e5928a-9eda-4ba9-a272-c91d75190fcc)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
