### PR TITLE
fix: correct score filters (github and name)

### DIFF
--- a/client/src/modules/Score/components/ScoreTable/index.tsx
+++ b/client/src/modules/Score/components/ScoreTable/index.tsx
@@ -41,7 +41,7 @@ export function ScoreTable(props: Props) {
   const router = useRouter();
   const { width } = useWindowDimensions();
   const { activeOnly } = props;
-  const { ['mentor.githubId']: mentor, cityName } = router.query;
+  const { ['mentor.githubId']: mentor, cityName, githubId, name } = router.query;
 
   const [isVisibleSetting, setIsVisibleSettings] = useState(false);
   const [columns, setColumns] = useState<ColumnType<ScoreStudentDto>[]>([]);
@@ -85,6 +85,13 @@ export function ScoreTable(props: Props) {
       }
       if (!isUndefined(mentor)) {
         filters = { ...filters, ['mentor.githubId']: mentor } as ScoreTableFilters;
+      }
+
+      if (!isUndefined(githubId)) {
+        filters = { ...filters, githubId } as ScoreTableFilters;
+      }
+      if (!isUndefined(name)) {
+        filters = { ...filters, name } as ScoreTableFilters;
       }
 
       const [courseScore, courseTasks] = await Promise.all([

--- a/client/src/modules/Score/hooks/useScorePaging.tsx
+++ b/client/src/modules/Score/hooks/useScorePaging.tsx
@@ -19,8 +19,8 @@ export function useScorePaging(router: NextRouter, courseService: CourseService,
 
   const getCourseScore = useCallback(
     async (pagination: IPaginationInfo, filters: ScoreTableFilters, scoreOrder: ScoreOrder) => {
-      const { cityName, ['mentor.githubId']: mentor } = filters;
-      const newQueryParams = getQueryParams({ cityName, ['mentor.githubId']: mentor }, currentQuery);
+      const { cityName, ['mentor.githubId']: mentor, githubId, name } = filters;
+      const newQueryParams = getQueryParams({ cityName, ['mentor.githubId']: mentor, githubId, name }, currentQuery);
       setQueryParams(newQueryParams);
       const field = scoreOrder.column?.sorter || 'rank';
       const courseScore = await courseService.getCourseScore(


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

Related issue #2241

#### 💡 Background and solution
Using as an example fields cityName and mentor,
corrected filters in score page, with putting in newQuery githubId, name and using it to set filters in loadInitialData.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
