### PR TITLE
fix(tasks): add row gap for Used in Courses

### DIFF
--- a/client/src/pages/admin/tasks.tsx
+++ b/client/src/pages/admin/tasks.tsx
@@ -13,6 +13,7 @@ import {
   Divider,
   Card,
   Tag,
+  Space,
 } from 'antd';
 import withSession, { Session } from 'components/withSession';
 import {
@@ -415,13 +416,13 @@ function TaskModal({
         <Col span={24}>
           <Form.Item name="usedInCourses" label="Used in Courses">
             <Card>
-              <div style={{ display: 'flex', flexWrap: 'wrap', rowGap: 8 }}>
+              <Space size={[0, 4]} wrap style={{ display: 'flex' }}>
                 {modalData?.courses?.map(({ name, isActive }) => (
                   <Tag key={name} color={isActive ? 'blue' : ''}>
                     {name}
                   </Tag>
                 ))}
-              </div>
+              </Space>
             </Card>
           </Form.Item>
         </Col>

--- a/client/src/pages/admin/tasks.tsx
+++ b/client/src/pages/admin/tasks.tsx
@@ -416,7 +416,7 @@ function TaskModal({
         <Col span={24}>
           <Form.Item name="usedInCourses" label="Used in Courses">
             <Card>
-              <Space size={[0, 4]} wrap style={{ display: 'flex' }}>
+              <Space size={[0, 8]} wrap>
                 {modalData?.courses?.map(({ name, isActive }) => (
                   <Tag key={name} color={isActive ? 'blue' : ''}>
                     {name}

--- a/client/src/pages/admin/tasks.tsx
+++ b/client/src/pages/admin/tasks.tsx
@@ -415,11 +415,13 @@ function TaskModal({
         <Col span={24}>
           <Form.Item name="usedInCourses" label="Used in Courses">
             <Card>
-              {modalData?.courses?.map(({ name, isActive }) => (
-                <Tag key={name} color={isActive ? 'blue' : ''}>
-                  {name}
-                </Tag>
-              ))}
+              <div style={{ display: 'flex', flexWrap: 'wrap', rowGap: 8 }}>
+                {modalData?.courses?.map(({ name, isActive }) => (
+                  <Tag key={name} color={isActive ? 'blue' : ''}>
+                    {name}
+                  </Tag>
+                ))}
+              </div>
             </Card>
           </Form.Item>
         </Col>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [x] Other

#### 🔗 Related issue link

_Describe the source of requirement, like related issue link._

#### 💡 Background and solution

Add row gap for Used in Courses labels in task edit form
Before
![chrome_ictJdeUHQM](https://github.com/rolling-scopes/rsschool-app/assets/17920285/a862cc5b-c7de-466e-b06f-5857b1e9faca)

After
![chrome_UYBpnFNyJT](https://github.com/rolling-scopes/rsschool-app/assets/17920285/7e0d6507-77af-455b-ab4b-59d0518b64f1)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
