### PR TITLE
feat: add criteria settings set based on task type

### DIFF
--- a/client/src/components/Forms/ModalForm.tsx
+++ b/client/src/components/Forms/ModalForm.tsx
@@ -1,4 +1,4 @@
-import { Form, Modal, Spin } from 'antd';
+import { ButtonProps, Form, Modal, Spin } from 'antd';
 import { FormInstance } from 'antd/es/form/Form';
 import * as React from 'react';
 
@@ -13,6 +13,7 @@ type Props = {
   loading?: boolean;
   okText?: string;
   form?: FormInstance;
+  okButtonProps?: ButtonProps;
 };
 
 export function ModalForm(props: Props) {
@@ -38,6 +39,7 @@ export function ModalForm(props: Props) {
         }
         props.submit(values);
       }}
+      okButtonProps={{ disabled: props.loading, ...props.okButtonProps }}
       onCancel={e => {
         props.cancel(e);
         form.resetFields();

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useModalForm } from './useModal/useModalForm';
+export type { ModalFormMode } from './useModal/useModalForm';

--- a/client/src/hooks/useModal/useModalForm.tsx
+++ b/client/src/hooks/useModal/useModalForm.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
+export type ModalFormMode = 'create' | 'edit';
+
 export const useModalForm = <T,>() => {
-  const [mode, setMode] = useState<'create' | 'edit'>('create');
+  const [mode, setMode] = useState<ModalFormMode>('create');
   const [open, setOpen] = useState(false);
   const [formData, setFormData] = useState<T>();
 

--- a/client/src/modules/Tasks/components/TaskModal/TaskModal.test.tsx
+++ b/client/src/modules/Tasks/components/TaskModal/TaskModal.test.tsx
@@ -1,17 +1,20 @@
 import { generateTasksData } from 'modules/Tasks/utils/test-utils';
 import { ModalProps, TaskModal } from './TaskModal';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ModalData } from 'modules/Tasks/types';
-import { ERROR_MESSAGES, LABELS, PLACEHOLDERS, TASK_SETTINGS_HEADERS } from 'modules/Tasks/constants';
+import { ModalAction, ModalData } from 'modules/Tasks/types';
+import { ERROR_MESSAGES, LABELS, MODAL_TITLES, PLACEHOLDERS, TASK_SETTINGS_HEADERS } from 'modules/Tasks/constants';
 
 const mockData = generateData();
 
 describe('TaskModal', () => {
-  test('should render modal', () => {
+  test('should render modal with proper title', () => {
     render(<TaskModal {...mockData} />);
 
     const modal = screen.getByRole('dialog');
     expect(modal).toBeInTheDocument();
+
+    const title = screen.getByText(MODAL_TITLES[ModalAction.Create]);
+    expect(title).toBeInTheDocument();
   });
 
   test('should render labels', () => {
@@ -147,6 +150,7 @@ function generateData(isEmpty = false): ModalProps {
     modalData,
     modalLoading: false,
     disciplines: [],
+    modalAction: ModalAction.Create,
     setDataCriteria: jest.fn(),
     handleModalSubmit: jest.fn(),
     setModalData: jest.fn(),

--- a/client/src/modules/Tasks/components/TaskModal/TaskModal.test.tsx
+++ b/client/src/modules/Tasks/components/TaskModal/TaskModal.test.tsx
@@ -1,8 +1,8 @@
-import { generateTasksData } from 'modules/Tasks/utils/test-utils';
-import { ModalProps, TaskModal } from './TaskModal';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ModalAction, ModalData } from 'modules/Tasks/types';
+import { generateTasksData } from 'modules/Tasks/utils/test-utils';
+import { FormValues } from 'modules/Tasks/types';
 import { ERROR_MESSAGES, LABELS, MODAL_TITLES, PLACEHOLDERS, TASK_SETTINGS_HEADERS } from 'modules/Tasks/constants';
+import { ModalProps, TaskModal } from './TaskModal';
 
 const mockData = generateData();
 
@@ -13,7 +13,7 @@ describe('TaskModal', () => {
     const modal = screen.getByRole('dialog');
     expect(modal).toBeInTheDocument();
 
-    const title = screen.getByText(MODAL_TITLES[ModalAction.Create]);
+    const title = screen.getByText(MODAL_TITLES.edit);
     expect(title).toBeInTheDocument();
   });
 
@@ -130,29 +130,30 @@ describe('TaskModal', () => {
 
 function generateData(isEmpty = false): ModalProps {
   const tasks = generateTasksData();
-  const modalData: ModalData = {
+  const formData: FormValues = {
     ...tasks[0],
     attributes: undefined,
+    discipline: tasks[0].discipline.id,
   };
 
   if (isEmpty) {
-    modalData.name = undefined;
-    modalData.type = undefined;
-    modalData.discipline = undefined;
-    modalData.descriptionUrl = undefined;
-    modalData.tags = undefined;
-    modalData.skills = undefined;
+    formData.name = undefined;
+    formData.type = undefined;
+    formData.discipline = undefined;
+    formData.descriptionUrl = undefined;
+    formData.tags = undefined;
+    formData.skills = undefined;
   }
 
   return {
     tasks,
     dataCriteria: [],
-    modalData,
+    formData,
     modalLoading: false,
     disciplines: [],
-    modalAction: ModalAction.Create,
+    mode: isEmpty ? 'create' : 'edit',
     setDataCriteria: jest.fn(),
     handleModalSubmit: jest.fn(),
-    setModalData: jest.fn(),
+    toggleModal: jest.fn(),
   };
 }

--- a/client/src/modules/Tasks/components/TaskModal/TaskModal.test.tsx
+++ b/client/src/modules/Tasks/components/TaskModal/TaskModal.test.tsx
@@ -150,6 +150,5 @@ function generateData(isEmpty = false): ModalProps {
     setDataCriteria: jest.fn(),
     handleModalSubmit: jest.fn(),
     setModalData: jest.fn(),
-    setModalValues: jest.fn(),
   };
 }

--- a/client/src/modules/Tasks/components/TaskModal/TaskModal.tsx
+++ b/client/src/modules/Tasks/components/TaskModal/TaskModal.tsx
@@ -6,12 +6,13 @@ import { ModalForm } from 'components/Forms';
 import { SKILLS } from 'data/skills';
 import { TASK_TYPES } from 'data/taskTypes';
 import { TaskSettings } from 'modules/Tasks/components';
-import { ERROR_MESSAGES, LABELS, PLACEHOLDERS } from 'modules/Tasks/constants';
-import { FormValues, ModalData } from 'modules/Tasks/types';
+import { ERROR_MESSAGES, LABELS, MODAL_TITLES, PLACEHOLDERS } from 'modules/Tasks/constants';
+import { FormValues, ModalAction, ModalData } from 'modules/Tasks/types';
 import { urlPattern } from 'services/validators';
 import { stringSorter } from 'components/Table';
 
 const { Text } = Typography;
+const { TextArea } = Input;
 
 export type ModalProps = {
   tasks: TaskDto[];
@@ -19,6 +20,7 @@ export type ModalProps = {
   dataCriteria: CriteriaDto[];
   modalLoading: boolean;
   disciplines: DisciplineDto[];
+  modalAction: ModalAction;
   setDataCriteria: (criteria: CriteriaDto[]) => void;
   handleModalSubmit: (values: any) => Promise<void>;
   setModalData: (data: ModalData) => void;
@@ -30,6 +32,7 @@ export function TaskModal({
   modalData,
   modalLoading,
   disciplines,
+  modalAction,
   setDataCriteria,
   handleModalSubmit,
   setModalData,
@@ -68,7 +71,7 @@ export function TaskModal({
     <ModalForm
       data={modalData}
       form={form}
-      title="Task"
+      title={MODAL_TITLES[modalAction]}
       submit={handleModalSubmit}
       cancel={() => {
         setModalData(null);
@@ -77,41 +80,9 @@ export function TaskModal({
       getInitialValues={getInitialValues}
       loading={modalLoading}
     >
-      <Row gutter={24}>
-        <Col span={12}>
-          <Form.Item name="name" label={LABELS.name} rules={[{ required: true, message: ERROR_MESSAGES.name }]}>
-            <Input placeholder={PLACEHOLDERS.name} />
-          </Form.Item>
-        </Col>
-        <Col span={12}>
-          <Form.Item name="type" label={LABELS.taskType} rules={[{ required: true, message: ERROR_MESSAGES.taskType }]}>
-            <Select placeholder={PLACEHOLDERS.taskType} options={taskTypes} onChange={handleTypeChange} />
-          </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={24}>
-        <Col span={12}>
-          <Form.Item
-            name="discipline"
-            label={LABELS.discipline}
-            rules={[{ required: true, message: ERROR_MESSAGES.discipline }]}
-          >
-            <Select
-              placeholder={PLACEHOLDERS.discipline}
-              options={disciplines.map(({ id, name }) => ({ value: id, label: name }))}
-            />
-          </Form.Item>
-        </Col>
-        <Col span={12}>
-          <Form.Item name="tags" label={LABELS.tags}>
-            <Select
-              mode="tags"
-              placeholder={PLACEHOLDERS.tags}
-              options={allTags.map(tag => ({ value: tag, label: tag }))}
-            />
-          </Form.Item>
-        </Col>
-      </Row>
+      <Form.Item name="name" label={LABELS.name} rules={[{ required: true, message: ERROR_MESSAGES.name }]}>
+        <Input placeholder={PLACEHOLDERS.name} />
+      </Form.Item>
       <Form.Item
         name="descriptionUrl"
         label={LABELS.descriptionUrl}
@@ -128,11 +99,36 @@ export function TaskModal({
       >
         <Input placeholder={PLACEHOLDERS.descriptionUrl} />
       </Form.Item>
-      <Form.Item name="description" label={LABELS.summary}>
-        <Input placeholder={PLACEHOLDERS.summary} />
-      </Form.Item>
       <Row gutter={24}>
-        <Col span={24}>
+        <Col span={12}>
+          <Form.Item name="type" label={LABELS.taskType} rules={[{ required: true, message: ERROR_MESSAGES.taskType }]}>
+            <Select placeholder={PLACEHOLDERS.taskType} options={taskTypes} onChange={handleTypeChange} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            name="discipline"
+            label={LABELS.discipline}
+            rules={[{ required: true, message: ERROR_MESSAGES.discipline }]}
+          >
+            <Select
+              placeholder={PLACEHOLDERS.discipline}
+              options={disciplines.map(({ id, name }) => ({ value: id, label: name }))}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={24}>
+        <Col span={12}>
+          <Form.Item name="tags" label={LABELS.tags}>
+            <Select
+              mode="tags"
+              placeholder={PLACEHOLDERS.tags}
+              options={allTags.map(tag => ({ value: tag, label: tag }))}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
           <Form.Item name="skills" label={LABELS.skills}>
             <Select
               mode="tags"
@@ -142,6 +138,9 @@ export function TaskModal({
           </Form.Item>
         </Col>
       </Row>
+      <Form.Item name="description" label={LABELS.summary}>
+        <TextArea placeholder={PLACEHOLDERS.summary} maxLength={100} showCount />
+      </Form.Item>
       <Row gutter={24}>
         <Col span={24}>
           <Space direction="vertical" size={8} style={{ width: '100%', marginBottom: 24 }}>

--- a/client/src/modules/Tasks/components/TaskModal/TaskModal.tsx
+++ b/client/src/modules/Tasks/components/TaskModal/TaskModal.tsx
@@ -14,6 +14,8 @@ import { stringSorter } from 'components/Table';
 const { Text } = Typography;
 const { TextArea } = Input;
 
+const taskTypes = TASK_TYPES.sort(stringSorter('name')).map(({ id, name }) => ({ value: id, label: name }));
+
 export type ModalProps = {
   tasks: TaskDto[];
   modalData: ModalData;
@@ -22,7 +24,7 @@ export type ModalProps = {
   disciplines: DisciplineDto[];
   modalAction: ModalAction;
   setDataCriteria: (criteria: CriteriaDto[]) => void;
-  handleModalSubmit: (values: any) => Promise<void>;
+  handleModalSubmit: (values: FormValues) => Promise<void>;
   setModalData: (data: ModalData) => void;
 };
 
@@ -50,10 +52,6 @@ export function TaskModal({
           .sort(),
       ),
     [tasks],
-  );
-  const taskTypes = useMemo(
-    () => TASK_TYPES.sort(stringSorter('name')).map(({ id, name }) => ({ value: id, label: name })),
-    [TASK_TYPES],
   );
 
   const handleTypeChange = () => {

--- a/client/src/modules/Tasks/components/TaskSettings/TaskSettings.test.tsx
+++ b/client/src/modules/Tasks/components/TaskSettings/TaskSettings.test.tsx
@@ -1,13 +1,16 @@
 import { render, screen } from '@testing-library/react';
-import { TaskSettings } from './TaskSettings';
 import { Form } from 'antd';
-import { TASK_SETTINGS_HEADERS } from 'modules/Tasks/constants';
 import { CriteriaDto } from 'api';
+import { TASK_SETTINGS_HEADERS } from 'modules/Tasks/constants';
+import { Settings } from 'modules/Tasks/types';
+import { TaskSettings } from './TaskSettings';
+
+const settings: Settings = { isJsonRequired: true, isGithubRequired: true, isCrossCheckRequired: true };
 
 const renderTaskSettings = (dataCriteria: CriteriaDto[] = [], setDataCriteria = jest.fn()) => {
   render(
     <Form>
-      <TaskSettings dataCriteria={dataCriteria} setDataCriteria={setDataCriteria} />
+      <TaskSettings dataCriteria={dataCriteria} setDataCriteria={setDataCriteria} requiredSettings={settings} />
     </Form>,
   );
 };

--- a/client/src/modules/Tasks/components/TaskSettings/TaskSettings.test.tsx
+++ b/client/src/modules/Tasks/components/TaskSettings/TaskSettings.test.tsx
@@ -2,15 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { Form } from 'antd';
 import { CriteriaDto } from 'api';
 import { TASK_SETTINGS_HEADERS } from 'modules/Tasks/constants';
-import { Settings } from 'modules/Tasks/types';
 import { TaskSettings } from './TaskSettings';
-
-const settings: Settings = { isJsonRequired: true, isGithubRequired: true, isCrossCheckRequired: true };
 
 const renderTaskSettings = (dataCriteria: CriteriaDto[] = [], setDataCriteria = jest.fn()) => {
   render(
     <Form>
-      <TaskSettings dataCriteria={dataCriteria} setDataCriteria={setDataCriteria} requiredSettings={settings} />
+      <TaskSettings dataCriteria={dataCriteria} setDataCriteria={setDataCriteria} taskType={undefined} />
     </Form>,
   );
 };

--- a/client/src/modules/Tasks/components/TaskSettings/TaskSettings.tsx
+++ b/client/src/modules/Tasks/components/TaskSettings/TaskSettings.tsx
@@ -1,4 +1,4 @@
-import { Collapse, CollapseProps } from 'antd';
+import { Collapse, CollapseProps, Space, Typography } from 'antd';
 import { CollapsibleType } from 'antd/es/collapse/CollapsePanel';
 import { CriteriaDto, TaskDtoTypeEnum } from 'api';
 
@@ -12,6 +12,8 @@ type Props = {
   setDataCriteria: (criteria: CriteriaDto[]) => void;
   taskType: TaskDtoTypeEnum | undefined;
 };
+
+const { Text } = Typography;
 
 export function TaskSettings({ dataCriteria, taskType, setDataCriteria }: Props) {
   const [activeKey, setActiveKey] = useState<CollapseProps['activeKey']>([]);
@@ -46,7 +48,10 @@ export function TaskSettings({ dataCriteria, taskType, setDataCriteria }: Props)
   }, [taskType]);
 
   return (
-    <Collapse items={collapseItems} defaultActiveKey={[]} activeKey={activeKey} onChange={handleChange} accordion />
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <Text strong>Settings for some types of tasks</Text>
+      <Collapse items={collapseItems} defaultActiveKey={[]} activeKey={activeKey} onChange={handleChange} accordion />
+    </Space>
   );
 }
 

--- a/client/src/modules/Tasks/components/TaskSettings/TaskSettings.tsx
+++ b/client/src/modules/Tasks/components/TaskSettings/TaskSettings.tsx
@@ -71,6 +71,8 @@ const taskSettingsSet: SettingsSet = {
     TaskDtoTypeEnum.Ipynb,
     TaskDtoTypeEnum.Kotlintask,
     TaskDtoTypeEnum.Objctask,
+    TaskDtoTypeEnum.Cvhtml,
+    TaskDtoTypeEnum.Cvmarkdown,
   ],
   crossCheck: [TaskDtoTypeEnum.Htmltask, TaskDtoTypeEnum.Jstask],
 };

--- a/client/src/modules/Tasks/components/TaskSettings/TaskSettings.tsx
+++ b/client/src/modules/Tasks/components/TaskSettings/TaskSettings.tsx
@@ -15,26 +15,26 @@ type Props = {
 
 export function TaskSettings({ dataCriteria, taskType, setDataCriteria }: Props) {
   const [activeKey, setActiveKey] = useState<CollapseProps['activeKey']>([]);
-  const { isJsonRequired, isGithubRequired, isCrossCheckRequired } = getRequiredSettings(taskType);
+  const { json, github, crossCheck } = getSettings(taskType);
 
   const collapseItems = [
     {
       label: TASK_SETTINGS_HEADERS.crossCheckCriteria,
       children: <CrossCheckTaskCriteriaPanel dataCriteria={dataCriteria} setDataCriteria={setDataCriteria} />,
       forceRender: true,
-      collapsible: isCollapsible(isCrossCheckRequired),
+      collapsible: isCollapsible(crossCheck),
     },
     {
       label: TASK_SETTINGS_HEADERS.github,
       children: <GitHubPanel />,
       forceRender: true,
-      collapsible: isCollapsible(isGithubRequired),
+      collapsible: isCollapsible(github),
     },
     {
       label: TASK_SETTINGS_HEADERS.jsonAttributes,
       children: <JsonAttributesPanel />,
       forceRender: true,
-      collapsible: isCollapsible(isJsonRequired),
+      collapsible: isCollapsible(json),
     },
   ];
 
@@ -70,20 +70,20 @@ const taskSettingsSet: SettingsSet = {
   crossCheck: [TaskDtoTypeEnum.Htmltask, TaskDtoTypeEnum.Jstask],
 };
 
-const defaultSettings: Settings = { isJsonRequired: false, isGithubRequired: false, isCrossCheckRequired: false };
+const defaultSettings: Settings = { json: false, github: false, crossCheck: false };
 
-function getRequiredSettings(taskType?: TaskDtoTypeEnum): Settings {
+function getSettings(taskType?: TaskDtoTypeEnum): Settings {
   if (!taskType) {
     return defaultSettings;
   }
 
-  const isJsonRequired = taskSettingsSet.json.includes(taskType);
-  const isGithubRequired = taskSettingsSet.github.includes(taskType);
-  const isCrossCheckRequired = taskSettingsSet.crossCheck.includes(taskType);
+  const json = taskSettingsSet.json.includes(taskType);
+  const github = taskSettingsSet.github.includes(taskType);
+  const crossCheck = taskSettingsSet.crossCheck.includes(taskType);
 
-  return { isJsonRequired, isGithubRequired, isCrossCheckRequired };
+  return { json, github, crossCheck };
 }
 
-function isCollapsible(isFieldRequired: boolean) {
-  return (!isFieldRequired ? 'disabled' : undefined) as CollapsibleType;
+function isCollapsible(isPanelEnabled: boolean) {
+  return (!isPanelEnabled ? 'disabled' : undefined) as CollapsibleType;
 }

--- a/client/src/modules/Tasks/constants.ts
+++ b/client/src/modules/Tasks/constants.ts
@@ -1,4 +1,4 @@
-import { ModalAction } from './types';
+import { ModalFormMode } from 'hooks';
 
 const LABELS = {
   name: 'Task name',
@@ -43,9 +43,9 @@ const ERROR_MESSAGES = {
   invalidJson: 'Invalid JSON',
 };
 
-const MODAL_TITLES: Record<ModalAction, string> = {
-  [ModalAction.Create]: 'Add Task',
-  [ModalAction.Update]: 'Edit Task',
+const MODAL_TITLES: Record<ModalFormMode, string> = {
+  create: 'Add Task',
+  edit: 'Edit Task',
 };
 
 export { LABELS, TASK_SETTINGS_HEADERS, PLACEHOLDERS, ERROR_MESSAGES, MODAL_TITLES };

--- a/client/src/modules/Tasks/constants.ts
+++ b/client/src/modules/Tasks/constants.ts
@@ -1,5 +1,7 @@
+import { ModalAction } from './types';
+
 const LABELS = {
-  name: 'Name',
+  name: 'Task name',
   taskType: 'Task type',
   discipline: 'Discipline',
   tags: 'Tags',
@@ -41,4 +43,9 @@ const ERROR_MESSAGES = {
   invalidJson: 'Invalid JSON',
 };
 
-export { LABELS, TASK_SETTINGS_HEADERS, PLACEHOLDERS, ERROR_MESSAGES };
+const MODAL_TITLES: Record<ModalAction, string> = {
+  [ModalAction.Create]: 'Add Task',
+  [ModalAction.Update]: 'Edit Task',
+};
+
+export { LABELS, TASK_SETTINGS_HEADERS, PLACEHOLDERS, ERROR_MESSAGES, MODAL_TITLES };

--- a/client/src/modules/Tasks/pages/TasksPage/TasksPage.tsx
+++ b/client/src/modules/Tasks/pages/TasksPage/TasksPage.tsx
@@ -5,7 +5,7 @@ import { AdminPageLayout } from 'components/PageLayout';
 import { CreateTaskDto, CriteriaDto, DisciplineDto, DisciplinesApi, TaskDto, TasksApi, TasksCriteriaApi } from 'api';
 import { TaskType } from 'modules/CrossCheck/components/CrossCheckCriteriaForm';
 import { TasksTable, TaskModal } from 'modules/Tasks/components';
-import { FormValues, ModalData } from 'modules/Tasks/types';
+import { FormValues, ModalAction, ModalData } from 'modules/Tasks/types';
 import { useActiveCourseContext } from 'modules/Course/contexts';
 
 const { Content } = Layout;
@@ -20,7 +20,7 @@ export function TasksPage() {
   const [disciplines, setDisciplines] = useState<DisciplineDto[]>([]);
   const [modalLoading, setModalLoading] = useState(false);
   const [modalData, setModalData] = useState<ModalData>(null);
-  const [modalAction, setModalAction] = useState<'update' | 'create'>('update');
+  const [modalAction, setModalAction] = useState<ModalAction>(ModalAction.Update);
   const [dataCriteria, setDataCriteria] = useState<CriteriaDto[]>([]);
 
   const { loading } = useAsync(async () => {
@@ -37,14 +37,14 @@ export function TasksPage() {
   const handleAddItem = () => {
     setDataCriteria([]);
     setModalData({});
-    setModalAction('create');
+    setModalAction(ModalAction.Create);
   };
 
   const handleEditItem = async (record: TaskDto) => {
     const { data } = await criteriaApi.getTaskCriteria(record.id);
     setDataCriteria(data.criteria ?? []);
     setModalData(prepareValues(record));
-    setModalAction('update');
+    setModalAction(ModalAction.Update);
   };
 
   const handleModalSubmit = useCallback(
@@ -76,7 +76,7 @@ export function TasksPage() {
           return;
         }
 
-        if (modalAction === 'update') {
+        if (modalAction === ModalAction.Update) {
           if (!modalData?.id) {
             return;
           }
@@ -119,6 +119,7 @@ export function TasksPage() {
           disciplines={disciplines}
           handleModalSubmit={handleModalSubmit}
           modalData={modalData}
+          modalAction={modalAction}
           modalLoading={modalLoading}
           setDataCriteria={setDataCriteria}
           setModalData={setModalData}

--- a/client/src/modules/Tasks/types.ts
+++ b/client/src/modules/Tasks/types.ts
@@ -3,13 +3,6 @@ import { TaskDto, TaskDtoTypeEnum } from 'api';
 // discipline on form is the discipline id(number), on TaskDto it's an object(id, name);
 type FormValues = Partial<Omit<TaskDto, 'discipline' | 'attributes'> & { discipline: number; attributes: string }>;
 
-type ModalData = Partial<Omit<TaskDto, 'attributes'> & { attributes: string }> | null;
-
-const enum ModalAction {
-  Update = 'update',
-  Create = 'create',
-}
-
 const enum ColumnName {
   Id = 'Id',
   Name = 'Name',
@@ -34,6 +27,6 @@ type Settings = Record<Criteria, boolean>;
 
 type SettingsSet = Record<Criteria, TaskDtoTypeEnum[]>;
 
-export type { FormValues, ModalData, Settings, SettingsSet };
+export type { FormValues, Settings, SettingsSet };
 
-export { ColumnName, ModalAction };
+export { ColumnName };

--- a/client/src/modules/Tasks/types.ts
+++ b/client/src/modules/Tasks/types.ts
@@ -19,13 +19,15 @@ const enum ColumnName {
   Actions = 'Actions',
 }
 
-type Settings = {
-  isJsonRequired: boolean;
-  isGithubRequired: boolean;
-  isCrossCheckRequired: boolean;
-};
+const enum Criteria {
+  json = 'json',
+  github = 'github',
+  crossCheck = 'crossCheck',
+}
 
-type SettingsSet = Record<'json' | 'github' | 'crossCheck', TaskDtoTypeEnum[]>;
+type Settings = Record<Criteria, boolean>;
+
+type SettingsSet = Record<Criteria, TaskDtoTypeEnum[]>;
 
 export type { FormValues, ModalData, Settings, SettingsSet };
 

--- a/client/src/modules/Tasks/types.ts
+++ b/client/src/modules/Tasks/types.ts
@@ -5,6 +5,11 @@ type FormValues = Partial<Omit<TaskDto, 'discipline' | 'attributes'> & { discipl
 
 type ModalData = Partial<Omit<TaskDto, 'attributes'> & { attributes: string }> | null;
 
+const enum ModalAction {
+  Update = 'update',
+  Create = 'create',
+}
+
 const enum ColumnName {
   Id = 'Id',
   Name = 'Name',
@@ -31,4 +36,4 @@ type SettingsSet = Record<Criteria, TaskDtoTypeEnum[]>;
 
 export type { FormValues, ModalData, Settings, SettingsSet };
 
-export { ColumnName };
+export { ColumnName, ModalAction };

--- a/client/src/modules/Tasks/types.ts
+++ b/client/src/modules/Tasks/types.ts
@@ -1,6 +1,9 @@
-import { TaskDto } from 'api';
+import { TaskDto, TaskDtoTypeEnum } from 'api';
 
-type ModalData = (Partial<Omit<TaskDto, 'attributes'>> & { attributes?: string }) | null;
+// discipline on form is the discipline id(number), on TaskDto it's an object(id, name);
+type FormValues = Partial<Omit<TaskDto, 'discipline' | 'attributes'> & { discipline: number; attributes: string }>;
+
+type ModalData = Partial<Omit<TaskDto, 'attributes'> & { attributes: string }> | null;
 
 const enum ColumnName {
   Id = 'Id',
@@ -16,6 +19,14 @@ const enum ColumnName {
   Actions = 'Actions',
 }
 
-export type { ModalData };
+type Settings = {
+  isJsonRequired: boolean;
+  isGithubRequired: boolean;
+  isCrossCheckRequired: boolean;
+};
+
+type SettingsSet = Record<'json' | 'github' | 'crossCheck', TaskDtoTypeEnum[]>;
+
+export type { FormValues, ModalData, Settings, SettingsSet };
 
 export { ColumnName };


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link
[PR#2305](https://github.com/rolling-scopes/rsschool-app/pull/2305)
[issue#1980](https://github.com/rolling-scopes/rsschool-app/issues/1980)

#### 💡 Background and solution

- remove redundant `setState` call on form inputs changes
- add criteria settings set based on task type
![admin-task](https://github.com/rolling-scopes/rsschool-app/assets/67139199/5cd55a66-4c77-401e-bb02-90b6b2307ea5)
UI Update:
![Screenshot from 2023-11-11 13-08-08](https://github.com/rolling-scopes/rsschool-app/assets/67139199/a4b147dc-f104-466a-8b28-1c7f401c8b5a)



#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
