### PR TITLE
fix: adjust popup positioning

### DIFF
--- a/client/src/modules/Score/data/getTaskColumns.tsx
+++ b/client/src/modules/Score/data/getTaskColumns.tsx
@@ -19,6 +19,7 @@ export function getTaskColumns(courseTasks: CourseTaskDto[]) {
               </ul>
             }
             trigger="click"
+            overlayStyle={{ position: 'fixed', minWidth: 235 }}
           >
             <QuestionCircleOutlined title="Click for details" />
           </Popover>

--- a/client/src/modules/Score/data/getTaskColumns.tsx
+++ b/client/src/modules/Score/data/getTaskColumns.tsx
@@ -13,7 +13,7 @@ export function getTaskColumns(courseTasks: CourseTaskDto[]) {
           <Popover
             content={
               <ul>
-                <li>Coefficient: {courseTask.scoreWeight}</li>
+                <li>Coefficient: {Number(courseTask.scoreWeight.toFixed(2))}</li>
                 <li>Deadline: {dateTimeRenderer(courseTask.studentEndDate)}</li>
                 <li>Max. score: {courseTask.maxScore}</li>
               </ul>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

[issue#2302](https://github.com/rolling-scopes/rsschool-app/issues/2302)

#### 💡 Background and solution

- set `min-width: 235px` so popup won't shrink, which fixes flickering;
- set `position: fixed` instead of `absolute`, which fixes `body` overflow(horizontal);
- set score coefficient `toFixed(2)`, same as on schedule table;

![score-popup](https://github.com/rolling-scopes/rsschool-app/assets/67139199/50b97863-7add-4b9e-866e-d2f638f621bf)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
