### PR TITLE
fix: move 'start task' and 'show results' buttons above table

### DIFF
--- a/client/src/modules/AutoTest/components/VerificationInformation/VerificationInformation.test.tsx
+++ b/client/src/modules/AutoTest/components/VerificationInformation/VerificationInformation.test.tsx
@@ -6,9 +6,11 @@ import VerificationInformation, { VerificationInformationProps } from './Verific
 function renderVerificationInformation({
   type,
   studentEndDate = '2022-10-10 12:00',
+  isTableVisible = true,
 }: {
   type: CourseTaskDetailedDtoTypeEnum;
   studentEndDate?: string;
+  isTableVisible?: boolean;
 }) {
   const courseTask = {
     name: 'Course Task',
@@ -26,7 +28,7 @@ function renderVerificationInformation({
 
   const props: VerificationInformationProps = {
     courseTask,
-    isTableVisible: true,
+    isTableVisible,
     loading: false,
     reload: jest.fn(),
     startTask: jest.fn(),
@@ -63,5 +65,23 @@ describe('VerificationInformation', () => {
 
     const answersButton = screen.getByRole('button', { name: /show answers/i });
     expect(answersButton).toBeInTheDocument();
+  });
+
+  it('should render start and refresh buttons if table is visible', () => {
+    renderVerificationInformation({ type: CourseTaskDetailedDtoTypeEnum.Jstask, isTableVisible: true });
+
+    const startTaskButton = screen.getByRole('button', { name: /start task/i });
+    const refreshButton = screen.getByRole('button', { name: /refresh/i });
+    expect(startTaskButton).toBeInTheDocument();
+    expect(refreshButton).toBeInTheDocument();
+  });
+
+  it('should not render start and refresh buttons if table is not visible', () => {
+    renderVerificationInformation({ type: CourseTaskDetailedDtoTypeEnum.Jstask, isTableVisible: false });
+
+    const startTaskButton = screen.queryByRole('button', { name: /start task/i });
+    const refreshButton = screen.queryByRole('button', { name: /refresh/i });
+    expect(startTaskButton).not.toBeInTheDocument();
+    expect(refreshButton).not.toBeInTheDocument();
   });
 });

--- a/client/src/modules/AutoTest/components/VerificationInformation/VerificationInformation.tsx
+++ b/client/src/modules/AutoTest/components/VerificationInformation/VerificationInformation.tsx
@@ -45,21 +45,12 @@ function VerificationInformation({
         )}
         {isTableVisible && (
           <Col flex="none">
-            <Button icon={<ReloadOutlined />} onClick={reload}>
-              Refresh
-            </Button>
-          </Col>
-        )}
-      </Row>
-      {isTableVisible && (
-        <Row style={{ background: 'white', padding: '0 24px 24px' }} gutter={[0, 24]} justify="center">
-          <Col span={24}>
-            <VerificationsTable maxScore={maxScore} verifications={verifications} loading={loading} />
-          </Col>
-          <Col>
-            <Space size={16}>
+            <Space wrap style={{ justifyContent: 'end' }}>
               <Button type="primary" onClick={startTask} disabled={!allowStartTask}>
                 Start task
+              </Button>
+              <Button icon={<ReloadOutlined />} onClick={reload}>
+                Refresh
               </Button>
               {isSelfEducationTask && (
                 <Tooltip
@@ -72,6 +63,13 @@ function VerificationInformation({
                 </Tooltip>
               )}
             </Space>
+          </Col>
+        )}
+      </Row>
+      {isTableVisible && (
+        <Row style={{ background: 'white', padding: '0 24px 24px' }} gutter={[0, 24]} justify="center">
+          <Col span={24}>
+            <VerificationsTable maxScore={maxScore} verifications={verifications} loading={loading} />
           </Col>
         </Row>
       )}


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/2375

#### 💡 Background and solution

Move 'start task' and 'show results' buttons above the table according to the solution proposed in the comments to the issue.

<details>
<summary>Screenshots with 3 and 2 buttons for different viewport widths:</summary>
<br>
two buttons, 768
<img src="https://github.com/rolling-scopes/rsschool-app/assets/50028051/6550dfec-c6e3-4687-a5bd-5f6b8066a45f">

three buttons, 768
<img src="https://github.com/rolling-scopes/rsschool-app/assets/50028051/47f9c42e-e166-4212-8d01-067c72689ea8">

two buttons, 320
<img src="https://github.com/rolling-scopes/rsschool-app/assets/50028051/36297b63-2267-425d-88e0-a80ff3cbd962">

three buttons, 320
<img src="https://github.com/rolling-scopes/rsschool-app/assets/50028051/966b421a-eebf-48f9-985c-c27b7aeb080e">


</details>

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
