### PR TITLE
Show correct eligible students amount

### DIFF
--- a/nestjs/src/courses/stats/course-stats.service.ts
+++ b/nestjs/src/courses/stats/course-stats.service.ts
@@ -55,7 +55,7 @@ export class CourseStatsService {
         'students_with_certificate',
       )
       .addSelect(
-        `COUNT(CASE WHEN student.totalScore >= (${maxScore} * course.certificateThreshold / 100) THEN 1 END)`,
+        `COUNT(CASE WHEN student.isExpelled = false AND student.totalScore >= (${maxScore} * course.certificateThreshold / 100) THEN 1 END)`,
         'eligible_for_certification',
       )
       .where('student.courseId = :courseId', { courseId });


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/2473

#### 💡 Background and solution

If amount of eligible students is greater than 100% => it should be 100% (as alternative solution we can show amount of eligible students vs all students, but I think it doesn't make much sense)

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
