### PR TITLE
Fix no styles on login page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@ant-design/compatible": "5.1.2",
+    "@ant-design/cssinjs": "^1.20.0",
     "@ant-design/plots": "1.2.5",
     "@sentry/nextjs": "7.81.0",
     "antd": "5.11.2",

--- a/client/src/__tests__/__snapshots__/ProfilePage.test.tsx.snap
+++ b/client/src/__tests__/__snapshots__/ProfilePage.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`ProfilePage Should render correctly if full profile info is in the stat
     style="justify-content: center; align-items: center; display: flex; width: 100vw; position: fixed; height: 100vh;"
   >
     <div
-      class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+      class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
     >
       <div>
         <div
           aria-busy="true"
           aria-live="polite"
-          class="ant-spin ant-spin-spinning ant-spin-show-text css-dev-only-do-not-override-nllxry"
+          class="ant-spin ant-spin-spinning ant-spin-show-text css-dev-only-do-not-override-1v2lwm6"
           style="font-size: 20px;"
         >
           <span

--- a/client/src/components/Forms/__tests__/__snapshots__/CourseTaskSelect.test.tsx.snap
+++ b/client/src/components/Forms/__tests__/__snapshots__/CourseTaskSelect.test.tsx.snap
@@ -4,16 +4,16 @@ exports[`CourseTaskSelect Should render correctly if groupBy is cross-check dead
 <body>
   <div>
     <form
-      class="ant-form ant-form-horizontal css-dev-only-do-not-override-nllxry"
+      class="ant-form ant-form-horizontal css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-form-item css-dev-only-do-not-override-nllxry"
+        class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
         >
           <div
-            class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
           >
             <label
               class="ant-form-item-required"
@@ -24,7 +24,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is cross-check dead
             </label>
           </div>
           <div
-            class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
           >
             <div
               class="ant-form-item-control-input"
@@ -34,7 +34,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is cross-check dead
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-nllxry ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
+                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-1v2lwm6 ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -100,7 +100,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is cross-check dead
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-dev-only-do-not-override-nllxry ant-select-dropdown-placement-bottomLeft"
+      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-dev-only-do-not-override-1v2lwm6 ant-select-dropdown-placement-bottomLeft"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div>
@@ -397,16 +397,16 @@ exports[`CourseTaskSelect Should render correctly if groupBy is deadline 1`] = `
 <body>
   <div>
     <form
-      class="ant-form ant-form-horizontal css-dev-only-do-not-override-nllxry"
+      class="ant-form ant-form-horizontal css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-form-item css-dev-only-do-not-override-nllxry"
+        class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
         >
           <div
-            class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
           >
             <label
               class="ant-form-item-required"
@@ -417,7 +417,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is deadline 1`] = `
             </label>
           </div>
           <div
-            class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
           >
             <div
               class="ant-form-item-control-input"
@@ -427,7 +427,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is deadline 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-nllxry ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
+                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-1v2lwm6 ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -494,7 +494,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is deadline 1`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-dev-only-do-not-override-nllxry ant-select-dropdown-placement-bottomLeft"
+      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-dev-only-do-not-override-1v2lwm6 ant-select-dropdown-placement-bottomLeft"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div>
@@ -728,16 +728,16 @@ exports[`CourseTaskSelect Should render correctly if groupBy is default 1`] = `
 <body>
   <div>
     <form
-      class="ant-form ant-form-horizontal css-dev-only-do-not-override-nllxry"
+      class="ant-form ant-form-horizontal css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-form-item css-dev-only-do-not-override-nllxry"
+        class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
         >
           <div
-            class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
           >
             <label
               class="ant-form-item-required"
@@ -748,7 +748,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is default 1`] = `
             </label>
           </div>
           <div
-            class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
           >
             <div
               class="ant-form-item-control-input"
@@ -758,7 +758,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is default 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-nllxry ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
+                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-1v2lwm6 ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -824,7 +824,7 @@ exports[`CourseTaskSelect Should render correctly if groupBy is default 1`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-dev-only-do-not-override-nllxry ant-select-dropdown-placement-bottomLeft"
+      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-dev-only-do-not-override-1v2lwm6 ant-select-dropdown-placement-bottomLeft"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div>

--- a/client/src/components/Profile/__test__/__snapshots__/AboutCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/AboutCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AboutCard Should render correctly if "data" is not present 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`AboutCard Should render correctly if "data" is not present 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -52,7 +52,7 @@ exports[`AboutCard Should render correctly if "data" is not present 1`] = `
       class="ant-card-body"
     >
       <div
-        class="css-dev-only-do-not-override-nllxry ant-empty ant-empty-normal"
+        class="css-dev-only-do-not-override-1v2lwm6 ant-empty ant-empty-normal"
       >
         <div
           class="ant-empty-image"
@@ -104,7 +104,7 @@ exports[`AboutCard Should render correctly if "data" is not present 1`] = `
 exports[`AboutCard Should render correctly if "data" is present 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -116,7 +116,7 @@ exports[`AboutCard Should render correctly if "data" is present 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -154,7 +154,7 @@ exports[`AboutCard Should render correctly if "data" is present 1`] = `
     >
       <div
         aria-label="Top contributor of Rolling Scopes"
-        class="ant-typography ant-typography-ellipsis css-dev-only-do-not-override-nllxry"
+        class="ant-typography ant-typography-ellipsis css-dev-only-do-not-override-1v2lwm6"
       >
         Top contributor of Rolling Scopes
         <span

--- a/client/src/components/Profile/__test__/__snapshots__/CommonCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/CommonCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CommonCard Should render correctly if is null content passed 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`CommonCard Should render correctly if is null content passed 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -33,7 +33,7 @@ exports[`CommonCard Should render correctly if is null content passed 1`] = `
       class="ant-card-body"
     >
       <div
-        class="css-dev-only-do-not-override-nllxry ant-empty ant-empty-normal"
+        class="css-dev-only-do-not-override-1v2lwm6 ant-empty ant-empty-normal"
       >
         <div
           class="ant-empty-image"
@@ -85,7 +85,7 @@ exports[`CommonCard Should render correctly if is null content passed 1`] = `
 exports[`CommonCard Should render correctly if just basic props is present 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -97,7 +97,7 @@ exports[`CommonCard Should render correctly if just basic props is present 1`] =
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>

--- a/client/src/components/Profile/__test__/__snapshots__/CommonCardWithSettingsModal.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/CommonCardWithSettingsModal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CommonCardWithSettingsModal Should render correctly if just basic props are present 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`CommonCardWithSettingsModal Should render correctly if just basic props
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -63,7 +63,7 @@ exports[`CommonCardWithSettingsModal Should render correctly if just basic props
 exports[`CommonCardWithSettingsModal Should render correctly if null content is passed and editing mode is disabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -75,7 +75,7 @@ exports[`CommonCardWithSettingsModal Should render correctly if null content is 
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -93,7 +93,7 @@ exports[`CommonCardWithSettingsModal Should render correctly if null content is 
       class="ant-card-body"
     >
       <div
-        class="css-dev-only-do-not-override-nllxry ant-empty ant-empty-normal"
+        class="css-dev-only-do-not-override-1v2lwm6 ant-empty ant-empty-normal"
       >
         <div
           class="ant-empty-image"

--- a/client/src/components/Profile/__test__/__snapshots__/ContactsCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/ContactsCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -49,10 +49,10 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -64,7 +64,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     EPAM E-mail
@@ -78,7 +78,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     E-mail
@@ -92,7 +92,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     Telegram
@@ -106,7 +106,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     Phone
@@ -120,7 +120,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     Skype
@@ -134,7 +134,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     Notes
@@ -148,7 +148,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     LinkedIn
@@ -175,7 +175,7 @@ exports[`ContactsCard Should render correctly if editing mode is disabled 1`] = 
 exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -187,7 +187,7 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -241,10 +241,10 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -256,7 +256,7 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     EPAM E-mail
@@ -270,7 +270,7 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     E-mail
@@ -280,7 +280,7 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
                  
                 vasya@tut.by
                 <div
-                  class="ant-alert ant-alert-error ant-alert-no-icon css-dev-only-do-not-override-nllxry"
+                  class="ant-alert ant-alert-error ant-alert-no-icon css-dev-only-do-not-override-1v2lwm6"
                   data-show="true"
                   role="alert"
                 >
@@ -307,7 +307,7 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     Phone
@@ -321,7 +321,7 @@ exports[`ContactsCard Should render correctly if editing mode is enabled 1`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 >
                   <strong>
                     Skype

--- a/client/src/components/Profile/__test__/__snapshots__/ContactsCardForm.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/ContactsCardForm.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`ContactsCardForm Should render correctly if "contacts" is empty 1`] = `
 <div>
   <form
-    class="ant-form ant-form-horizontal css-dev-only-do-not-override-nllxry"
+    class="ant-form ant-form-horizontal css-dev-only-do-not-override-1v2lwm6"
   >
     <div
-      class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+      class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+        class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
       >
         <div
           class="ant-spin-container"
@@ -18,7 +18,7 @@ exports[`ContactsCardForm Should render correctly if "contacts" is empty 1`] = `
             class="ant-list-empty-text"
           >
             <div
-              class="css-dev-only-do-not-override-nllxry ant-empty ant-empty-normal"
+              class="css-dev-only-do-not-override-1v2lwm6 ant-empty ant-empty-normal"
             >
               <div
                 class="ant-empty-image"
@@ -73,13 +73,13 @@ exports[`ContactsCardForm Should render correctly if "contacts" is empty 1`] = `
 exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`] = `
 <div>
   <form
-    class="ant-form ant-form-horizontal css-dev-only-do-not-override-nllxry"
+    class="ant-form ant-form-horizontal css-dev-only-do-not-override-1v2lwm6"
   >
     <div
-      class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+      class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+        class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
       >
         <div
           class="ant-spin-container"
@@ -94,7 +94,7 @@ exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`]
                 style="width: 100%;"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                   style="font-size: 18px; margin-bottom: 5px; display: inline-block;"
                 >
                   <strong>
@@ -103,13 +103,13 @@ exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`]
                   </strong>
                 </span>
                 <div
-                  class="ant-form-item css-dev-only-do-not-override-nllxry"
+                  class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
                 >
                   <div
-                    class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+                    class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
                   >
                     <div
-                      class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+                      class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
                     >
                       <div
                         class="ant-form-item-control-input"
@@ -118,7 +118,7 @@ exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`]
                           class="ant-form-item-control-input-content"
                         >
                           <input
-                            class="ant-input css-dev-only-do-not-override-nllxry"
+                            class="ant-input css-dev-only-do-not-override-1v2lwm6"
                             id="epamEmail"
                             style="width: 100%;"
                             type="text"
@@ -138,7 +138,7 @@ exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`]
                 style="width: 100%;"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-nllxry"
+                  class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                   style="font-size: 18px; margin-bottom: 5px; display: inline-block;"
                 >
                   <strong>
@@ -147,13 +147,13 @@ exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`]
                   </strong>
                 </span>
                 <div
-                  class="ant-form-item css-dev-only-do-not-override-nllxry"
+                  class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
                 >
                   <div
-                    class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+                    class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
                   >
                     <div
-                      class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+                      class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
                     >
                       <div
                         class="ant-form-item-control-input"
@@ -162,7 +162,7 @@ exports[`ContactsCardForm Should render correctly if "contacts" is not empty 1`]
                           class="ant-form-item-control-input-content"
                         >
                           <input
-                            class="ant-input css-dev-only-do-not-override-nllxry"
+                            class="ant-input css-dev-only-do-not-override-1v2lwm6"
                             id="email"
                             style="width: 100%;"
                             type="text"

--- a/client/src/components/Profile/__test__/__snapshots__/CoreJsIviewsCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/CoreJsIviewsCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CoreJSIviewsCard should render correctly 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`CoreJSIviewsCard should render correctly 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -52,10 +52,10 @@ exports[`CoreJSIviewsCard should render correctly 1`] = `
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -74,7 +74,7 @@ exports[`CoreJSIviewsCard should render correctly 1`] = `
                     style="margin-bottom: 5px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2019
@@ -92,7 +92,7 @@ exports[`CoreJSIviewsCard should render correctly 1`] = `
                   >
                     Score: 
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <mark>
                         4
@@ -111,7 +111,7 @@ exports[`CoreJSIviewsCard should render correctly 1`] = `
                   </p>
                 </div>
                 <button
-                  class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-dashed"
+                  class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-dashed"
                   data-testid="profile-corejs-iview-button"
                   type="button"
                 >

--- a/client/src/components/Profile/__test__/__snapshots__/EducationCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/EducationCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EducationCard Should render correctly if "data" has element with "null" value 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`EducationCard Should render correctly if "data" has element with "null"
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -69,10 +69,10 @@ exports[`EducationCard Should render correctly if "data" has element with "null"
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -99,7 +99,7 @@ exports[`EducationCard Should render correctly if "data" has element with "null"
 exports[`EducationCard Should render correctly if "data" is empty 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -111,7 +111,7 @@ exports[`EducationCard Should render correctly if "data" is empty 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -145,7 +145,7 @@ exports[`EducationCard Should render correctly if "data" is empty 1`] = `
       class="ant-card-body"
     >
       <div
-        class="css-dev-only-do-not-override-nllxry ant-empty ant-empty-normal"
+        class="css-dev-only-do-not-override-1v2lwm6 ant-empty ant-empty-normal"
       >
         <div
           class="ant-empty-image"
@@ -197,7 +197,7 @@ exports[`EducationCard Should render correctly if "data" is empty 1`] = `
 exports[`EducationCard Should render correctly if editing mode is disabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -209,7 +209,7 @@ exports[`EducationCard Should render correctly if editing mode is disabled 1`] =
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -243,10 +243,10 @@ exports[`EducationCard Should render correctly if editing mode is disabled 1`] =
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -259,7 +259,7 @@ exports[`EducationCard Should render correctly if editing mode is disabled 1`] =
               >
                 <p>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-nllxry"
+                    class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                   >
                     <strong>
                       2002
@@ -281,7 +281,7 @@ exports[`EducationCard Should render correctly if editing mode is disabled 1`] =
 exports[`EducationCard Should render correctly if editing mode is enabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -293,7 +293,7 @@ exports[`EducationCard Should render correctly if editing mode is enabled 1`] = 
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -327,10 +327,10 @@ exports[`EducationCard Should render correctly if editing mode is enabled 1`] = 
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -343,7 +343,7 @@ exports[`EducationCard Should render correctly if editing mode is enabled 1`] = 
               >
                 <p>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-nllxry"
+                    class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                   >
                     <strong>
                       2002

--- a/client/src/components/Profile/__test__/__snapshots__/MainCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/MainCard.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`MainCard Should render correctly if editing mode is disabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
     style="position: relative;"
   >
     <div
       class="ant-card-body"
     >
       <span
-        class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-nllxry"
+        class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-1v2lwm6"
         style="width: 96px; height: 96px; line-height: 96px; font-size: 18px; margin: 0px auto 10px; display: block;"
       >
         <img
@@ -18,13 +18,13 @@ exports[`MainCard Should render correctly if editing mode is disabled 1`] = `
         />
       </span>
       <h1
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="font-size: 24px; text-align: center; margin: 0px;"
       >
         John Doe
       </h1>
       <div
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="text-align: center; margin-bottom: 20px;"
       >
         <a
@@ -56,7 +56,7 @@ exports[`MainCard Should render correctly if editing mode is disabled 1`] = `
         </a>
       </div>
       <div
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="text-align: center; margin: 0px;"
       >
         <span>
@@ -84,7 +84,7 @@ exports[`MainCard Should render correctly if editing mode is disabled 1`] = `
         </span>
       </div>
       <div
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="text-align: center; margin-top: 20px;"
       >
         <a
@@ -102,7 +102,7 @@ exports[`MainCard Should render correctly if editing mode is disabled 1`] = `
 exports[`MainCard Should render correctly if editing mode is enabled 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
     style="position: relative;"
   >
     <div
@@ -130,7 +130,7 @@ exports[`MainCard Should render correctly if editing mode is enabled 1`] = `
         </svg>
       </span>
       <span
-        class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-nllxry"
+        class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-1v2lwm6"
         style="width: 96px; height: 96px; line-height: 96px; font-size: 18px; margin: 0px auto 10px; display: block;"
       >
         <img
@@ -138,13 +138,13 @@ exports[`MainCard Should render correctly if editing mode is enabled 1`] = `
         />
       </span>
       <h1
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="font-size: 24px; text-align: center; margin: 0px;"
       >
         John Doe
       </h1>
       <div
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="text-align: center; margin-bottom: 20px;"
       >
         <a
@@ -176,7 +176,7 @@ exports[`MainCard Should render correctly if editing mode is enabled 1`] = `
         </a>
       </div>
       <div
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="text-align: center; margin: 0px;"
       >
         <span>
@@ -204,7 +204,7 @@ exports[`MainCard Should render correctly if editing mode is enabled 1`] = `
         </span>
       </div>
       <div
-        class="ant-typography css-dev-only-do-not-override-nllxry"
+        class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         style="text-align: center; margin-top: 20px;"
       >
         <a

--- a/client/src/components/Profile/__test__/__snapshots__/MentorStatsCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/MentorStatsCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MentorStatsCard should render correctly 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`MentorStatsCard should render correctly 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -53,7 +53,7 @@ exports[`MentorStatsCard should render correctly 1`] = `
           Mentored Students:
            
           <span
-            class="ant-typography css-dev-only-do-not-override-nllxry"
+            class="ant-typography css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 18px;"
           >
             <strong>
@@ -65,7 +65,7 @@ exports[`MentorStatsCard should render correctly 1`] = `
           Courses as Mentor:
            
           <span
-            class="ant-typography css-dev-only-do-not-override-nllxry"
+            class="ant-typography css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 18px;"
           >
             <strong>
@@ -75,10 +75,10 @@ exports[`MentorStatsCard should render correctly 1`] = `
         </p>
       </div>
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -97,7 +97,7 @@ exports[`MentorStatsCard should render correctly 1`] = `
                     style="font-size: 20px; margin-bottom: 5px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2020-q1
@@ -121,7 +121,7 @@ exports[`MentorStatsCard should render correctly 1`] = `
                     style="margin-bottom: 5px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2018-q1
@@ -131,7 +131,7 @@ exports[`MentorStatsCard should render correctly 1`] = `
                   </p>
                 </div>
                 <button
-                  class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-dashed"
+                  class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-dashed"
                   style="margin-left: 16px;"
                   type="button"
                 >

--- a/client/src/components/Profile/__test__/__snapshots__/PreScreeningIviewCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/PreScreeningIviewCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PreScreeningIviewCard Should render correctly 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -52,10 +52,10 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -74,7 +74,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                     style="margin-bottom: 0px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2018-q1
@@ -82,16 +82,16 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                     </span>
                   </p>
                   <div
-                    class="ant-row css-dev-only-do-not-override-nllxry"
+                    class="ant-row css-dev-only-do-not-override-1v2lwm6"
                   >
                     <span
-                      class="ant-tag ant-tag-green css-dev-only-do-not-override-nllxry"
+                      class="ant-tag ant-tag-green css-dev-only-do-not-override-1v2lwm6"
                     >
                       Completed
                     </span>
                   </div>
                   <ul
-                    class="ant-rate css-dev-only-do-not-override-nllxry ant-rate-disabled"
+                    class="ant-rate css-dev-only-do-not-override-1v2lwm6 ant-rate-disabled"
                     role="radiogroup"
                     style="margin-bottom: 5px;"
                     tabindex="-1"
@@ -388,7 +388,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                     </li>
                   </ul>
                   <span
-                    class="ant-typography ant-rate-text css-dev-only-do-not-override-nllxry"
+                    class="ant-typography ant-rate-text css-dev-only-do-not-override-1v2lwm6"
                     style="font-weight: bold;"
                   >
                     3.40
@@ -404,7 +404,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                   >
                     Good candidate: 
                     <span
-                      class="ant-tag ant-tag-green css-dev-only-do-not-override-nllxry"
+                      class="ant-tag ant-tag-green css-dev-only-do-not-override-1v2lwm6"
                     >
                       Yes
                     </span>
@@ -421,7 +421,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                   </p>
                 </div>
                 <button
-                  class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-dashed"
+                  class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-dashed"
                   type="button"
                 >
                   <span
@@ -456,7 +456,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                     style="margin-bottom: 0px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2019-q1
@@ -464,16 +464,16 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                     </span>
                   </p>
                   <div
-                    class="ant-row css-dev-only-do-not-override-nllxry"
+                    class="ant-row css-dev-only-do-not-override-1v2lwm6"
                   >
                     <span
-                      class="ant-tag ant-tag-green css-dev-only-do-not-override-nllxry"
+                      class="ant-tag ant-tag-green css-dev-only-do-not-override-1v2lwm6"
                     >
                       Completed
                     </span>
                   </div>
                   <ul
-                    class="ant-rate css-dev-only-do-not-override-nllxry ant-rate-disabled"
+                    class="ant-rate css-dev-only-do-not-override-1v2lwm6 ant-rate-disabled"
                     role="radiogroup"
                     style="margin-bottom: 5px;"
                     tabindex="-1"
@@ -770,7 +770,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                     </li>
                   </ul>
                   <span
-                    class="ant-typography ant-rate-text css-dev-only-do-not-override-nllxry"
+                    class="ant-typography ant-rate-text css-dev-only-do-not-override-1v2lwm6"
                     style="font-weight: bold;"
                   >
                     3.40
@@ -786,7 +786,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                   >
                     Good candidate: 
                     <span
-                      class="ant-tag ant-tag-green css-dev-only-do-not-override-nllxry"
+                      class="ant-tag ant-tag-green css-dev-only-do-not-override-1v2lwm6"
                     >
                       Yes
                     </span>
@@ -803,7 +803,7 @@ exports[`PreScreeningIviewCard Should render correctly 1`] = `
                   </p>
                 </div>
                 <button
-                  class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-dashed"
+                  class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-dashed"
                   type="button"
                 >
                   <span

--- a/client/src/components/Profile/__test__/__snapshots__/ProfileSettingsModal.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/ProfileSettingsModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ProfileSettingsModal should render correctly 1`] = `
 <div
   aria-labelledby="test-id"
   aria-modal="true"
-  class="ant-modal css-dev-only-do-not-override-nllxry ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+  class="ant-modal css-dev-only-do-not-override-1v2lwm6 ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
   role="dialog"
   style="width: 520px;"
 >
@@ -67,7 +67,7 @@ exports[`ProfileSettingsModal should render correctly 1`] = `
       class="ant-modal-footer"
     >
       <button
-        class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-default"
+        class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-default"
         type="button"
       >
         <span>
@@ -75,7 +75,7 @@ exports[`ProfileSettingsModal should render correctly 1`] = `
         </span>
       </button>
       <button
-        class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-primary"
+        class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-primary"
         type="button"
       >
         <span>

--- a/client/src/components/Profile/__test__/__snapshots__/PublicFeedbackCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/PublicFeedbackCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PublicFeedbackCard should render correctly 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -52,7 +52,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
         style="margin-bottom: 20px;"
       >
         <span
-          class="ant-typography css-dev-only-do-not-override-nllxry"
+          class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         >
           <strong>
             Total badges:
@@ -68,10 +68,10 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
           style="margin: 5px; display: inline-block;"
         >
           <span
-            class="ant-badge css-dev-only-do-not-override-nllxry"
+            class="ant-badge css-dev-only-do-not-override-1v2lwm6"
           >
             <span
-              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-nllxry"
+              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-1v2lwm6"
               style="width: 48px; height: 48px; line-height: 48px; font-size: 18px;"
             >
               <img
@@ -103,10 +103,10 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
           style="margin: 5px; display: inline-block;"
         >
           <span
-            class="ant-badge css-dev-only-do-not-override-nllxry"
+            class="ant-badge css-dev-only-do-not-override-1v2lwm6"
           >
             <span
-              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-nllxry"
+              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-1v2lwm6"
               style="width: 48px; height: 48px; line-height: 48px; font-size: 18px;"
             >
               <img
@@ -138,10 +138,10 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
           style="margin: 5px; display: inline-block;"
         >
           <span
-            class="ant-badge css-dev-only-do-not-override-nllxry"
+            class="ant-badge css-dev-only-do-not-override-1v2lwm6"
           >
             <span
-              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-nllxry"
+              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-1v2lwm6"
               style="width: 48px; height: 48px; line-height: 48px; font-size: 18px;"
             >
               <img
@@ -174,7 +174,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
         style="margin-bottom: 0px;"
       >
         <span
-          class="ant-typography css-dev-only-do-not-override-nllxry"
+          class="ant-typography css-dev-only-do-not-override-1v2lwm6"
         >
           <strong>
             Last feedback:
@@ -182,7 +182,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
         </span>
       </div>
       <div
-        class="ant-comment css-dev-only-do-not-override-nllxry"
+        class="ant-comment css-dev-only-do-not-override-1v2lwm6"
       >
         <div
           class="ant-comment-inner"
@@ -191,7 +191,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
             class="ant-comment-avatar"
           >
             <span
-              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-nllxry"
+              class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-1v2lwm6"
               style="width: 48px; height: 48px; line-height: 48px; font-size: 18px;"
             >
               <img
@@ -226,7 +226,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
               class="ant-comment-content-detail"
             >
               <span
-                class="ant-typography css-dev-only-do-not-override-nllxry"
+                class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                 style="font-size: 12px;"
               >
                 <strong>
@@ -235,7 +235,7 @@ exports[`PublicFeedbackCard should render correctly 1`] = `
               </span>
               <div
                 aria-label="Test"
-                class="ant-typography ant-typography-ellipsis css-dev-only-do-not-override-nllxry"
+                class="ant-typography ant-typography-ellipsis css-dev-only-do-not-override-1v2lwm6"
               >
                 Test
                 <span

--- a/client/src/components/Profile/__test__/__snapshots__/StudentStatsCard.test.tsx.snap
+++ b/client/src/components/Profile/__test__/__snapshots__/StudentStatsCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StudentStatsCard should render correctly 1`] = `
 <div>
   <div
-    class="ant-card ant-card-bordered css-dev-only-do-not-override-nllxry"
+    class="ant-card ant-card-bordered css-dev-only-do-not-override-1v2lwm6"
   >
     <div
       class="ant-card-head"
@@ -15,7 +15,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
           class="ant-card-head-title"
         >
           <h2
-            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-nllxry"
+            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line css-dev-only-do-not-override-1v2lwm6"
             style="font-size: 16px; margin-bottom: 0px; display: flex; align-items: center; justify-content: space-between;"
           >
             <span>
@@ -49,10 +49,10 @@ exports[`StudentStatsCard should render correctly 1`] = `
       class="ant-card-body"
     >
       <div
-        class="ant-list ant-list-split css-dev-only-do-not-override-nllxry"
+        class="ant-list ant-list-split css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-spin-nested-loading css-dev-only-do-not-override-nllxry"
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-spin-container"
@@ -71,7 +71,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
                     style="margin-bottom: 0px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2018-q1
@@ -84,7 +84,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
                   >
                     <div
                       aria-valuenow="100"
-                      class="ant-progress ant-progress-status-success ant-progress-line ant-progress-show-info ant-progress-small css-dev-only-do-not-override-nllxry"
+                      class="ant-progress ant-progress-status-success ant-progress-line ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1v2lwm6"
                       role="progressbar"
                     >
                       <div
@@ -149,7 +149,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
                   </p>
                 </div>
                 <button
-                  class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-dashed"
+                  class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-dashed"
                   type="button"
                 >
                   <span
@@ -184,7 +184,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
                     style="margin-bottom: 0px;"
                   >
                     <span
-                      class="ant-typography css-dev-only-do-not-override-nllxry"
+                      class="ant-typography css-dev-only-do-not-override-1v2lwm6"
                     >
                       <strong>
                         rs-2019-q1
@@ -197,7 +197,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
                   >
                     <div
                       aria-valuenow="50"
-                      class="ant-progress ant-progress-status-exception ant-progress-line ant-progress-show-info ant-progress-small css-dev-only-do-not-override-nllxry"
+                      class="ant-progress ant-progress-status-exception ant-progress-line ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1v2lwm6"
                       role="progressbar"
                     >
                       <div
@@ -263,7 +263,7 @@ exports[`StudentStatsCard should render correctly 1`] = `
                   </p>
                 </div>
                 <button
-                  class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-dashed"
+                  class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-dashed"
                   type="button"
                 >
                   <span

--- a/client/src/modules/CrossCheck/__tests__/__snapshots__/AddCriteriaForCrossCheck.test.tsx.snap
+++ b/client/src/modules/CrossCheck/__tests__/__snapshots__/AddCriteriaForCrossCheck.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="ant-form-item css-dev-only-do-not-override-nllxry"
+        class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
         >
           <div
-            class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
           >
             <label
               class=""
@@ -22,7 +22,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
             </label>
           </div>
           <div
-            class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
           >
             <div
               class="ant-form-item-control-input"
@@ -31,7 +31,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <div
-                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-nllxry ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-in-form-item css-dev-only-do-not-override-1v2lwm6 ant-select-single ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -95,13 +95,13 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
         </div>
       </div>
       <div
-        class="ant-form-item css-dev-only-do-not-override-nllxry"
+        class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
         >
           <div
-            class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
           >
             <label
               class=""
@@ -111,7 +111,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
             </label>
           </div>
           <div
-            class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+            class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
           >
             <div
               class="ant-form-item-control-input"
@@ -120,7 +120,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
                 class="ant-form-item-control-input-content"
               >
                 <textarea
-                  class="ant-input css-dev-only-do-not-override-nllxry"
+                  class="ant-input css-dev-only-do-not-override-1v2lwm6"
                   placeholder="Add description"
                   rows="3"
                   style="max-width: 1200px;"
@@ -134,7 +134,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
         style="text-align: right;"
       >
         <button
-          class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-primary"
+          class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-primary"
           disabled=""
           type="button"
         >
@@ -147,13 +147,13 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="ant-form-item css-dev-only-do-not-override-nllxry"
+      class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+        class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+          class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
         >
           <label
             class=""
@@ -163,7 +163,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
           </label>
         </div>
         <div
-          class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+          class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-form-item-control-input"
@@ -172,7 +172,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
               class="ant-form-item-control-input-content"
             >
               <div
-                class="ant-select ant-select-in-form-item css-dev-only-do-not-override-nllxry ant-select-single ant-select-show-arrow"
+                class="ant-select ant-select-in-form-item css-dev-only-do-not-override-1v2lwm6 ant-select-single ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -236,13 +236,13 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
       </div>
     </div>
     <div
-      class="ant-form-item css-dev-only-do-not-override-nllxry"
+      class="ant-form-item css-dev-only-do-not-override-1v2lwm6"
     >
       <div
-        class="ant-row ant-form-item-row css-dev-only-do-not-override-nllxry"
+        class="ant-row ant-form-item-row css-dev-only-do-not-override-1v2lwm6"
       >
         <div
-          class="ant-col ant-form-item-label css-dev-only-do-not-override-nllxry"
+          class="ant-col ant-form-item-label css-dev-only-do-not-override-1v2lwm6"
         >
           <label
             class=""
@@ -252,7 +252,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
           </label>
         </div>
         <div
-          class="ant-col ant-form-item-control css-dev-only-do-not-override-nllxry"
+          class="ant-col ant-form-item-control css-dev-only-do-not-override-1v2lwm6"
         >
           <div
             class="ant-form-item-control-input"
@@ -261,7 +261,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
               class="ant-form-item-control-input-content"
             >
               <textarea
-                class="ant-input css-dev-only-do-not-override-nllxry"
+                class="ant-input css-dev-only-do-not-override-1v2lwm6"
                 placeholder="Add description"
                 rows="3"
                 style="max-width: 1200px;"
@@ -275,7 +275,7 @@ exports[`AddCriteriaForCrossCheck should match shapshot 1`] = `
       style="text-align: right;"
     >
       <button
-        class="ant-btn css-dev-only-do-not-override-nllxry ant-btn-primary"
+        class="ant-btn css-dev-only-do-not-override-1v2lwm6 ant-btn-primary"
         disabled=""
         type="button"
       >

--- a/client/src/pages/login/index.tsx
+++ b/client/src/pages/login/index.tsx
@@ -1,12 +1,11 @@
 import { GithubOutlined } from '@ant-design/icons';
 import { Button, Card } from 'antd';
-import dynamic from 'next/dynamic';
 import * as React from 'react';
 import css from 'styled-jsx/css';
 
 const { Meta } = Card;
 
-function LoginPage() {
+export default function LoginPage() {
   return (
     <main>
       <div className="login-form">
@@ -67,9 +66,8 @@ const styles = css`
   }
 
   .login-card-img {
-    width: 100px;
+    width: 100px !important;
+    height: 83.32px;
     margin: 30px auto 20px;
   }
 `;
-
-export default dynamic(async () => LoginPage, { ssr: false });

--- a/client/src/pages/login/index.tsx
+++ b/client/src/pages/login/index.tsx
@@ -1,11 +1,12 @@
 import { GithubOutlined } from '@ant-design/icons';
 import { Button, Card } from 'antd';
+import dynamic from 'next/dynamic';
 import * as React from 'react';
 import css from 'styled-jsx/css';
 
 const { Meta } = Card;
 
-export default function LoginPage() {
+function LoginPage() {
   return (
     <main>
       <div className="login-form">
@@ -70,3 +71,5 @@ const styles = css`
     margin: 30px auto 20px;
   }
 `;
+
+export default dynamic(async () => LoginPage, { ssr: false });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@ant-design/compatible": "5.1.2",
+        "@ant-design/cssinjs": "^1.20.0",
         "@ant-design/plots": "1.2.5",
         "@sentry/nextjs": "7.81.0",
         "antd": "5.11.2",
@@ -345,15 +346,15 @@
       "integrity": "sha512-LrX0OGZtW+W6iLnTAqnTaoIsRelYeuLZWsrmBJFUXDALQphPsN8cE5DCsmoSlL0QYb94BQxINiuS70Ar/8BNgA=="
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.17.2.tgz",
-      "integrity": "sha512-vu7lnfEx4Mf8MPzZxn506Zen3Nt4fRr2uutwvdCuTCN5IiU0lDdQ0tiJ24/rmB8+pefwjluYsbyzbQSbgfJy+A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.20.0.tgz",
+      "integrity": "sha512-uG3iWzJxgNkADdZmc6W0Ci3iQAUOvLMcM8SnnmWq3r6JeocACft4ChnY/YWvI2Y+rG/68QBla/O+udke1yH3vg==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
         "@emotion/unitless": "^0.7.5",
         "classnames": "^2.3.1",
-        "csstype": "^3.0.10",
+        "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
         "stylis": "^4.0.13"
       },
@@ -9590,9 +9591,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/csvtojson": {
       "version": "2.0.10",
@@ -23694,15 +23695,15 @@
       "integrity": "sha512-LrX0OGZtW+W6iLnTAqnTaoIsRelYeuLZWsrmBJFUXDALQphPsN8cE5DCsmoSlL0QYb94BQxINiuS70Ar/8BNgA=="
     },
     "@ant-design/cssinjs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.17.2.tgz",
-      "integrity": "sha512-vu7lnfEx4Mf8MPzZxn506Zen3Nt4fRr2uutwvdCuTCN5IiU0lDdQ0tiJ24/rmB8+pefwjluYsbyzbQSbgfJy+A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.20.0.tgz",
+      "integrity": "sha512-uG3iWzJxgNkADdZmc6W0Ci3iQAUOvLMcM8SnnmWq3r6JeocACft4ChnY/YWvI2Y+rG/68QBla/O+udke1yH3vg==",
       "requires": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
         "@emotion/unitless": "^0.7.5",
         "classnames": "^2.3.1",
-        "csstype": "^3.0.10",
+        "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
         "stylis": "^4.0.13"
       }
@@ -30445,6 +30446,7 @@
       "version": "file:client",
       "requires": {
         "@ant-design/compatible": "5.1.2",
+        "@ant-design/cssinjs": "^1.20.0",
         "@ant-design/plots": "1.2.5",
         "@next/bundle-analyzer": "13.4.3",
         "@playwright/test": "1.37.1",
@@ -31000,9 +31002,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "csvtojson": {
       "version": "2.0.10",


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

https://github.com/rolling-scopes/rsschool-app/issues/2452

#### 💡 Background and solution

This happens because of SSR, we don't need it for this page  
UPD: this is a global problem related with how Antd works with SSR, however, this is a small page that users see first/often, so I think it still worth to fix it at least here
UPD [2]: It seems that there's alternative approach of styles loading without breaking SSR https://ant.design/docs/react/use-with-next#using-pages-router

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
