### PR TITLE
chore: remove auth guard from get request to courses

### DIFF
--- a/nestjs/src/courses/courses.controller.ts
+++ b/nestjs/src/courses/courses.controller.ts
@@ -31,7 +31,6 @@ export class CoursesController {
   @Get('/')
   @ApiOperation({ operationId: 'getCourses' })
   @ApiOkResponse({ type: [CourseDto] })
-  @UseGuards(DefaultGuard)
   public async getCourses() {
     const data = await this.courseService.getAll();
     return data.map(it => new CourseDto(it));


### PR DESCRIPTION
* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [x] Other

#### 🔗 Related issue link

[rs-site-issue#404](https://github.com/rolling-scopes/site/issues/404)

#### 💡 Background and solution

As a part of integration of courses dates with rs-site, auth guard from get request to api/v2/courses was removed.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
