### PR TITLE
fix: pagination for stage interview page

### DIFF
--- a/client/src/pages/course/admin/stage-interviews.tsx
+++ b/client/src/pages/course/admin/stage-interviews.tsx
@@ -60,7 +60,13 @@ function Page() {
       </Row>
 
       <Table
-        pagination={{ pageSize: 50 }}
+        pagination={{
+          defaultPageSize: 50,
+          showSizeChanger: true,
+          showTotal: (total, range) => {
+            return `${range[0]}-${range[1]} of ${total} interviews`;
+          },
+        }}
         size="small"
         rowKey="id"
         dataSource={interviews}

--- a/client/src/pages/course/admin/stage-interviews.tsx
+++ b/client/src/pages/course/admin/stage-interviews.tsx
@@ -63,9 +63,7 @@ function Page() {
         pagination={{
           defaultPageSize: 50,
           showSizeChanger: true,
-          showTotal: (total, range) => {
-            return `${range[0]}-${range[1]} of ${total} interviews`;
-          },
+          showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} interviews`,
         }}
         size="small"
         rowKey="id"


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

- Related Issue #2596
- Closes #2596


#### 💡 Background and solution
BEFORE:
It was not possible to use sizeChanger control with an affect on the page.
sizeChanger control is displayed when items.count >50.

AFTER:
default page size set to ant table pagination,
also displaying of the total items was improved.
So user can change page size and work with interviews page more comfortably.
sizeChanger control is displayed all the time.

![image](https://github.com/user-attachments/assets/b71935c5-f830-41bb-85c2-1b3099b23314)


#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
