### PR TITLE
fix: set proper active course having alias in url

### DIFF
--- a/client/src/modules/Course/contexts/ActiveCourseContext.tsx
+++ b/client/src/modules/Course/contexts/ActiveCourseContext.tsx
@@ -32,21 +32,23 @@ export const ActiveCourseProvider = ({ children }: Props) => {
   const alias = router.query.course;
   const [storageCourseId] = useLocalStorage('activeCourseId');
   const [activeCourse, setActiveCourse] = useState<ProfileCourseDto>();
+  const [loading, setLoading] = useState(true);
 
-  const { error, loading } = useAsync(async () => {
-    if (!coursesCache) {
-      coursesCache = await new UserService().getCourses();
+  const { error } = useAsync(async () => {
+    if (router.isReady) {
+      if (!coursesCache) {
+        coursesCache = await new UserService().getCourses();
+      }
+
+      const course =
+        coursesCache.find(course => course.alias === alias) ??
+        coursesCache.find(course => course.id === storageCourseId) ??
+        coursesCache[0];
+
+      setCourse(course);
+      setLoading(false);
     }
-
-    const course =
-      coursesCache.find(course => course.alias === alias) ??
-      coursesCache.find(course => course.id === storageCourseId) ??
-      coursesCache[0];
-
-    setActiveCourse(course);
-
-    return course;
-  }, []);
+  }, [router.isReady]);
 
   const setCourse = (course: ProfileCourseDto) => {
     setActiveCourse(course);


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

Closes #2595

#### 💡 Background and solution

before the fix
- useAsync called when router was not ready and alias undefined while it was in page URL

after the fix
- fetch data and set active course only when router is ready, so if an alias in the url, it is taken into account.
Also, the proper course is set to localstorage sharing the active course accross the pages

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
