### PR TITLE
fix: make e-mail field in ContactInfo component required

### DIFF
--- a/client/src/modules/Registry/components/Cards/ContactInfo/ContactInfo.test.tsx
+++ b/client/src/modules/Registry/components/Cards/ContactInfo/ContactInfo.test.tsx
@@ -12,9 +12,11 @@ const mockValues = {
   contactsNotes: 'notes',
 };
 
-const renderContactInfo = () =>
+type Values = typeof mockValues | Record<string, unknown>;
+
+const renderContactInfo = (values: Values = mockValues) =>
   render(
-    <Form initialValues={mockValues}>
+    <Form role="form" initialValues={values}>
       <ContactInfo />
     </Form>,
   );
@@ -107,5 +109,16 @@ describe('ContactInfo', () => {
 
     const errorMessage = await screen.findByText(message);
     expect(errorMessage).toBeInTheDocument();
+  });
+
+  test('should render error messages only on required fields', async () => {
+    renderContactInfo({});
+
+    const form = screen.getByRole('form');
+    fireEvent.submit(form);
+
+    const errorEmail = await screen.findByText(ERROR_MESSAGES.email);
+
+    expect(errorEmail).toBeInTheDocument();
   });
 });

--- a/client/src/modules/Registry/components/Cards/ContactInfo/ContactInfo.tsx
+++ b/client/src/modules/Registry/components/Cards/ContactInfo/ContactInfo.tsx
@@ -47,7 +47,7 @@ export function ContactInfo() {
       <Form.Item
         label={LABELS.email}
         name="contactsEmail"
-        rules={[{ pattern: emailPattern, message: ERROR_MESSAGES.email }]}
+        rules={[{ required: true, pattern: emailPattern, message: ERROR_MESSAGES.email }]}
       >
         <Input placeholder={PLACEHOLDERS.email} />
       </Form.Item>


### PR DESCRIPTION
**🟢 Add `deploy` label if you want to deploy this Pull Request to staging environment**

#### 🧑‍⚖️ Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Do not put issue id in title
- Do not put WIP in title. Use [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) functionality
- Consider to add `area:*` label(s)

* [x] I followed naming convention rules

---

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [x] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

N/A

#### 💡 Background and solution

- [x] Made the email field in the Contact Information form (ContactInfo component) required
- [x] Added a test to check for an error when the required field is not filled in on submission

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Database migration is added or not needed
- [x] Documentation is updated/provided or not needed
- [x] Changes are tested locally
