### PR TITLE
Fix: cross-check criteria item type issue

### DIFF
--- a/client/src/modules/CrossCheck/AddCriteriaForCrossCheck.tsx
+++ b/client/src/modules/CrossCheck/AddCriteriaForCrossCheck.tsx
@@ -19,7 +19,6 @@ export const AddCriteriaForCrossCheck = ({ onCreate }: IAddCriteriaForCrossCheck
     setMax(0);
     setMaxPenalty(0);
     setText('');
-    setType('title');
   };
 
   const onSave = () => {

--- a/client/src/modules/CrossCheck/AddCriteriaForCrossCheck.tsx
+++ b/client/src/modules/CrossCheck/AddCriteriaForCrossCheck.tsx
@@ -84,7 +84,7 @@ export const AddCriteriaForCrossCheck = ({ onCreate }: IAddCriteriaForCrossCheck
 
       {type === TaskType.Penalty && (
         <Item label="Add Max Penalty">
-          <InputNumber type="number" value={maxPenalty} step={1} onChange={changeMaxPenalty} />
+          <InputNumber type="number" value={maxPenalty} min={0} step={1} onChange={changeMaxPenalty} />
         </Item>
       )}
 

--- a/client/src/modules/CrossCheck/AddCriteriaForCrossCheck.tsx
+++ b/client/src/modules/CrossCheck/AddCriteriaForCrossCheck.tsx
@@ -78,13 +78,13 @@ export const AddCriteriaForCrossCheck = ({ onCreate }: IAddCriteriaForCrossCheck
 
       {type === TaskType.Subtask && (
         <Item label="Add Max Score">
-          <InputNumber value={max} min={0} step={1} onChange={changeMax} />
+          <InputNumber type="number" value={max} min={0} step={1} onChange={changeMax} />
         </Item>
       )}
 
       {type === TaskType.Penalty && (
         <Item label="Add Max Penalty">
-          <InputNumber value={maxPenalty} step={1} onChange={changeMaxPenalty} />
+          <InputNumber type="number" value={maxPenalty} step={1} onChange={changeMaxPenalty} />
         </Item>
       )}
 


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
https://github.com/rolling-scopes/rsschool-app/issues/2700

**Description**:
Scope of changes:  
1. Fixed unexpected partial change of selected criteria – now type is preserved. It's better than switch to Title type on each item save. Mostly you need to add one title and then multiple subtasks/penalties, constant re-selection of subtask/penalty type is not convenient.
2. Prohibit entering non-numeric values into inputs

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
