### PR TITLE
fix: don't send request to server on criteria upload

### DIFF
--- a/client/src/modules/CrossCheck/UploadCriteriaJSON.tsx
+++ b/client/src/modules/CrossCheck/UploadCriteriaJSON.tsx
@@ -42,7 +42,14 @@ export const UploadCriteriaJSON = ({ onLoad }: IUploadCriteriaJSON) => {
   };
 
   return (
-    <Upload data-testid="uploader" accept=".JSON" onChange={handleChange}>
+    <Upload
+      data-testid="uploader"
+      accept=".JSON"
+      onChange={handleChange}
+      // This is to override default behavior of the uploader (send request to the server)
+      // We don't need it, because we handle file client-side
+      customRequest={(opts) => opts.onSuccess?.(null)}
+    >
       <Button
         icon={<UploadOutlined />}
         title='required format: \n{ criteria: {"type": "string", "max": number, "text": "string"}}'

--- a/client/src/modules/CrossCheck/UploadCriteriaJSON.tsx
+++ b/client/src/modules/CrossCheck/UploadCriteriaJSON.tsx
@@ -48,7 +48,7 @@ export const UploadCriteriaJSON = ({ onLoad }: IUploadCriteriaJSON) => {
       onChange={handleChange}
       // This is to override default behavior of the uploader (send request to the server)
       // We don't need it, because we handle file client-side
-      customRequest={(opts) => opts.onSuccess?.(null)}
+      customRequest={opts => opts.onSuccess?.(null)}
     >
       <Button
         icon={<UploadOutlined />}


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
https://github.com/rolling-scopes/rsschool-app/issues/2699

**Description**:
Root cause of the issue is the default behavior of `Upload` component – it sends file to server with POST request. We don't need it here, because we handle file content client-side using `FileReader` API. Override of default behavior with customRequest fixes issue.

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
