### PR TITLE
fix: add name of completed course to mentor registry invite selector

### DIFF
--- a/client/src/pages/admin/mentor-registry.tsx
+++ b/client/src/pages/admin/mentor-registry.tsx
@@ -140,11 +140,11 @@ function Page() {
 
   const handleModalSubmit = useCallback(
     async (values: FormData) => {
-      const originalData = modalData?.record?.preselectedCourses?.map(String).sort();
-      const updatedData = values.preselectedCourses?.map(String).sort();
+      const originalSortedData = modalData?.record?.preselectedCourses.map(courseId => String(courseId)).sort();
+      const updatedPreselectedCourses = values.preselectedCourses.map(courseId => String(courseId));
+      const updatedSortedData = updatedPreselectedCourses.sort();
 
-      const isSame =
-        originalData?.length === updatedData?.length && originalData.every((value, i) => value === updatedData[i]);
+      const isSame = JSON.stringify(originalSortedData) === JSON.stringify(updatedSortedData);
 
       if (isSame) {
         setModalData(null);
@@ -155,7 +155,7 @@ function Page() {
         setModalLoading(true);
         if (modalData?.record?.githubId) {
           await mentorRegistryService.updateMentor(modalData.record.githubId, {
-            preselectedCourses: values.preselectedCourses.map(v => String(v)),
+            preselectedCourses: updatedPreselectedCourses,
           });
         }
         setModalData(null);
@@ -176,11 +176,11 @@ function Page() {
       return null;
     }
 
-    const allShownCourses = courses.filter(
-      course =>
-        (course.completed && data.preselectedCourses.includes(course.id)) ||
-        (!course.completed && course.personalMentoring),
-    );
+    const allShownCourses = courses.filter(course => {
+      const isCompletedAndPreselected = course.completed && data.preselectedCourses.includes(course.id);
+      const isActiveWithPersonalMentoring = !course.completed && course.personalMentoring;
+      return isCompletedAndPreselected || isActiveWithPersonalMentoring;
+    });
 
     return (
       <ModalForm


### PR DESCRIPTION
**Issue**:
After the merge - #2681 courses, which have been completed, the label displays the course ID instead of the course name.
If we want to remove this course from Pre-Selected, it is inconvenient.

![image](https://github.com/user-attachments/assets/b5aeb23b-56d8-4490-8ba3-00a904b70452)

**Description**:
Now we can read the name of the completed course in the label as well as its modified style and tooltip.
Also, now we don't send a request to the server if the values in the multiselector don't change.
For example, if we delete any course and then add it immediately and click save, or if we delete all courses from the multiselector and add the same ones in a different order.

![image](https://github.com/user-attachments/assets/4bce7a95-b8c1-451a-ae70-4f22fcf2af30)
![image](https://github.com/user-attachments/assets/384e6850-2ae4-4de6-89f0-435218e72ad0)

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
