### PR TITLE
fix: change mentors telegram chat appearing after mentor registration to refer to the correct course

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -13990,6 +13990,39 @@ export const DiscordServersApiAxiosParamCreator = function (configuration?: Conf
         },
         /**
          * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getDiscordServerById: async (id: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('getDiscordServerById', 'id', id)
+            const localVarPath = `/discord-servers/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -14117,6 +14150,16 @@ export const DiscordServersApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getDiscordServerById(id: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getDiscordServerById(id, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -14174,6 +14217,15 @@ export const DiscordServersApiFactory = function (configuration?: Configuration,
         },
         /**
          * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getDiscordServerById(id: number, options?: any): AxiosPromise<string> {
+            return localVarFp.getDiscordServerById(id, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -14228,6 +14280,17 @@ export class DiscordServersApi extends BaseAPI {
      */
     public deleteDiscordServer(id: number, options?: AxiosRequestConfig) {
         return DiscordServersApiFp(this.configuration).deleteDiscordServer(id, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {number} id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DiscordServersApi
+     */
+    public getDiscordServerById(id: number, options?: AxiosRequestConfig) {
+        return DiscordServersApiFp(this.configuration).getDiscordServerById(id, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/client/src/pages/course/mentor/confirm.tsx
+++ b/client/src/pages/course/mentor/confirm.tsx
@@ -1,8 +1,8 @@
 import { Button, Col, Form, message, Result, Row, Typography } from 'antd';
-import { CourseDto as Course } from 'api';
+import { CourseDto as Course, DiscordServersApi } from 'api';
 import { PageLayout, PageLayoutSimple } from 'components/PageLayout';
 import { useRouter } from 'next/router';
-import { useMemo, useState, useContext } from 'react';
+import { useMemo, useState, useContext, useEffect } from 'react';
 import { useAsync } from 'react-use';
 import { CourseService } from 'services/course';
 import { CoursesService } from 'services/courses';
@@ -10,10 +10,17 @@ import { MentorRegistryService, MentorResponse } from 'services/mentorRegistry';
 import { Warning } from 'components/Warning';
 import { MentorOptions } from 'components/MentorOptions';
 import { SessionContext, SessionProvider } from 'modules/Course/contexts';
+import { LoadingScreen } from '@client/components/LoadingScreen';
 
 const { Link } = Typography;
 
+type SuccessComponentProps = {
+  discordServerId: number;
+};
+
 const mentorRegistry = new MentorRegistryService();
+const discordServer = new DiscordServersApi();
+
 function Page() {
   const session = useContext(SessionContext);
   const [form] = Form.useForm();
@@ -149,7 +156,7 @@ function Page() {
   if (success) {
     return (
       <PageLayout {...pageProps}>
-        <SuccessComponent />
+        <SuccessComponent discordServerId={course.discordServerId} />
       </PageLayout>
     );
   }
@@ -165,14 +172,27 @@ function Page() {
   );
 }
 
-const SuccessComponent = () => {
+const SuccessComponent = ({ discordServerId }: SuccessComponentProps) => {
+  const [mentorsChat, setMentorsChat] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const discordServerData = await discordServer.getDiscordServerById(discordServerId);
+      setMentorsChat(discordServerData.data);
+    };
+
+    fetchData();
+  }, [discordServerId]);
+
+  if (!mentorsChat) return <LoadingScreen show={!mentorsChat} />;
+
   const titleCmp = (
     <Row gutter={24} justify="center">
       <Col xs={18} sm={16} md={12}>
         <p>Thanks for the confirmation!</p>
         <p>You are mentor now!</p>
         <Typography.Paragraph type="secondary">
-          Join our <a href="https://t.me/joinchat/HqpGRxNRANkGN2xx9bL8zQ">RSSchool Mentors FAQ</a> Telegram group.
+          Join our <a href={mentorsChat}>RSSchool Mentors FAQ</a> Telegram group.
         </Typography.Paragraph>
         <p>
           <Button type="primary" size="large" href="/">

--- a/nestjs/src/discord-servers/discord-servers.controller.ts
+++ b/nestjs/src/discord-servers/discord-servers.controller.ts
@@ -38,6 +38,15 @@ export class DiscordServersController {
     return items.map(item => new IdNameDto(item));
   }
 
+  @Get(':id')
+  @RequiredRoles([Role.Admin, CourseRole.Mentor])
+  @ApiOperation({ operationId: 'getDiscordServerById' })
+  @ApiOkResponse({ type: String })
+  public async getById(@Param('id', ParseIntPipe) id: number) {
+    const item = await this.service.getById(id);
+    return item?.mentorsChatUrl;
+  }
+
   @Put(':id')
   @RequiredRoles([Role.Admin])
   @ApiOperation({ operationId: 'updateDiscordServer' })

--- a/nestjs/src/discord-servers/discord-servers.service.ts
+++ b/nestjs/src/discord-servers/discord-servers.service.ts
@@ -15,6 +15,10 @@ export class DiscordServersService {
     return this.repository.find();
   }
 
+  public async getById(id: number) {
+    return this.repository.findOneBy({ id });
+  }
+
   public create(data: CreateDiscordServerDto) {
     return this.repository.save(data);
   }

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -2147,25 +2147,16 @@
         "tags": ["discord-servers"]
       }
     },
-    "/discord-servers/reduced": {
+    "/discord-servers/{id}": {
       "get": {
-        "operationId": "getReducedDiscordServers",
-        "parameters": [],
+        "operationId": "getDiscordServerById",
+        "parameters": [{ "name": "id", "required": true, "in": "path", "schema": { "type": "number" } }],
         "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/IdNameDto" } }
-              }
-            }
-          }
+          "200": { "description": "", "content": { "application/json": { "schema": { "type": "string" } } } }
         },
         "summary": "",
         "tags": ["discord-servers"]
-      }
-    },
-    "/discord-servers/{id}": {
+      },
       "put": {
         "operationId": "updateDiscordServer",
         "parameters": [{ "name": "id", "required": true, "in": "path", "schema": { "type": "number" } }],
@@ -2189,6 +2180,24 @@
           "200": {
             "description": "",
             "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DiscordServerDto" } } }
+          }
+        },
+        "summary": "",
+        "tags": ["discord-servers"]
+      }
+    },
+    "/discord-servers/reduced": {
+      "get": {
+        "operationId": "getReducedDiscordServers",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/IdNameDto" } }
+              }
+            }
           }
         },
         "summary": "",


### PR DESCRIPTION
**Issue**:
Issue - #2737

**Description**:
After the second step, the mentor can access the right course FAQ chat link. 

![image](https://github.com/user-attachments/assets/165a4d3c-01ef-4b24-a5a1-d58e53c6a40e)
![image](https://github.com/user-attachments/assets/f4bed341-e7df-4347-81e4-4441900e3aca)
![image](https://github.com/user-attachments/assets/078f5f17-f6f3-496a-8ff2-5f983e84279f)


**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
