### PR TITLE
fix: cross-check criteria rows can only be triggered via the dragHandle

### DIFF
--- a/client/src/modules/CrossCheck/EditableTableForCrossCheck.tsx
+++ b/client/src/modules/CrossCheck/EditableTableForCrossCheck.tsx
@@ -10,6 +10,7 @@ import { CriteriaActions } from './CriteriaActions';
 import { EditableTableColumnsDataIndex } from './constants';
 import { DragSortTable } from './components/DragSortTable';
 import { arrayMoveImmutable } from './utils/arrayMoveImmutable';
+import { DragHandle } from './components/DragHandle';
 
 interface IEditableTableProps {
   dataCriteria: CriteriaDto[];
@@ -71,23 +72,15 @@ export const EditableTable = ({ dataCriteria, setDataCriteria }: IEditableTableP
 
   const columns = [
     {
-      title: 'Type',
-      dataIndex: EditableTableColumnsDataIndex.Type,
-      width: '18%',
-      editable: true,
+      title: '⇅',
+      dataIndex: 'drag',
+      width: 40,
+      align: 'center' as const,
+      render: (_: any, record: CriteriaDto) => <DragHandle id={record.key} />,
     },
-    {
-      title: 'Max',
-      dataIndex: EditableTableColumnsDataIndex.Max,
-      width: '10%',
-      editable: true,
-    },
-    {
-      title: 'Text',
-      dataIndex: EditableTableColumnsDataIndex.Text,
-      width: '52%',
-      editable: true,
-    },
+    { title: 'Type', dataIndex: EditableTableColumnsDataIndex.Type, width: '18%', editable: true },
+    { title: 'Max', dataIndex: EditableTableColumnsDataIndex.Max, width: '10%', editable: true },
+    { title: 'Text', dataIndex: EditableTableColumnsDataIndex.Text, width: '52%', editable: true },
     {
       title: 'Actions',
       dataIndex: EditableTableColumnsDataIndex.Actions,
@@ -129,11 +122,7 @@ export const EditableTable = ({ dataCriteria, setDataCriteria }: IEditableTableP
         <SortableContext items={dataCriteria.map(i => i.key)} strategy={verticalListSortingStrategy}>
           <DragSortTable
             rowKey="key"
-            components={{
-              body: {
-                cell: EditableCellForCrossCheck,
-              },
-            }}
+            components={{ body: { cell: EditableCellForCrossCheck } }}
             style={{ wordBreak: 'break-word', fontStyle: 'normal' }}
             size="small"
             dataSource={dataCriteria}

--- a/client/src/modules/CrossCheck/components/DragHandle.tsx
+++ b/client/src/modules/CrossCheck/components/DragHandle.tsx
@@ -1,0 +1,27 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { MenuOutlined } from '@ant-design/icons';
+
+import css from 'styled-jsx/css';
+import { Button } from 'antd';
+
+export const DragHandle = ({ id }: { id: string }) => {
+  const { attributes, listeners, setActivatorNodeRef } = useSortable({ id });
+
+  return (
+    <>
+      <span ref={setActivatorNodeRef} {...attributes} {...listeners}>
+        <Button className={`drag-handle ${dragDrop}`} type="text" icon={<MenuOutlined />} />
+      </span>
+      {buttonStyles}
+    </>
+  );
+};
+
+const { className: dragDrop, styles: buttonStyles } = css.resolve`
+  .drag-handle {
+    cursor: grab;
+  }
+  .drag-handle:active {
+    cursor: grabbing;
+  }
+`;

--- a/client/src/modules/CrossCheck/components/DragSortTable.tsx
+++ b/client/src/modules/CrossCheck/components/DragSortTable.tsx
@@ -9,20 +9,17 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
 }
 
 const DragSortTableRow = ({ children, ...props }: RowProps) => {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: props['data-row-key'],
-  });
+  const { attributes, setNodeRef, transform, transition, isDragging } = useSortable({ id: props['data-row-key'] });
 
   const style: React.CSSProperties = {
     ...props.style,
     transform: CSS.Transform.toString(transform),
     transition,
-    cursor: 'move',
     ...(isDragging ? { position: 'relative', zIndex: 9999 } : {}),
   };
 
   return (
-    <tr {...props} ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <tr {...props} ref={setNodeRef} style={style} {...attributes}>
       {children}
     </tr>
   );
@@ -32,13 +29,7 @@ export const DragSortTable = <T extends object>(props: TableProps<T>) => {
   return (
     <Table
       {...props}
-      components={{
-        ...props.components,
-        body: {
-          ...props.components?.body,
-          row: DragSortTableRow,
-        },
-      }}
+      components={{ ...props.components, body: { ...props.components?.body, row: DragSortTableRow } }}
     />
   );
 };


### PR DESCRIPTION
**Issue**:
Issue - #2746 

**Description**:
Global cross-check criteria row dragging has been disabled. Drag-and-drop can now only be triggered via the DragHandle.

![image](https://github.com/user-attachments/assets/da45fa76-bfe1-42df-a99f-37ca17adada7)

https://github.com/user-attachments/assets/e89d3947-ad14-4b9e-a9ff-6c3cd34629f2

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
