### PR TITLE
fix: change telegram link on the mentor's dashboard page

### DIFF
--- a/client/src/modules/Mentor/components/Instructions/Instructions.tsx
+++ b/client/src/modules/Mentor/components/Instructions/Instructions.tsx
@@ -1,12 +1,42 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Badge, Card, Col, Row, Space, Typography } from 'antd';
 import { INSTRUCTIONS_TEXT, renderDescription, renderSocialLinks } from '.';
+import { DiscordServersApi } from 'api';
+
+interface InstructionsProps {
+  discordServerId: number;
+}
 
 const { Meta, Grid } = Card;
 const { Text } = Typography;
 
-function Instructions() {
-  const { title, description, steps } = INSTRUCTIONS_TEXT;
+const discordServer = new DiscordServersApi();
+
+function Instructions({ discordServerId }: InstructionsProps) {
+  const { title, description } = INSTRUCTIONS_TEXT;
+  const [steps, setSteps] = useState(INSTRUCTIONS_TEXT.steps);
+
+  useEffect(() => {
+    if (!discordServerId) return;
+
+    async function fetchTelegramLink() {
+      const discordServerData = await discordServer.getDiscordServerById(discordServerId);
+
+      const updatedSteps = steps.map(step => {
+        if (!step.links) return step;
+
+        const updatedLinks = step.links.map(link =>
+          link.title === 'telegram' ? { ...link, url: discordServerData.data } : link,
+        );
+
+        return { ...step, links: updatedLinks };
+      });
+
+      setSteps(updatedSteps);
+    }
+
+    fetchTelegramLink();
+  }, []);
 
   return (
     <Card bordered={false}>

--- a/client/src/modules/Mentor/components/Instructions/Instructions.tsx
+++ b/client/src/modules/Mentor/components/Instructions/Instructions.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Badge, Card, Col, Row, Space, Typography } from 'antd';
 import { INSTRUCTIONS_TEXT, renderDescription, renderSocialLinks } from '.';
 import { DiscordServersApi } from 'api';
+import { useAsyncEffect } from 'ahooks';
 
 interface InstructionsProps {
   discordServerId: number;
@@ -16,27 +17,23 @@ function Instructions({ discordServerId }: InstructionsProps) {
   const { title, description } = INSTRUCTIONS_TEXT;
   const [steps, setSteps] = useState(INSTRUCTIONS_TEXT.steps);
 
-  useEffect(() => {
+  useAsyncEffect(async () => {
     if (!discordServerId) return;
 
-    const updateTelegramLink = async () => {
-      const response = await discordServer.getDiscordServerById(discordServerId);
-      const telegramInviteURL = response.data;
+    const response = await discordServer.getInviteLinkByDiscordServerId(discordServerId);
+    const telegramInviteURL = response.data;
 
-      const updatedSteps = steps.map(step => {
-        if (!step.links) return step;
+    const updatedSteps = steps.map(step => {
+      if (!step.links) return step;
 
-        const updatedLinks = step.links.map(link =>
-          link.title === 'telegram' ? { ...link, url: telegramInviteURL } : link,
-        );
+      const updatedLinks = step.links.map(link =>
+        link.title === 'telegram' ? { ...link, url: telegramInviteURL } : link,
+      );
 
-        return { ...step, links: updatedLinks };
-      });
+      return { ...step, links: updatedLinks };
+    });
 
-      setSteps(updatedSteps);
-    };
-
-    updateTelegramLink();
+    setSteps(updatedSteps);
   }, []);
 
   return (

--- a/client/src/modules/Mentor/components/Instructions/Instructions.tsx
+++ b/client/src/modules/Mentor/components/Instructions/Instructions.tsx
@@ -19,23 +19,24 @@ function Instructions({ discordServerId }: InstructionsProps) {
   useEffect(() => {
     if (!discordServerId) return;
 
-    async function fetchTelegramLink() {
-      const discordServerData = await discordServer.getDiscordServerById(discordServerId);
+    const updateTelegramLink = async () => {
+      const response = await discordServer.getDiscordServerById(discordServerId);
+      const telegramInviteURL = response.data;
 
       const updatedSteps = steps.map(step => {
         if (!step.links) return step;
 
         const updatedLinks = step.links.map(link =>
-          link.title === 'telegram' ? { ...link, url: discordServerData.data } : link,
+          link.title === 'telegram' ? { ...link, url: telegramInviteURL } : link,
         );
 
         return { ...step, links: updatedLinks };
       });
 
       setSteps(updatedSteps);
-    }
+    };
 
-    fetchTelegramLink();
+    updateTelegramLink();
   }, []);
 
   return (

--- a/client/src/modules/Mentor/components/Instructions/constants.ts
+++ b/client/src/modules/Mentor/components/Instructions/constants.ts
@@ -9,7 +9,7 @@ export const INSTRUCTIONS_TEXT = {
         { title: 'github', url: 'https://github.com/rolling-scopes/rsschool-app' },
         { title: 'discord', url: 'https://discord.com/invite/PRADsJB' },
         { title: 'linkedin', url: 'https://www.linkedin.com/company/the-rolling-scopes-school/' },
-        { title: 'telegram', url: 'https://t.me/joinchat/HqpGRxNRANkGN2xx9bL8zQ' },
+        { title: 'telegram', url: '' },
       ],
     },
     {

--- a/client/src/modules/Mentor/components/Instructions/renderers.tsx
+++ b/client/src/modules/Mentor/components/Instructions/renderers.tsx
@@ -21,22 +21,24 @@ const getSocialLinkIcon = (title: string) => {
 
 export const renderSocialLinks = (links: Record<'title' | 'url', string>[]) => (
   <Space size="middle" style={{ width: '100%', justifyContent: 'center' }}>
-    {links.map(link => (
-      <Link key={link.title} href={link.url} target="_blank">
-        {getSocialLinkIcon(link.title)}
-      </Link>
-    ))}
+    {links.map(link =>
+      link.url ? (
+        <Link key={link.title} href={link.url} target="_blank">
+          {getSocialLinkIcon(link.title)}
+        </Link>
+      ) : (
+        <span key={link.title} style={{ cursor: 'not-allowed', opacity: 0.5 }}>
+          {getSocialLinkIcon(link.title)}
+        </span>
+      ),
+    )}
   </Space>
 );
 
 export const renderDescription = (text: string) => {
   return (
     <Text>
-      <div
-        dangerouslySetInnerHTML={{
-          __html: text,
-        }}
-      ></div>
+      <div dangerouslySetInnerHTML={{ __html: text }}></div>
     </Text>
   );
 };

--- a/client/src/modules/Mentor/components/Instructions/renderers.tsx
+++ b/client/src/modules/Mentor/components/Instructions/renderers.tsx
@@ -38,7 +38,11 @@ export const renderSocialLinks = (links: Record<'title' | 'url', string>[]) => (
 export const renderDescription = (text: string) => {
   return (
     <Text>
-      <div dangerouslySetInnerHTML={{ __html: text }}></div>
+      <div
+        dangerouslySetInnerHTML={{
+          __html: text,
+        }}
+      />
     </Text>
   );
 };

--- a/client/src/modules/Mentor/components/MentorDashboard/MentorDashboard.tsx
+++ b/client/src/modules/Mentor/components/MentorDashboard/MentorDashboard.tsx
@@ -7,7 +7,7 @@ import { useMentorDashboard } from 'modules/Mentor/hooks/useMentorDashboard';
 function MentorDashboard() {
   const { courses } = useContext(SessionContext);
   const { course } = useActiveCourseContext();
-  const { id: courseId } = course;
+  const { id: courseId, discordServerId } = course;
   const mentorId = courses?.[courseId]?.mentorId as number;
 
   const [data, loading, run] = useMentorDashboard(mentorId, courseId);
@@ -18,7 +18,7 @@ function MentorDashboard() {
       {data?.length ? (
         <TaskSolutionsTable data={data} loading={loading} onChange={run} mentorId={mentorId} courseId={courseId} />
       ) : (
-        <Instructions />
+        <Instructions discordServerId={discordServerId} />
       )}
     </PageLayout>
   );


### PR DESCRIPTION
For megre after: #2750

**Issue**:
#2737 

**Description**:
Now you can access the right course FAQ telegram chat link on the mentor's dashboard page.

![image](https://github.com/user-attachments/assets/591a40c7-048a-4355-9240-b3ae82b7d3aa)


**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
