### PR TITLE
fix: rename getDiscordServerById endpoint to getInviteLinkByDiscordServerId with URL invite/:id

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -13990,15 +13990,11 @@ export const DiscordServersApiAxiosParamCreator = function (configuration?: Conf
         },
         /**
          * 
-         * @param {number} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getDiscordServerById: async (id: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getDiscordServerById', 'id', id)
-            const localVarPath = `/discord-servers/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+        getDiscordServers: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/discord-servers`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -14023,11 +14019,15 @@ export const DiscordServersApiAxiosParamCreator = function (configuration?: Conf
         },
         /**
          * 
+         * @param {number} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getDiscordServers: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/discord-servers`;
+        getInviteLinkByDiscordServerId: async (id: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('getInviteLinkByDiscordServerId', 'id', id)
+            const localVarPath = `/discord-servers/invite/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -14150,21 +14150,21 @@ export const DiscordServersApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {number} id 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getDiscordServerById(id: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getDiscordServerById(id, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-        /**
-         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async getDiscordServers(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<DiscordServerDto>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getDiscordServers(options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getInviteLinkByDiscordServerId(id: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInviteLinkByDiscordServerId(id, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -14217,20 +14217,20 @@ export const DiscordServersApiFactory = function (configuration?: Configuration,
         },
         /**
          * 
-         * @param {number} id 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getDiscordServerById(id: number, options?: any): AxiosPromise<string> {
-            return localVarFp.getDiscordServerById(id, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         getDiscordServers(options?: any): AxiosPromise<Array<DiscordServerDto>> {
             return localVarFp.getDiscordServers(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getInviteLinkByDiscordServerId(id: number, options?: any): AxiosPromise<string> {
+            return localVarFp.getInviteLinkByDiscordServerId(id, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -14284,23 +14284,23 @@ export class DiscordServersApi extends BaseAPI {
 
     /**
      * 
-     * @param {number} id 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DiscordServersApi
-     */
-    public getDiscordServerById(id: number, options?: AxiosRequestConfig) {
-        return DiscordServersApiFp(this.configuration).getDiscordServerById(id, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DiscordServersApi
      */
     public getDiscordServers(options?: AxiosRequestConfig) {
         return DiscordServersApiFp(this.configuration).getDiscordServers(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {number} id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DiscordServersApi
+     */
+    public getInviteLinkByDiscordServerId(id: number, options?: AxiosRequestConfig) {
+        return DiscordServersApiFp(this.configuration).getInviteLinkByDiscordServerId(id, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/client/src/pages/course/mentor/confirm.tsx
+++ b/client/src/pages/course/mentor/confirm.tsx
@@ -177,8 +177,8 @@ const SuccessComponent = ({ discordServerId }: SuccessComponentProps) => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const discordServerData = await discordServer.getDiscordServerById(discordServerId);
-      setMentorsChat(discordServerData.data);
+      const telegramInviteLinkResponse = await discordServer.getInviteLinkByDiscordServerId(discordServerId);
+      setMentorsChat(telegramInviteLinkResponse.data);
     };
 
     fetchData();

--- a/nestjs/src/discord-servers/discord-servers.controller.ts
+++ b/nestjs/src/discord-servers/discord-servers.controller.ts
@@ -38,9 +38,9 @@ export class DiscordServersController {
     return items.map(item => new IdNameDto(item));
   }
 
-  @Get(':id')
+  @Get('invite/:id')
   @RequiredRoles([Role.Admin, CourseRole.Mentor])
-  @ApiOperation({ operationId: 'getDiscordServerById' })
+  @ApiOperation({ operationId: 'getInviteLinkByDiscordServerId' })
   @ApiOkResponse({ type: String })
   public async getById(@Param('id', ParseIntPipe) id: number) {
     const item = await this.service.getById(id);

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -2147,16 +2147,36 @@
         "tags": ["discord-servers"]
       }
     },
-    "/discord-servers/{id}": {
+    "/discord-servers/reduced": {
       "get": {
-        "operationId": "getDiscordServerById",
+        "operationId": "getReducedDiscordServers",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/IdNameDto" } }
+              }
+            }
+          }
+        },
+        "summary": "",
+        "tags": ["discord-servers"]
+      }
+    },
+    "/discord-servers/invite/{id}": {
+      "get": {
+        "operationId": "getInviteLinkByDiscordServerId",
         "parameters": [{ "name": "id", "required": true, "in": "path", "schema": { "type": "number" } }],
         "responses": {
           "200": { "description": "", "content": { "application/json": { "schema": { "type": "string" } } } }
         },
         "summary": "",
         "tags": ["discord-servers"]
-      },
+      }
+    },
+    "/discord-servers/{id}": {
       "put": {
         "operationId": "updateDiscordServer",
         "parameters": [{ "name": "id", "required": true, "in": "path", "schema": { "type": "number" } }],
@@ -2180,24 +2200,6 @@
           "200": {
             "description": "",
             "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DiscordServerDto" } } }
-          }
-        },
-        "summary": "",
-        "tags": ["discord-servers"]
-      }
-    },
-    "/discord-servers/reduced": {
-      "get": {
-        "operationId": "getReducedDiscordServers",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/IdNameDto" } }
-              }
-            }
           }
         },
         "summary": "",


### PR DESCRIPTION

**Issue**:
The getDiscordServerById endpoint should be renamed for better readability and understanding of the code.

**Description**:
Rename endpoint and update api for the frontend.

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
