### PR TITLE
fix: change access for the mentors chat link for course mentor only

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -8758,6 +8758,39 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
+         * @param {number} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        clearAuthUserSessionCache: async (userId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('clearAuthUserSessionCache', 'userId', userId)
+            const localVarPath = `/auth/cache/{userId}`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -8865,6 +8898,16 @@ export const AuthApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {number} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async clearAuthUserSessionCache(userId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.clearAuthUserSessionCache(userId, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -8911,6 +8954,15 @@ export const AuthApiFactory = function (configuration?: Configuration, basePath?
         },
         /**
          * 
+         * @param {number} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        clearAuthUserSessionCache(userId: number, options?: any): AxiosPromise<void> {
+            return localVarFp.clearAuthUserSessionCache(userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -8952,6 +9004,17 @@ export class AuthApi extends BaseAPI {
      */
     public authControllerCreateConnectLinkViaGithub(authConnectionDto: AuthConnectionDto, options?: AxiosRequestConfig) {
         return AuthApiFp(this.configuration).authControllerCreateConnectLinkViaGithub(authConnectionDto, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {number} userId 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthApi
+     */
+    public clearAuthUserSessionCache(userId: number, options?: AxiosRequestConfig) {
+        return AuthApiFp(this.configuration).clearAuthUserSessionCache(userId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -14019,14 +14082,18 @@ export const DiscordServersApiAxiosParamCreator = function (configuration?: Conf
         },
         /**
          * 
+         * @param {number} courseId 
          * @param {number} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInviteLinkByDiscordServerId: async (id: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInviteLinkByDiscordServerId: async (courseId: number, id: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'courseId' is not null or undefined
+            assertParamExists('getInviteLinkByDiscordServerId', 'courseId', courseId)
             // verify required parameter 'id' is not null or undefined
             assertParamExists('getInviteLinkByDiscordServerId', 'id', id)
-            const localVarPath = `/discord-servers/invite/{id}`
+            const localVarPath = `/discord-servers/{courseId}/invite/{id}`
+                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)))
                 .replace(`{${"id"}}`, encodeURIComponent(String(id)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -14159,12 +14226,13 @@ export const DiscordServersApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {number} courseId 
          * @param {number} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getInviteLinkByDiscordServerId(id: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInviteLinkByDiscordServerId(id, options);
+        async getInviteLinkByDiscordServerId(courseId: number, id: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInviteLinkByDiscordServerId(courseId, id, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -14225,12 +14293,13 @@ export const DiscordServersApiFactory = function (configuration?: Configuration,
         },
         /**
          * 
+         * @param {number} courseId 
          * @param {number} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInviteLinkByDiscordServerId(id: number, options?: any): AxiosPromise<string> {
-            return localVarFp.getInviteLinkByDiscordServerId(id, options).then((request) => request(axios, basePath));
+        getInviteLinkByDiscordServerId(courseId: number, id: number, options?: any): AxiosPromise<string> {
+            return localVarFp.getInviteLinkByDiscordServerId(courseId, id, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -14294,13 +14363,14 @@ export class DiscordServersApi extends BaseAPI {
 
     /**
      * 
+     * @param {number} courseId 
      * @param {number} id 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DiscordServersApi
      */
-    public getInviteLinkByDiscordServerId(id: number, options?: AxiosRequestConfig) {
-        return DiscordServersApiFp(this.configuration).getInviteLinkByDiscordServerId(id, options).then((request) => request(this.axios, this.basePath));
+    public getInviteLinkByDiscordServerId(courseId: number, id: number, options?: AxiosRequestConfig) {
+        return DiscordServersApiFp(this.configuration).getInviteLinkByDiscordServerId(courseId, id, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/client/src/modules/Mentor/components/Instructions/Instructions.tsx
+++ b/client/src/modules/Mentor/components/Instructions/Instructions.tsx
@@ -5,6 +5,7 @@ import { DiscordServersApi } from 'api';
 import { useAsyncEffect } from 'ahooks';
 
 interface InstructionsProps {
+  courseId: number;
   discordServerId: number;
 }
 
@@ -13,14 +14,14 @@ const { Text } = Typography;
 
 const discordServer = new DiscordServersApi();
 
-function Instructions({ discordServerId }: InstructionsProps) {
+function Instructions({ courseId, discordServerId }: InstructionsProps) {
   const { title, description } = INSTRUCTIONS_TEXT;
   const [steps, setSteps] = useState(INSTRUCTIONS_TEXT.steps);
 
   useAsyncEffect(async () => {
     if (!discordServerId) return;
 
-    const response = await discordServer.getInviteLinkByDiscordServerId(discordServerId);
+    const response = await discordServer.getInviteLinkByDiscordServerId(courseId, discordServerId);
     const telegramInviteURL = response.data;
 
     const updatedSteps = steps.map(step => {

--- a/client/src/modules/Mentor/components/MentorDashboard/MentorDashboard.tsx
+++ b/client/src/modules/Mentor/components/MentorDashboard/MentorDashboard.tsx
@@ -18,7 +18,7 @@ function MentorDashboard() {
       {data?.length ? (
         <TaskSolutionsTable data={data} loading={loading} onChange={run} mentorId={mentorId} courseId={courseId} />
       ) : (
-        <Instructions discordServerId={discordServerId} />
+        <Instructions courseId={courseId} discordServerId={discordServerId} />
       )}
     </PageLayout>
   );

--- a/nestjs/src/auth/auth.controller.ts
+++ b/nestjs/src/auth/auth.controller.ts
@@ -1,4 +1,17 @@
-import { Body, Controller, Get, Logger, Post, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
@@ -77,5 +90,13 @@ export class AuthController {
     return {
       link,
     };
+  }
+
+  @Delete('cache/:userId')
+  @ApiOperation({ operationId: 'clearAuthUserSessionCache' })
+  @UseGuards(DefaultGuard)
+  async clearAuthUserSessionCache(@Param('userId', ParseIntPipe) userId: number, @Req() req: CurrentRequest) {
+    if (req.user.id !== userId) throw new ForbiddenException();
+    await this.authService.clearAuthUserSessionCache(userId);
   }
 }

--- a/nestjs/src/auth/auth.service.ts
+++ b/nestjs/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { LoginData, LoginState } from '@entities/loginState';
 import { User } from '@entities/user';
 import { HttpService } from '@nestjs/axios';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { Request } from 'express';
 import { customAlphabet } from 'nanoid/async';
@@ -16,6 +16,7 @@ import { lastValueFrom } from 'rxjs';
 import * as dayjs from 'dayjs';
 import { NotificationUserConnection } from '@entities/notificationUserConnection';
 import { CourseUser } from '@entities/courseUser';
+import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 
 const nanoid = customAlphabet('1234567890abcdef', 10);
 
@@ -53,6 +54,7 @@ export class AuthService {
     @InjectRepository(NotificationUserConnection)
     private notificationUserConnectionRepository: Repository<NotificationUserConnection>,
     private httpService: HttpService,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {
     this.admins = configService.users.admins;
     this.hirers = configService.users.hirers;
@@ -231,5 +233,10 @@ export class AuthService {
       mentors: result.mentors ?? [],
       courseUsers: result.courseUsers ?? [],
     };
+  }
+
+  public async clearAuthUserSessionCache(userId: number) {
+    const cacheKey = `auth-user-${userId}`;
+    await this.cacheManager.del(cacheKey);
   }
 }

--- a/nestjs/src/discord-servers/discord-servers.controller.ts
+++ b/nestjs/src/discord-servers/discord-servers.controller.ts
@@ -38,11 +38,14 @@ export class DiscordServersController {
     return items.map(item => new IdNameDto(item));
   }
 
-  @Get('invite/:id')
-  @RequiredRoles([Role.Admin, CourseRole.Mentor])
+  @Get(':courseId/invite/:id')
+  @RequiredRoles([Role.Admin, CourseRole.Mentor], true)
   @ApiOperation({ operationId: 'getInviteLinkByDiscordServerId' })
   @ApiOkResponse({ type: String })
-  public async getInviteLinkById(@Param('id', ParseIntPipe) id: number) {
+  public async getInviteLinkById(
+    @Param('courseId', ParseIntPipe) _courseId: number,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
     const item = await this.service.getById(id);
     return item?.mentorsChatUrl;
   }

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -1803,6 +1803,15 @@
         "tags": ["auth"]
       }
     },
+    "/auth/cache/{userId}": {
+      "delete": {
+        "operationId": "clearAuthUserSessionCache",
+        "parameters": [{ "name": "userId", "required": true, "in": "path", "schema": { "type": "number" } }],
+        "responses": { "200": { "description": "" } },
+        "summary": "",
+        "tags": ["auth"]
+      }
+    },
     "/profile/{username}/courses": {
       "get": {
         "operationId": "getUserCourses",
@@ -2165,10 +2174,13 @@
         "tags": ["discord-servers"]
       }
     },
-    "/discord-servers/invite/{id}": {
+    "/discord-servers/{courseId}/invite/{id}": {
       "get": {
         "operationId": "getInviteLinkByDiscordServerId",
-        "parameters": [{ "name": "id", "required": true, "in": "path", "schema": { "type": "number" } }],
+        "parameters": [
+          { "name": "courseId", "required": true, "in": "path", "schema": { "type": "number" } },
+          { "name": "id", "required": true, "in": "path", "schema": { "type": "number" } }
+        ],
         "responses": {
           "200": { "description": "", "content": { "application/json": { "schema": { "type": "string" } } } }
         },


### PR DESCRIPTION
Merge only after #2756!

**Issue**:
A mentor can have access to the FAQ chats of all disciplines.

**Description**:
Now, a mentor can only access the FAQ chat course discipline.

<img width="1906" height="1027" alt="image" src="https://github.com/user-attachments/assets/7894aa51-f0a5-4459-a34c-f1e6299476a2" />
<img width="1132" height="468" alt="image" src="https://github.com/user-attachments/assets/fe9c33af-6136-47d8-be27-7d110016585c" />
<img width="1918" height="667" alt="image" src="https://github.com/user-attachments/assets/4c5309ea-774a-435b-ae76-0e41877d482c" />

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
