### PR TITLE
fix: renovate ignore path option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base"],
-  "ignorePaths": ["tools/**", "server/**"],
+  "ignorePaths": ["/tools/bumblebee/**", "/server/**"],
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
   "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
N/A

**Description**:
`tools/**` were ingored, but renovate kept creating PRs for `tools/bumblebee`. Root cause of the issue is how renovate handles paths in `ignorePaths` option: it uses `.gitignore`-like syntax and in order to explicitly ask it to look at the root of the project, we should use `/tools/**` instead of `tools/**`.
Bumblebee is dead, but IMO renovate PRs for other `tools` are useful, so I set it to explicitly ignore only Bumblebee tool.

**Self-Check**:

- [ ] Database migration added (if required)
- [ ] Changes tested locally
