### PR TITLE
fix: change tooltip placement on the auto test task page

### DIFF
--- a/client/src/modules/AutoTest/components/VerificationInformation/VerificationInformation.tsx
+++ b/client/src/modules/AutoTest/components/VerificationInformation/VerificationInformation.tsx
@@ -63,7 +63,7 @@ function VerificationInformation({
               </Button>
               {isSelfEducationTask && (
                 <Tooltip
-                  placement="top"
+                  placement="topRight"
                   title={allowCheckAnswers ? '' : 'Will be available after the deadline and at least 1 attempt'}
                 >
                   <Button disabled={!allowCheckAnswers} onClick={showAnswers}>


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
Tooltip rerender on the auto-test task page.

https://github.com/user-attachments/assets/f67f4993-74fd-47a5-9997-18ecd583aee4

**Description**:
Now the tooltip is working correctly.


https://github.com/user-attachments/assets/68cc83d9-9fc4-4e65-9900-22a871e72ef2

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
