### PR TITLE
FIX: wrong colors for cross-check detailed view

### DIFF
--- a/client/src/modules/CrossCheck/components/criteria/CrossCheckCriteria.tsx
+++ b/client/src/modules/CrossCheck/components/criteria/CrossCheckCriteria.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { theme, Typography } from 'antd';
 import { CrossCheckCriteriaDataDto } from 'api';
 import { getCriteriaStatusColor } from 'modules/CrossCheck';
 import { TaskType } from '../../constants';
@@ -15,24 +15,31 @@ export function CrossCheckCriteria({ criteria }: Props) {
     criteriaItem => criteriaItem.type.toLocaleLowerCase() === TaskType.Penalty && criteriaItem.point,
   );
 
+  const { token } = theme.useToken();
+
   return (
     <>
       {criteria
         .filter(criteriaItem => criteriaItem.type.toLocaleLowerCase() === TaskType.Subtask)
         .map(criteriaItem => {
-          const backgroundColor = getCriteriaStatusColor(criteriaItem.point ?? 0, criteriaItem.max);
+          const colorToken = getCriteriaStatusColor(criteriaItem.point ?? 0, criteriaItem.max);
 
           return (
             <div
               key={criteriaItem.key}
-              style={{ border: '1px solid #F5F5F5', margin: '24px 0', paddingBottom: '14px', backgroundColor }}
+              style={{
+                border: `1px solid ${token.colorBorder}`,
+                margin: '24px 0',
+                paddingBottom: '14px',
+                backgroundColor: token[colorToken],
+              }}
             >
               <div
                 style={{
                   display: 'block',
                   fontSize: '14px',
-                  background: '#FAFAFA',
-                  borderBottom: '1px solid #F5F5F5',
+                  background: token.colorBgLayout,
+                  borderBottom: `1px solid ${token.colorBorder}`,
                   padding: '14px 12px',
                   marginBottom: '14px',
                 }}

--- a/client/src/modules/CrossCheck/components/criteria/SubtaskCriteria.tsx
+++ b/client/src/modules/CrossCheck/components/criteria/SubtaskCriteria.tsx
@@ -42,7 +42,7 @@ export function SubtaskCriteria({ subtaskData, updateCriteriaData }: SubtaskCrit
     <div style={{ border: `1px solid ${token.colorBorder}`, margin: '24px 0', background: token[colorToken] }}>
       <div
         style={{
-          borderBottom: '1px solid #F5F5F5',
+          borderBottom: `1px solid ${token.colorBorder}`,
           padding: '14px 12px',
         }}
       >


### PR DESCRIPTION
**Issue**:
Issue: https://github.com/rolling-scopes/rsschool-app/issues/2775
Original message: https://github.com/rolling-scopes/rsschool-app/issues/2763#issuecomment-3112534622

**Description**:
Before:
<img width="1314" height="787" alt="image" src="https://github.com/user-attachments/assets/efec4abc-9eb9-424b-a2c8-f0b411bbd00d" />
After:
<img width="642" height="751" alt="Screenshot_20250728_121741" src="https://github.com/user-attachments/assets/a1e499ca-3b95-490d-8c2d-44621e758d9a" />