### PR TITLE
fix: textarea remove `resize: none` to enable resizing

### DIFF
--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -29,10 +29,6 @@ textarea::-webkit-scrollbar-track {
   margin: calc(var(--scroll-size) / 2);
 }
 
-textarea {
-  resize: none !important;
-}
-
 .dark .header-logo,
 .dark .login-image {
   filter: invert(1);


### PR DESCRIPTION
**Description**:
the ability to resize the `textarea` was disabled by adding: `textarea { resize: none !important }`, which is particularly inconvenient in the cross-check form.

a commit that adds `resize: none` - [FIX: dark theme colors mismatch](https://github.com/rolling-scopes/rsschool-app/commit/4f06e5ecab81cab923466975ead19ac522feacdd#diff-ca755a9c38506314db43d98d5551f095ec104065422bd127b7e0bd22e5fc9232R33) 

[textarea.webm](https://github.com/user-attachments/assets/cf9029c2-4998-47f7-ba3c-f2fbef44e002)


**Self-Check**:

- [x] Changes tested locally
