### PR TITLE
Replace TwoTone icons with Outlined icons on the Home page

### DIFF
--- a/client/src/modules/Home/data/links.tsx
+++ b/client/src/modules/Home/data/links.tsx
@@ -1,15 +1,14 @@
 import {
-  AudioTwoTone,
-  CalendarTwoTone,
-  CheckCircleTwoTone,
-  GoldTwoTone,
-  CodeTwoTone,
-  DashboardTwoTone,
-  FireTwoTone,
-  PlayCircleTwoTone,
-  StopTwoTone,
   AppstoreOutlined,
   UsergroupAddOutlined,
+  FireOutlined,
+  DashboardOutlined,
+  GoldOutlined,
+  CodeOutlined,
+  CheckCircleOutlined,
+  AudioOutlined,
+  PlayCircleOutlined,
+  StopOutlined,
 } from '@ant-design/icons';
 import { Session } from 'components/withSession';
 import React from 'react';
@@ -18,6 +17,7 @@ import { isStudent, isAdmin, isMentor, isCourseManager, isActiveStudent, isDemen
 import { getAutoTestRoute } from 'services/routes';
 import { MenuProps } from 'antd';
 import Router from 'next/router';
+import CalendarOutlined from '@ant-design/icons/CalendarOutlined';
 
 const anyAccess = () => true;
 const isCourseNotCompleted = (_: Session, course: Course) => !course.completed;
@@ -51,7 +51,7 @@ export type LinkRenderData = Pick<LinkData, 'icon' | 'name'> & { url: string };
 const links: LinkData[] = [
   {
     name: 'Dashboard',
-    icon: <DashboardTwoTone />,
+    icon: <DashboardOutlined />,
     getUrl: (course: Course) => `/course/student/dashboard?course=${course.alias}`,
     access: every(isStudent),
     courseAccess: everyCourse(isCourseNotCompleted),
@@ -65,67 +65,67 @@ const links: LinkData[] = [
   },
   {
     name: 'Score',
-    icon: <FireTwoTone twoToneColor="#ffa500" />,
+    icon: <FireOutlined style={{ color: '#ffa500' }} />,
     getUrl: (course: Course) => `/course/score?course=${course.alias}`,
     access: anyAccess,
   },
   {
     name: 'Schedule',
-    icon: <CalendarTwoTone twoToneColor="#eb2f96" />,
+    icon: <CalendarOutlined style={{ color: '#eb2f96' }} />,
     getUrl: (course: Course) => `/course/schedule?course=${course.alias}`,
     access: anyAccess,
   },
   {
     name: 'My Students',
-    icon: <GoldTwoTone twoToneColor="#7f00ff" />,
+    icon: <GoldOutlined style={{ color: '#7f00ff' }} />,
     getUrl: (course: Course) => `/course/mentor/students?course=${course.alias}`,
     access: every(isMentor),
   },
   {
     name: 'Cross-Check: Submit',
-    icon: <CodeTwoTone />,
+    icon: <CodeOutlined />,
     getUrl: (course: Course) => `/course/student/cross-check-submit?course=${course.alias}`,
     access: every(isActiveStudent),
     courseAccess: everyCourse(isCourseNotCompleted),
   },
   {
     name: 'Cross-Check: Review',
-    icon: <CheckCircleTwoTone twoToneColor="#f56161" />,
+    icon: <CheckCircleOutlined style={{ color: '#f56161' }} />,
     getUrl: (course: Course) => `/course/student/cross-check-review?course=${course.alias}`,
     access: every(isActiveStudent),
     courseAccess: everyCourse(isCourseNotCompleted),
   },
   {
     name: 'Interviews',
-    icon: <AudioTwoTone />,
+    icon: <AudioOutlined />,
     getUrl: (course: Course) => `/course/student/interviews?course=${course.alias}`,
     access: every(isStudent),
     courseAccess: everyCourse(isCourseNotCompleted),
   },
   {
     name: 'Interviews',
-    icon: <AudioTwoTone twoToneColor="#ffa500" />,
+    icon: <AudioOutlined style={{ color: '#ffa500' }} />,
     getUrl: (course: Course) => `/course/mentor/interviews?course=${course.alias}`,
     access: every(isMentor),
     courseAccess: everyCourse(isCourseNotCompleted),
   },
   {
     name: 'Auto-Test',
-    icon: <PlayCircleTwoTone twoToneColor="#7f00ff" />,
+    icon: <PlayCircleOutlined style={{ color: '#7f00ff' }} />,
     getUrl: (course: Course) => getAutoTestRoute(course.alias),
     access: some(isActiveStudent, isCourseManager),
     courseAccess: everyCourse(isCourseNotCompleted),
   },
   {
     name: 'Expel/Unassign Student',
-    icon: <StopTwoTone twoToneColor="#ff0000" />,
+    icon: <StopOutlined style={{ color: '#ff0000' }} />,
     getUrl: (course: Course) => `/course/mentor/expel-student?course=${course.alias}`,
     access: every(isMentor),
     courseAccess: everyCourse(isCourseNotCompleted),
   },
   {
     name: 'Team Distributions',
-    icon: <UsergroupAddOutlined twoToneColor="#7f00ff" />,
+    icon: <UsergroupAddOutlined style={{ color: '#7f00ff' }} />,
     getUrl: (course: Course) => `/course/team-distributions?course=${course.alias}`,
     access: some(isCourseManager, isActiveStudent, isDementor),
     courseAccess: everyCourse(isCourseNotCompleted),


### PR DESCRIPTION
**Issue**:
[Update course link icons on the Homepage](https://github.com/rolling-scopes/rsschool-app/issues/2789)

**Description**:
Original message: https://github.com/rolling-scopes/rsschool-app/issues/2768#issuecomment-3109180377
Some icons filled with white inside.

| | Light | Dark |
| -- | -- | -- |
| Before | <img width="595" height="1041" alt="before light" src="https://github.com/user-attachments/assets/051ce7e9-dccc-437a-bf1b-22fa991e31f0" /> | <img width="589" height="1037" alt="before dark" src="https://github.com/user-attachments/assets/46190aaa-7933-4420-a4a9-f885c150beb6" /> |
| After |  <img width="583" height="1035" alt="after light" src="https://github.com/user-attachments/assets/f6734b6b-8013-4e20-b4c5-8cec253ae80d" /> |  <img width="584" height="1045" alt="after dark" src="https://github.com/user-attachments/assets/ca3f0e67-bf50-4dd3-a199-48aef681413a" /> |

