### PR TITLE
fix: current mustn't be bigger than the total pages number

### DIFF
--- a/client/src/modules/Score/components/ScoreTable/index.tsx
+++ b/client/src/modules/Score/components/ScoreTable/index.tsx
@@ -97,6 +97,19 @@ export function ScoreTable(props: Props) {
         courseService.getStudentCourseScore(props.session?.githubId as string),
         courseTasksApi.getCourseTasks(props.course.id),
       ]);
+
+      const {
+        pagination: { totalPages },
+      } = courseScore;
+      const {
+        pagination: { current: currentPage },
+      } = students;
+
+      if (currentPage > totalPages) {
+        setStudents({ ...students, pagination: { ...courseScore.pagination, current: totalPages } });
+        return;
+      }
+
       const sortedTasks = courseTasks.data
         .filter(task => !!task.studentEndDate || props.course.completed)
         .map(task => ({


### PR DESCRIPTION
**Issue**:
- https://github.com/rolling-scopes/rsschool-app/issues/2549

**Description**:
If the current selected page number larger than the total amount of page numbers, it'll be set to the last page in the range.