### PR TITLE
fix: change auto-test status to completed if only has minimum equals tresholdPercentage

### DIFF
--- a/client/src/modules/AutoTest/utils/map.ts
+++ b/client/src/modules/AutoTest/utils/map.ts
@@ -3,12 +3,15 @@ import dayjs from 'dayjs';
 import { SelfEducationPublicAttributes, Verification } from 'services/course';
 import { CourseTaskState, CourseTaskStatus, CourseTaskVerifications } from '../types';
 
-function getState({ studentEndDate }: CourseTaskDetailedDto, verifications: Verification[]): CourseTaskState {
+function getState(courseTask: CourseTaskDetailedDto, verifications: Verification[]): CourseTaskState {
   const now = dayjs();
-  const end = dayjs(studentEndDate);
+  const end = dayjs(courseTask.studentEndDate);
   const attemptsCount = verifications?.length || 0;
 
-  if (attemptsCount > 0) {
+  const publicAttributes = courseTask.publicAttributes as SelfEducationPublicAttributes;
+  const isScorePassed = verifications?.some(v => v.score >= publicAttributes.tresholdPercentage) ?? false;
+
+  if (isScorePassed) {
     return CourseTaskState.Completed;
   }
 


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
When a student takes the auto-test for the first time, the test status changes to 'completed' regardless of the result.
<img width="472" height="387" alt="image" src="https://github.com/user-attachments/assets/5f6686ac-05ff-40db-8b26-c796ebd22974" />

**Description**:
Changed behavior, now status depends on the result!
<img width="423" height="387" alt="image" src="https://github.com/user-attachments/assets/674ceb5e-66b2-4487-b1f9-902f6d1e53a2" />
<img width="1330" height="319" alt="image" src="https://github.com/user-attachments/assets/12327c7f-e5ae-44f9-89b3-b3e6c09ee017" />
<img width="441" height="406" alt="image" src="https://github.com/user-attachments/assets/4827ce39-478a-426e-b045-e6920ac02963" />

**Self-Check**:

- [x] Database migration added (if required)
- [x] Changes tested locally
