### PR TITLE
fix: correct course event modal time zone mode for start/end date

### DIFF
--- a/client/src/modules/CourseManagement/components/CourseEventModal/formState.ts
+++ b/client/src/modules/CourseManagement/components/CourseEventModal/formState.ts
@@ -16,8 +16,8 @@ const createRecord = (eventTemplateId: number, values: any): CreateCourseEventDt
   const record = {
     eventId: eventTemplateId,
     special: values.special ? values.special.join(',') : '',
-    dateTime: values.dateTime ? dayjs(values.dateTime).tz(values.timeZone, true).utc().format() : undefined,
-    endTime: values.endTime ? dayjs(values.endTime).tz(values.timeZone, true).utc().format() : undefined,
+    dateTime: values.dateTime ? dayjs(values.dateTime).tz(values.timeZone, true).format() : undefined,
+    endTime: values.endTime ? dayjs(values.endTime).tz(values.timeZone, true).format() : undefined,
     place: values.place || null,
     organizer: values.taskOwner?.id ? { id: values.taskOwner?.id } : undefined,
   };


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
#2823 

**Description**:


**Self-Check**:

- [x] Database migration added (if required)
- [x] Changes tested locally
