### PR TITLE
fix: correct 'discipline' and 'task owner' fields initial issue

### DIFF
--- a/client/src/modules/CourseManagement/components/CourseEventModal/formState.ts
+++ b/client/src/modules/CourseManagement/components/CourseEventModal/formState.ts
@@ -81,11 +81,12 @@ export function getInitialValues(modalData: Partial<CourseEvent>) {
   return {
     ...modalData,
     type: EVENT_TYPES.find(event => event.id === modalData.event?.type)?.id ?? null,
+    disciplineId: modalData?.event?.discipline?.id || modalData?.event?.disciplineId,
     descriptionUrl: modalData.event?.descriptionUrl ? modalData.event.descriptionUrl : '',
     description: modalData.event?.description ? modalData.event.description : '',
     dateTime: dayjs.utc(modalData.dateTime ?? undefined),
     endTime: dayjs.utc(modalData.endTime ?? undefined),
-    organizerId: modalData.organizer ? modalData.organizer.id : undefined,
+    taskOwner: modalData.organizer ? { id: modalData.organizer.id } : undefined,
     special: modalData.special ? modalData.special.split(',') : [],
     timeZone,
   };

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -78,7 +78,7 @@ export interface CourseTaskDetails extends CourseTaskDto {
 
 export interface CourseEvent {
   id: number;
-  event: EventDto;
+  event: EventDto & { disciplineId: number | null };
   date?: string;
   time?: string;
   dateTime: string;


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
#2823 

**Description**:
Correct the initial value of the 'discipline' and 'task owner' fields.

**Self-Check**:

- [x] Database migration added (if required)
- [x] Changes tested locally
