### PR TITLE
Dark theme bug on heroes page

### DIFF
--- a/client/src/components/Forms/Heroes/index.tsx
+++ b/client/src/components/Forms/Heroes/index.tsx
@@ -210,7 +210,6 @@ const styles = css`
   }
   .badge-note {
     padding: 16px;
-    background: rgba(255, 255, 255, 0.7);
     border: 2px rgba(24, 144, 255, 0.5) dashed;
   }
   .card:hover .badge {
@@ -225,7 +224,6 @@ const styles = css`
   }
   .card:hover .badge-note {
     transition: all 1s ease;
-    background: rgba(255, 255, 255, 1);
     border: 2px rgba(24, 144, 255, 1) dashed;
   }
 `;

--- a/client/src/components/Forms/Heroes/index.tsx
+++ b/client/src/components/Forms/Heroes/index.tsx
@@ -212,11 +212,13 @@ const styles = css`
     padding: 16px;
     border: 2px rgba(24, 144, 255, 0.5) dashed;
   }
+  .card .badge {
+    transform: scale(1);
+    transition: transform 1s ease;
+  }
   .card:hover .badge {
-    transform: scale(6.2);
-    transition: all 1s ease;
-    opacity: 0;
-    z-index: -1;
+    transform: scale(1.5);
+    transition: transform 1s ease;
   }
   .card:hover .badge-bg {
     transition: all 2s ease;


### PR DESCRIPTION
**Issue**:
[_Link to the relevant GitHub Issue (e.g., `#123` for issue number 123)._](https://github.com/rolling-scopes/rsschool-app/issues/2828)

**Description**:
Wrong background color on the heroes page cards.

**Done**
1. Change heroes page cards background to the appropriate
2. Tiny improvements of the badges animation

[Screencast_20250929_152522.webm](https://github.com/user-attachments/assets/141e06aa-187e-472b-8d0b-674a88e38175)
