### PR TITLE
Wrong criteria background colors

### DIFF
--- a/client/src/modules/CrossCheck/utils/getCriteriaStatusColor.ts
+++ b/client/src/modules/CrossCheck/utils/getCriteriaStatusColor.ts
@@ -1,7 +1,7 @@
 const colors = ['colorBgContainer', 'red1', 'yellow1', 'green1'] as const;
 
 export function getCriteriaStatusColor(score: number, maxScore?: number) {
-  const [transparent, red, green, yellow] = colors;
+  const [transparent, red, yellow, green] = colors;
 
   if (!maxScore) {
     return transparent;


### PR DESCRIPTION
**Issue**:
- [The coloring of the cross-check form fields needs to be fixed](https://github.com/rolling-scopes/rsschool-app/issues/2841)

**Description**:
Wrong color keys were used for the card background.

<img width="457" height="211" alt="Screenshot_20251013_152644" src="https://github.com/user-attachments/assets/ffd71d14-e61a-4744-9d2d-6da88a582ee7" />
<img width="461" height="217" alt="Screenshot_20251013_152634" src="https://github.com/user-attachments/assets/3979bc61-0208-43f6-b14a-d0692b41b0d2" />
<img width="460" height="216" alt="Screenshot_20251013_152619" src="https://github.com/user-attachments/assets/0a56f72f-b4d2-4507-8706-6186e05c70cb" />


**Self-Check**:

- [ ] Changes tested locally
