### PR TITLE
fix: openapi generation script crashing due to a TypeScript compilation error

### DIFF
--- a/nestjs/src/courses/task-verifications/task-verifications.service.ts
+++ b/nestjs/src/courses/task-verifications/task-verifications.service.ts
@@ -87,7 +87,7 @@ export class TaskVerificationsService {
               questionImage: taskQuestion.questionImage,
             });
           })
-          .filter(Boolean);
+          .filter((question): question is SelfEducationQuestionSelectedAnswersDto => question !== null);
 
         return new TaskVerificationAttemptDto(verification, questionsWithIncorrectAnswers);
       });


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
The npm run openapi script doesn't work.

**Description**:
Fix the openapi generation script crashing due to a TypeScript compilation error with a type mismatch error in the code.

**Self-Check**:

- [x] Database migration added (if required)
- [x] Changes tested locally
