### PR TITLE
fix: filter student in the waiting list while mentor thinks stage interview

### DIFF
--- a/nestjs/src/courses/interviews/interviews.service.ts
+++ b/nestjs/src/courses/interviews/interviews.service.ts
@@ -168,6 +168,7 @@ export class InterviewsService {
         'si.isCompleted',
         'si.isCanceled',
         'si.score',
+        'si.decision',
         'sif.json',
         'sif.updatedDate',
         'sif.version',
@@ -192,7 +193,7 @@ export class InterviewsService {
         return (
           !s.stageInterviews ||
           s.stageInterviews.length === 0 ||
-          s.stageInterviews.every(i => i.isCompleted || i.isCanceled)
+          s.stageInterviews.every(i => (i.isCompleted && i.decision !== 'draft') || i.isCanceled)
         );
       })
       .map(student => {


### PR DESCRIPTION
**Issue**:
Student gets on the waiting list until the mentor has made a final decision (decision = draft)

**Description**:
Filter student in the waiting list while mentor thinks (decision = draft) after stage interview

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
