### PR TITLE
fix: show profile interview good candidate flag only

### DIFF
--- a/client/src/components/Profile/ui/IsGoodCandidateWidget.tsx
+++ b/client/src/components/Profile/ui/IsGoodCandidateWidget.tsx
@@ -3,14 +3,13 @@ import { Tag, Typography } from 'antd';
 const { Text } = Typography;
 
 export function IsGoodCandidateWidget({ isGoodCandidate }: { isGoodCandidate: boolean | null }) {
-  if (isGoodCandidate === null) {
+  if (!isGoodCandidate) {
     return null;
   }
 
   return (
     <Text>
-      <Text style={{ fontWeight: 'bold' }}>Good candidate:</Text>{' '}
-      {isGoodCandidate ? <Tag color="green">Yes</Tag> : <Tag color="red">No</Tag>}
+      <Text style={{ fontWeight: 'bold' }}>Good candidate:</Text> <Tag color="green">Yes</Tag>
     </Text>
   );
 }

--- a/client/src/components/Profile/ui/__tests__/IsGoodCandidateWidget.test.tsx
+++ b/client/src/components/Profile/ui/__tests__/IsGoodCandidateWidget.test.tsx
@@ -9,11 +9,9 @@ describe('IsGoodCandidateWidget', () => {
     expect(screen.getByText('Yes')).toBeInTheDocument();
   });
 
-  it('renders No tag when isGoodCandidate is false', () => {
+  it('renders nothing when isGoodCandidate is false', () => {
     render(<IsGoodCandidateWidget isGoodCandidate={false} />);
-
-    expect(screen.getByText('Good candidate:')).toBeInTheDocument();
-    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.queryByText(/Good candidate:/i)).not.toBeInTheDocument();
   });
 
   it('renders nothing when isGoodCandidate is null', () => {


### PR DESCRIPTION

**Issue**:
A mentor may accidentally check and then uncheck the ‘good candidate’ checkbox during the interview feedback. This action affects the students' statistics.

<img width="684" height="1312" alt="image" src="https://github.com/user-attachments/assets/12cb2da5-49c4-42ef-99e9-6b0335219ba7" />

**Description**:
Show good candidate flag only or nothing inside profile interviews section.
 
<img width="684" height="838" alt="image" src="https://github.com/user-attachments/assets/f2ca5932-69b5-41c7-ac40-104a104a570c" />
<img width="684" height="838" alt="image" src="https://github.com/user-attachments/assets/dff0bc70-ce29-47ad-9077-f9619d135cb7" />

**Self-Check**:

- [x] Changes tested locally
