### PR TITLE
fix: render all student's interview cards with result

### DIFF
--- a/client/src/pages/course/student/interviews.tsx
+++ b/client/src/pages/course/student/interviews.tsx
@@ -103,29 +103,27 @@ function StudentInterviewPage() {
               const items = getStudentInterviewItems(name);
 
               if (items.length > 0) {
-                return items.map(item => {
-                  return (
-                    <InterviewCard
-                      key={id + item.id}
-                      interview={interview}
-                      item={item}
-                      isRegistered={true}
-                      onRegister={handleRegister}
-                    />
-                  );
-                });
-              } else {
-                const registered = hasInterview(id);
-                return (
+                return items.map((item, index) => (
                   <InterviewCard
-                    key={id}
+                    key={item.id + index}
                     interview={interview}
-                    item={null}
-                    isRegistered={registered}
+                    item={item}
+                    isRegistered={true}
                     onRegister={handleRegister}
                   />
-                );
+                ));
               }
+
+              const registered = hasInterview(id);
+              return (
+                <InterviewCard
+                  key={id}
+                  interview={interview}
+                  item={null}
+                  isRegistered={registered}
+                  onRegister={handleRegister}
+                />
+              );
             })}
           </Row>
         )}


### PR DESCRIPTION

**Issue**:
The student can only see the result of the last interview. If the manager creates a second or more pairs of student-mentor interviews, the information on the interview card is overwritten. 

**Description**:
Now we render all interview cards, and student can see the results.

<img width="2688" height="1592" alt="image" src="https://github.com/user-attachments/assets/15d89413-1300-4045-85f7-8bc3a1cafdfe" />


**Self-Check**:

- [x] Changes tested locally
