### PR TITLE
fix: set property 'values' as optional within the InterviewDecisionCommentFeedback interface

### DIFF
--- a/nestjs/src/courses/interviews/interviewFeedback.service.ts
+++ b/nestjs/src/courses/interviews/interviewFeedback.service.ts
@@ -9,7 +9,7 @@ import { InterviewCommentDto } from './dto/interview-comment.dto';
 interface InterviewDecisionCommentFeedback {
   steps: {
     decision: {
-      values: {
+      values?: {
         comment?: string;
       };
     };
@@ -37,7 +37,7 @@ export class InterviewFeedbackService {
 
     const iterviewComments = records.map<InterviewCommentDto>(interviewFeedback => {
       const feedback = JSON.parse(interviewFeedback.sif_json) as InterviewDecisionCommentFeedback;
-      const commentToStudent = feedback.steps.decision.values.comment ?? null;
+      const commentToStudent = feedback.steps.decision.values?.comment ?? null;
 
       return {
         id: Number(interviewFeedback.si_id),


### PR DESCRIPTION
**Issue**:
When an interview is rejected with the result 'Ignored mentor', the ‘values’ property is not present in the feedback.

**Description**:
Set the property 'values' as optional within the InterviewDecisionCommentFeedback interface.

<img width="996" height="865" alt="image" src="https://github.com/user-attachments/assets/46344c15-a804-4be2-befb-bf69f87c0b5e" />


**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
