### PR TITLE
fix: add students to core-js-2-interview wait list

### DIFF
--- a/nestjs/src/courses/interviews/interviews.service.ts
+++ b/nestjs/src/courses/interviews/interviews.service.ts
@@ -83,7 +83,7 @@ export class InterviewsService {
       .createQueryBuilder('is')
       .innerJoin('is.student', 'student')
       .innerJoin('student.user', 'user')
-      .leftJoin('student.taskChecker', 'taskChecker')
+      .leftJoin('student.taskChecker', 'taskChecker', 'taskChecker.courseTaskId = :courseTaskId', { courseTaskId })
       .addSelect([
         'student.id',
         'student.totalScore',


### PR DESCRIPTION
**Issue**:
If a student has already been interviewed earlier in the course, they will not be included in the waiting list.
**Description**:

Resolved the issue by adding a condition to the ```leftJoin``` on the ```taskChecker``` table. The query now only retrieves tasks that have a matching ```courseTaskId```.

**Self-Check**:

- [x] Changes tested locally
