### PR TITLE
feat: add carousel banners

### DIFF
--- a/client/public/static/images/banner-gratitude.svg
+++ b/client/public/static/images/banner-gratitude.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 56" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a0933"/>
+      <stop offset="100%" stop-color="#2d0f52"/>
+    </linearGradient>
+    <linearGradient id="pinkText" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff85c2"/>
+      <stop offset="100%" stop-color="#eb2f96"/>
+    </linearGradient>
+  </defs>
+
+  <!-- background -->
+  <rect width="240" height="56" rx="6" fill="url(#bg)"/>
+
+  <!-- left magenta accent bar -->
+  <rect x="0" y="0" width="4" height="56" rx="3" fill="#eb2f96"/>
+
+  <!-- heart icon -->
+  <path
+    d="M26 39 C26 39 12 30 12 21 a7 7 0 0 1 14 0 a7 7 0 0 1 14 0 C40 30 26 39 26 39 Z"
+    fill="#eb2f96"
+  />
+
+  <!-- sparkle dots top-right -->
+  <circle cx="200" cy="14" r="1.5" fill="#eb2f96" opacity="0.6"/>
+  <circle cx="214" cy="10" r="1.1" fill="#ff85c2" opacity="0.7"/>
+  <circle cx="225" cy="22" r="1.6" fill="#eb2f96" opacity="0.4"/>
+  <circle cx="234" cy="13" r="1.2" fill="#ff85c2" opacity="0.5"/>
+  <circle cx="207" cy="40" r="1.4" fill="#eb2f96" opacity="0.5"/>
+  <circle cx="230" cy="42" r="1"   fill="#ff85c2" opacity="0.4"/>
+  <circle cx="237" cy="30" r="1.5" fill="#eb2f96" opacity="0.3"/>
+  <circle cx="220" cy="46" r="1.1" fill="#ff85c2" opacity="0.35"/>
+
+  <!-- main label -->
+  <text
+    x="46" y="26"
+    dominant-baseline="middle"
+    font-family="'Segoe UI', Arial, sans-serif"
+    font-size="15"
+    font-weight="700"
+    letter-spacing="0.3"
+    fill="url(#pinkText)"
+  >#gratitude</text>
+
+  <!-- subtitle -->
+  <text
+    x="46" y="43"
+    dominant-baseline="middle"
+    font-family="'Segoe UI', Arial, sans-serif"
+    font-size="10"
+    font-weight="400"
+    letter-spacing="0.3"
+    fill="#c084fc"
+    opacity="0.85"
+  >Send a thank you to someone</text>
+</svg>

--- a/client/public/static/images/banner-mentors-hall-of-fame.svg
+++ b/client/public/static/images/banner-mentors-hall-of-fame.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 56" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#07223b"/>
+      <stop offset="100%" stop-color="#0d3560"/>
+    </linearGradient>
+    <linearGradient id="goldText" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffe566"/>
+      <stop offset="100%" stop-color="#c8930a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- background -->
+  <rect width="240" height="56" rx="6" fill="url(#bg)"/>
+
+  <!-- left gold accent bar -->
+  <rect x="0" y="0" width="4" height="56" rx="3" fill="#FFDB20"/>
+
+  <!-- trophy cup body -->
+  <path d="M19 10 h14 v12 a7 7 0 0 1-7 7 a7 7 0 0 1-7-7 Z" fill="#FFDB20"/>
+  <!-- trophy handles -->
+  <path d="M19 13 h-3 a3 3 0 0 0 0 6 h3" fill="none" stroke="#FFDB20" stroke-width="1.8"/>
+  <path d="M33 13 h3 a3 3 0 0 1 0 6 h-3"  fill="none" stroke="#FFDB20" stroke-width="1.8"/>
+  <!-- trophy stem -->
+  <rect x="25" y="29" width="2" height="7" fill="#FFDB20"/>
+  <!-- trophy base -->
+  <rect x="20" y="36" width="12" height="2.5" rx="1.25" fill="#FFDB20"/>
+
+  <!-- decorative star dots top-right -->
+  <circle cx="200" cy="13" r="1.4" fill="#FFDB20" opacity="0.7"/>
+  <circle cx="213" cy="22" r="1.8" fill="#FFDB20" opacity="0.5"/>
+  <circle cx="224" cy="11" r="1.2" fill="#FFDB20" opacity="0.6"/>
+  <circle cx="232" cy="36" r="1.5" fill="#FFDB20" opacity="0.4"/>
+  <circle cx="207" cy="41" r="1.1" fill="#FFDB20" opacity="0.5"/>
+  <circle cx="236" cy="20" r="1"   fill="#ffe566" opacity="0.6"/>
+  <circle cx="220" cy="44" r="1.3" fill="#FFDB20" opacity="0.35"/>
+
+  <!-- main label -->
+  <text
+    x="46" y="28"
+    dominant-baseline="middle"
+    font-family="'Segoe UI', Arial, sans-serif"
+    font-size="15"
+    font-weight="700"
+    letter-spacing="0.3"
+    fill="url(#goldText)"
+  >Mentors Hall of Fame</text>
+
+  <!-- subtitle -->
+  <text
+    x="46" y="43"
+    dominant-baseline="middle"
+    font-family="'Segoe UI', Arial, sans-serif"
+    font-size="10"
+    font-weight="400"
+    letter-spacing="0.4"
+    fill="#7eb8f7"
+    opacity="0.8"
+  >Top mentors by certified students</text>
+</svg>

--- a/client/src/components/Header.module.css
+++ b/client/src/components/Header.module.css
@@ -15,7 +15,7 @@
 }
 
 .headerLogo {
-  height: 30px;
+  height: 56px;
 }
 
 .center {

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -56,7 +56,18 @@ const MENU_ITEMS = [
   },
 ];
 
-const CAROUSEL_ITEMS: ReadonlyArray<HeaderMiniBannerCarouselItem> = [];
+const CAROUSEL_ITEMS: ReadonlyArray<HeaderMiniBannerCarouselItem> = [
+  {
+    banner: '/static/images/banner-mentors-hall-of-fame.svg',
+    url: '/mentors-hall-of-fame',
+    title: 'Mentors Hall of Fame',
+  },
+  {
+    banner: '/static/images/banner-gratitude.svg',
+    url: '/gratitude',
+    title: '#gratitude',
+  },
+];
 const CAROUSEL_INTERVAL_MS = 5000;
 
 export function Header({ title, showCourseName, showCarousel = true }: Props) {

--- a/client/src/components/HeaderMiniBannerCarousel.module.css
+++ b/client/src/components/HeaderMiniBannerCarousel.module.css
@@ -1,14 +1,14 @@
 .carousel {
   position: relative;
-  width: 240px;
-  height: 30px;
-  border-radius: 4px;
+  width: 284px;
+  height: 56px;
+  border-radius: 6px;
 }
 
 .carouselViewport {
   width: 100%;
   height: 100%;
-  padding: 0 24px;
+  padding: 0 22px;
   overflow: hidden;
 }
 
@@ -24,8 +24,16 @@
   height: 100%;
 }
 
+/* text-only slide */
 .slideContent {
   height: 100%;
+}
+
+/* banner slide — needs position:relative so .bannerLink overlay works */
+.slideContentBanner {
+  position: relative;
+  height: 100%;
+  overflow: hidden;
 }
 
 .slide {
@@ -36,7 +44,7 @@
   justify-content: center;
   color: inherit;
   text-decoration: none;
-  padding: 0 8px;
+  padding: 0 26px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -47,9 +55,16 @@ a.slide:hover {
 }
 
 .banner {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+/* transparent full-size link overlay on top of banner img */
+.bannerLink {
+  position: absolute;
+  inset: 0;
 }
 
 .title {

--- a/client/src/components/HeaderMiniBannerCarousel.tsx
+++ b/client/src/components/HeaderMiniBannerCarousel.tsx
@@ -55,26 +55,29 @@ export function HeaderMiniBannerCarousel({ items = [], intervalMs = DEFAULT_INTE
         >
           {visibleItems.map((item, idx) => {
             const label = item.title ?? 'Header banner';
-            const content = item.banner ? (
-              <img src={item.banner} alt={label} className={styles.banner} />
-            ) : (
-              <span className={styles.title} style={{ color: token.colorText }}>
-                {item.title}
-              </span>
-            );
+            const hasBanner = Boolean(item.banner);
 
             return (
               <div
                 key={`${item.url ?? ''}-${item.banner ?? ''}-${item.title ?? label}-${idx}`}
-                className={styles.slideContent}
+                className={hasBanner ? styles.slideContentBanner : styles.slideContent}
               >
-                {item.url ? (
+                {hasBanner ? (
+                  <>
+                    <img src={item.banner} alt={label} className={styles.banner} />
+                    {item.url && <a href={item.url} className={styles.bannerLink} title={label} aria-label={label} />}
+                  </>
+                ) : item.url ? (
                   <a href={item.url} className={styles.slide} title={label}>
-                    {content}
+                    <span className={styles.title} style={{ color: token.colorText }}>
+                      {item.title}
+                    </span>
                   </a>
                 ) : (
                   <span className={styles.slide} title={label}>
-                    {content}
+                    <span className={styles.title} style={{ color: token.colorText }}>
+                      {item.title}
+                    </span>
                   </span>
                 )}
               </div>


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
N/A

**Description**:
Add Mentors hall of fame and Gratitude pages banners to header carousel  
<img width="307" height="99" alt="image" src="https://github.com/user-attachments/assets/2a6e75ca-4630-4e7b-920e-e9c24264afa8" />  
<img width="307" height="99" alt="image" src="https://github.com/user-attachments/assets/af48ad66-3373-4329-a7ee-8a78929632d3" />


**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally
