### PR TITLE
Add LoadingScreen.module.css with .loadingScreen styles

### DIFF
--- a/client/src/shared/components/LoadingScreen.module.css
+++ b/client/src/shared/components/LoadingScreen.module.css
@@ -1,0 +1,4 @@
+.loadingScreen {
+  inset: 0;
+  z-index: 1000;
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated CSS module for the loading screen so it covers the viewport and stacks above other UI.

### Description
- Add `client/src/shared/components/LoadingScreen.module.css` defining a `.loadingScreen` class that sets `inset: 0` and `z-index: 1000`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a993f0260c832bb2654a3477781a3a)