### PR TITLE
fix: add vitest config to CI workspace

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,11 +10,47 @@ env:
   TURBO_VERSION: '2.8.12'
 
 jobs:
-  deploy_build_client:
+  checks:
+    name: Test, Lint
+    concurrency:
+      group: deploy-checks
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore npm cache
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-npm
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm run test
+
+      - name: Lint
+        run: npm run lint
+
+  build_client:
     name: Build (Client)
     concurrency:
       group: deploy-build-client
       cancel-in-progress: true
+    needs: [checks]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -52,10 +88,6 @@ jobs:
         run: npm ci
         working-directory: ./app
 
-      - name: Test (npm run test:ci)
-        run: npm run test:ci
-        working-directory: ./app
-
       - name: Build (npm run build)
         env:
           NODE_ENV: production
@@ -89,11 +121,12 @@ jobs:
       - name: Publish "client" container
         run: docker push ghcr.io/rolling-scopes/rsschool-app-client:master
 
-  deploy_build_server:
+  build_server:
     name: Build (Server)
     concurrency:
       group: deploy-build-server
       cancel-in-progress: true
+    needs: [checks]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -131,10 +164,6 @@ jobs:
         run: npm ci
         working-directory: ./app
 
-      - name: Test (npm test)
-        run: npm test
-        working-directory: ./app
-
       - name: Build (npm run build)
         env:
           NODE_ENV: production
@@ -154,11 +183,12 @@ jobs:
       - name: Publish "server" container
         run: docker push ghcr.io/rolling-scopes/rsschool-app-server:master
 
-  deploy_build_nestjs:
+  build_nestjs:
     name: Build (Nest.js)
     concurrency:
       group: deploy-build-nestjs
       cancel-in-progress: true
+    needs: [checks]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -215,12 +245,12 @@ jobs:
       - name: Publish "nestjs" container
         run: docker push ghcr.io/rolling-scopes/rsschool-app-nestjs:master
 
-  deploy_aws:
-    name: Deploy to AWS
+  deploy:
+    name: deploy
     concurrency:
       group: deploy-aws
       cancel-in-progress: false
-    needs: [deploy_build_client, deploy_build_server, deploy_build_nestjs]
+    needs: [build_client, build_server, build_nestjs]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
N/A

**Description**:
Fixes issue with running test job in CI for server after migration to `vitest`  
https://github.com/rolling-scopes/rsschool-app/actions/runs/22978655332/job/66713251101  
<img width="875" height="671" alt="image" src="https://github.com/user-attachments/assets/925bffbd-6ea7-4f2b-89c2-20f2201f9261" />  
Root cause: 
The issue was in `deploy.yaml` — the workflow uses `turbo prune --scope=server --docker` to create an isolated workspace in `app/`. The root-level `vitest.shared.ts` file is not included in the pruned output, while `server/vitest.config.ts` imports it via `import shared from '../vitest.shared'`.

**Fix:** added `cp vitest.shared.ts app/` to the copy steps for both jobs — `deploy_build_server` and `deploy_build_nestjs` — so that `vitest.shared.ts` is available in the isolated workspace.



**Self-Check**:

- [ ] Database migration added (if required)
- [ ] Changes tested locally