### PR TITLE
refactor(client): migrate useLoading to ahooks useRequest

### DIFF
--- a/client/src/components/useLoading.tsx
+++ b/client/src/components/useLoading.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useRequest } from 'ahooks';
 import { message } from 'antd';
 
 type CatchHandler = (e?: unknown) => void;
+
+type AsyncAction<T extends unknown[], K> = (...args: T) => Promise<K>;
 
 export function useLoading(
   value = false,
@@ -9,18 +12,38 @@ export function useLoading(
     message.error('An unexpected error occurred. Please try later.');
   },
 ) {
-  const [loading, setLoading] = useState(value);
-  const wrapper =
-    <T extends unknown[], K = unknown>(action: (...args: T) => Promise<K>) =>
-    async (...args: Parameters<typeof action>) => {
-      try {
-        setLoading(true);
-        return await action(...args);
-      } catch (e) {
-        catchHandler(e);
-      } finally {
-        setLoading(false);
-      }
-    };
-  return [loading, wrapper] as const;
+  const actionRef = useRef<AsyncAction<unknown[], unknown>>();
+  const argsRef = useRef<unknown[]>([]);
+  const [initialLoading, setInitialLoading] = useState(value);
+
+  const { loading, runAsync } = useRequest(
+    async () => {
+      return actionRef.current?.(...argsRef.current);
+    },
+    {
+      manual: true,
+      onError: catchHandler,
+      onFinally: () => {
+        setInitialLoading(false);
+      },
+    },
+  );
+
+  const wrapper = useCallback(
+    <T extends unknown[], K = unknown>(action: AsyncAction<T, K>) =>
+      async (...args: Parameters<typeof action>) => {
+        actionRef.current = action as AsyncAction<unknown[], unknown>;
+        argsRef.current = args;
+
+        try {
+          return (await runAsync()) as K;
+        } finally {
+          actionRef.current = undefined;
+          argsRef.current = [];
+        }
+      },
+    [runAsync],
+  );
+
+  return [initialLoading || loading, wrapper] as const;
 }


### PR DESCRIPTION
### Motivation
- Replace a custom loading lifecycle with the recommended `useRequest` from `ahooks` to align with client-side hook guidance and reduce manual state handling.
- Preserve the existing hook contract so existing call sites do not require changes.

### Description
- Replaced implementation of `client/src/components/useLoading.tsx` to delegate async execution and loading state to `useRequest` while keeping the exported signature `[loading, withLoading]`.
- Introduced `actionRef`/`argsRef` and a `runAsync` wrapper so passed async actions execute via `useRequest` and retain original semantics.
- Preserved the `catchHandler` default behavior that shows an `antd` error message on failure.
- No client call sites were modified; the public API remains compatible with existing usage.

### Testing
- Ran `npm run lint`; command completed successfully (warnings only) and exit status was success.
- Ran `npm run test`; automated test suites passed (client, nestjs and server tests completed without failures).
- Ran `npm run compile`; TypeScript compilation (`tsc --noEmit`) succeeded.
- Ran `npm run format`; code formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ecdf423c832b9feb535181ca9859)