### PR TITLE
fix: resolve course update issue

### DIFF
--- a/nestjs/src/courses/dto/update-course.dto.ts
+++ b/nestjs/src/courses/dto/update-course.dto.ts
@@ -24,6 +24,8 @@ export class UpdateCourseDto {
   @ApiPropertyOptional()
   descriptionUrl?: string;
 
+  @IsNumber()
+  @IsOptional()
   @ApiPropertyOptional()
   year?: number;
 


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
Issue - #2966 
When updating course settings, have 400 with message: "property year should not exist",

**Description**:
Add @IsOptional() decorator in update-course.dto for the property 'year'.

**Self-Check**:

- [x] Changes tested locally