### PR TITLE
fix: make handleDelete manual to prevent unintended calls

### DIFF
--- a/client/src/modules/CourseManagement/hooks/useExpelledStats.ts
+++ b/client/src/modules/CourseManagement/hooks/useExpelledStats.ts
@@ -16,7 +16,7 @@ export const useExpelledStats = (courseId?: number) => {
 
   const { runAsync: handleDelete, loading: isDeleting } = useRequest(
     async (id: string) => courseStatsApi.deleteExpelledStat(id),
-    { onSuccess: refresh },
+    { onSuccess: refresh, manual: true },
   );
 
   return {


### PR DESCRIPTION
**Issue**:
https://github.com/rolling-scopes/rsschool-app/issues/2977

**Description**:
On visit `course/admin/reports?course=SOME_COURSE` error in browser console:
```log
installHook.js:1 RequiredError:
 Required parameter id was null or undefined when calling deleteExpelledStat.
```
Error caused automatical execution of the `useRequest`.

**Self-Check**:
- [x] Changes tested locally