### PR TITLE
emp74ark/rsschool-app-2951

### DIFF
--- a/client/src/modules/CourseStatistics/components/DonutChart/DonutChart.tsx
+++ b/client/src/modules/CourseStatistics/components/DonutChart/DonutChart.tsx
@@ -48,4 +48,3 @@ const DonutChart = ({ data, config = {} }: Props) => {
 };
 
 export default DonutChart;
-

--- a/client/src/modules/CourseStatistics/components/DonutChart/DonutChart.tsx
+++ b/client/src/modules/CourseStatistics/components/DonutChart/DonutChart.tsx
@@ -1,4 +1,6 @@
 import { Pie, PieConfig } from '@ant-design/plots';
+import { theme } from 'antd';
+import { useTheme } from '@client/shared/hooks/useTheme';
 
 type Props = {
   data: {
@@ -9,6 +11,9 @@ type Props = {
 };
 
 const DonutChart = ({ data, config = {} }: Props) => {
+  const { token } = theme.useToken();
+  const { theme: currentTheme } = useTheme();
+  const total = data.reduce((acc, curr) => acc + curr.value, 0);
   const pieConfig: PieConfig = {
     ...config,
     data,
@@ -16,6 +21,7 @@ const DonutChart = ({ data, config = {} }: Props) => {
     colorField: 'type',
     innerRadius: 0.6,
     label: false,
+    theme: currentTheme,
     legend: {
       color: {
         title: false,
@@ -23,8 +29,23 @@ const DonutChart = ({ data, config = {} }: Props) => {
         rowPadding: 5,
       },
     },
+    annotations: [
+      {
+        type: 'text',
+        style: {
+          text: `${total}`,
+          x: '50%',
+          y: '50%',
+          textAlign: 'center',
+          fontSize: 20,
+          fontStyle: 'bold',
+          fill: token.colorTextLabel,
+        },
+      },
+    ],
   };
   return <Pie {...pieConfig} />;
 };
 
 export default DonutChart;
+

--- a/client/src/modules/CourseStatistics/components/LiquidChart/LiquidChart.tsx
+++ b/client/src/modules/CourseStatistics/components/LiquidChart/LiquidChart.tsx
@@ -1,6 +1,6 @@
-import { Liquid, LiquidConfig } from '@ant-design/plots';
-import { Colors } from '../../data';
-import { GlobalToken, theme } from 'antd';
+import {Liquid, LiquidConfig} from '@ant-design/plots';
+import {Colors} from '../../data';
+import {GlobalToken, theme} from 'antd';
 
 type Props = {
   count: number;
@@ -11,14 +11,17 @@ type Props = {
 
 function LiquidChart({ count, total, color = Colors.Blue, background }: Props) {
   const { token } = theme.useToken();
+
   const percent = count / total;
   const config: LiquidConfig = {
+    interaction: { tooltip: false },
     theme: {
       background: background || token.colorBgContainer,
     },
     percent: percent,
     style: {
       fill: color,
+      textFill: token.colorTextLabel,
       outlineBorder: 4,
       outlineDistance: 8,
       outlineStroke: color,
@@ -30,3 +33,4 @@ function LiquidChart({ count, total, color = Colors.Blue, background }: Props) {
 }
 
 export default LiquidChart;
+

--- a/client/src/modules/CourseStatistics/components/LiquidChart/LiquidChart.tsx
+++ b/client/src/modules/CourseStatistics/components/LiquidChart/LiquidChart.tsx
@@ -1,6 +1,6 @@
-import {Liquid, LiquidConfig} from '@ant-design/plots';
-import {Colors} from '../../data';
-import {GlobalToken, theme} from 'antd';
+import { Liquid, LiquidConfig } from '@ant-design/plots';
+import { Colors } from '../../data';
+import { GlobalToken, theme } from 'antd';
 
 type Props = {
   count: number;
@@ -33,4 +33,3 @@ function LiquidChart({ count, total, color = Colors.Blue, background }: Props) {
 }
 
 export default LiquidChart;
-

--- a/client/src/modules/CourseStatistics/components/TaskPerformanceCard/TaskPerformanceCard.tsx
+++ b/client/src/modules/CourseStatistics/components/TaskPerformanceCard/TaskPerformanceCard.tsx
@@ -121,4 +121,3 @@ function getChartData(taskPerformanceStats: TaskPerformanceStatsDto) {
     { type: StudentPerformanceType.Perfect, value: taskPerformanceStats.perfectScores },
   ].filter(({ value }) => value > 0);
 }
-

--- a/client/src/modules/CourseStatistics/components/TaskPerformanceCard/TaskPerformanceCard.tsx
+++ b/client/src/modules/CourseStatistics/components/TaskPerformanceCard/TaskPerformanceCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, Form, Image, Select, Typography } from 'antd';
+import { Card, Flex, Form, Image, Select, theme, Typography } from 'antd';
 import { CourseStatsApi, CourseTaskDto, TaskPerformanceStatsDto } from '@client/api';
 import { useActiveCourseContext } from '@client/modules/Course/contexts';
 import { useState } from 'react';
@@ -19,6 +19,7 @@ const DonutChart = dynamicWithSkeleton(() => import('../DonutChart/DonutChart'))
 
 export const TaskPerformanceCard = ({ tasks }: Props) => {
   const { course } = useActiveCourseContext();
+  const { token } = theme.useToken();
 
   const [taskId, setTaskId] = useState<number>();
 
@@ -47,7 +48,7 @@ export const TaskPerformanceCard = ({ tasks }: Props) => {
       </Form>
       <div style={{ height: 250, width: '100%' }}>
         {taskPerformanceStats?.totalAchievement ? (
-          <DonutChart data={getChartData(taskPerformanceStats)} config={getChartConfig()} />
+          <DonutChart data={getChartData(taskPerformanceStats)} config={getChartConfig(token.colorTextLabel)} />
         ) : (
           <Flex vertical align="center" justify="center">
             <Text>No data available for this task, please select another task.</Text>
@@ -78,7 +79,7 @@ function getPerformanceDescriptionByType(type: string) {
   }
 }
 
-function getChartConfig(): Partial<PieConfig> {
+function getChartConfig(textColor: string): Partial<PieConfig> {
   return {
     tooltip: {
       items: [
@@ -87,6 +88,20 @@ function getChartConfig(): Partial<PieConfig> {
           value: d.value,
         }),
       ],
+    },
+    interaction: {
+      tooltip: {
+        render: (_: unknown, { items }: { items: Array<{ name: string; value: string | number; color?: string }> }) =>
+          `<div style="padding:4px 0">${items
+            .map(
+              ({ name, value, color }) =>
+                `<div style="display:flex;align-items:center;gap:1rem">
+                  <span style="color:${color};line-height:20px">●</span>
+                  <span style="color:${textColor};white-space:normal;word-break:break-word">${name}: <strong>${value}</strong></span>
+                </div>`,
+            )
+            .join('')}</div>`,
+      },
     },
     scale: {
       color: {
@@ -106,3 +121,4 @@ function getChartData(taskPerformanceStats: TaskPerformanceStatsDto) {
     { type: StudentPerformanceType.Perfect, value: taskPerformanceStats.perfectScores },
   ].filter(({ value }) => value > 0);
 }
+

--- a/client/src/modules/MentorRegistry/components/MentorRegistryTableContainer.tsx
+++ b/client/src/modules/MentorRegistry/components/MentorRegistryTableContainer.tsx
@@ -83,9 +83,9 @@ export const MentorRegistryTableContainer = ({
         .map(value => ({
           value: courses.find(course => course.id === value)?.name ?? value.toString(),
           alias: courses.find(course => course.id === value)?.alias ?? '',
-          color: record.courses.includes(value) ? '#87d068' : undefined,
+          color: record.courses.includes(value) ? token.green7 : undefined,
         }))
-        .map(v => (v.color ? colorTagRenderer(v.value, v.color) : renderTagWithCopyButton(v.value, v.alias)));
+        .map(v => (v.color ? colorTagRenderer(v.value, v.color, 'solid') : renderTagWithCopyButton(v.value, v.alias)));
     };
   };
 
@@ -390,3 +390,4 @@ export const MentorRegistryTableContainer = ({
     activeTab,
   });
 };
+

--- a/client/src/modules/MentorRegistry/components/MentorRegistryTableContainer.tsx
+++ b/client/src/modules/MentorRegistry/components/MentorRegistryTableContainer.tsx
@@ -390,4 +390,3 @@ export const MentorRegistryTableContainer = ({
     activeTab,
   });
 };
-

--- a/client/src/shared/components/Table/renderers.tsx
+++ b/client/src/shared/components/Table/renderers.tsx
@@ -119,7 +119,6 @@ export function tagsCoursesRendererWithRemainingNumber(_: undefined, { courses }
 }
 
 export function renderTag(value: number | string, color?: string, variant?: TagProps['variant']) {
-  console.log('renderTag', value, color);
   return (
     <Tag color={color} key={value} variant={variant}>
       {value}

--- a/client/src/shared/components/Table/renderers.tsx
+++ b/client/src/shared/components/Table/renderers.tsx
@@ -222,4 +222,3 @@ export const coloredDateRenderer = (timeZone: string, format: string, date: 'sta
     return <Text type={color}>{text}</Text>;
   };
 };
-

--- a/client/src/shared/components/Table/renderers.tsx
+++ b/client/src/shared/components/Table/renderers.tsx
@@ -4,7 +4,7 @@ import GithubOutlined from '@ant-design/icons/GithubOutlined';
 import MinusCircleOutlined from '@ant-design/icons/MinusCircleOutlined';
 import YoutubeOutlined from '@ant-design/icons/YoutubeOutlined';
 import InfoCircleOutlined from '@ant-design/icons/InfoCircleOutlined';
-import { Tag, Tooltip, Typography } from 'antd';
+import { Tag, TagProps, Tooltip, Typography } from 'antd';
 import { BaseType } from 'antd/lib/typography/Base';
 import {
   CourseScheduleItemDto,
@@ -89,8 +89,8 @@ export function boolIconRenderer(value: unknown) {
   );
 }
 
-export function colorTagRenderer(value: number | string, color?: string) {
-  return <span key={value}>{renderTag(value, color)}</span>;
+export function colorTagRenderer(value: number | string, color?: string, variant?: TagProps['variant']) {
+  return <span key={value}>{renderTag(value, color, variant)}</span>;
 }
 
 export function tagsRenderer(values: (number | string)[]) {
@@ -118,9 +118,10 @@ export function tagsCoursesRendererWithRemainingNumber(_: undefined, { courses }
   return <span>{tags.map(({ value, color }) => renderTag(value, color))}</span>;
 }
 
-export function renderTag(value: number | string, color?: string) {
+export function renderTag(value: number | string, color?: string, variant?: TagProps['variant']) {
+  console.log('renderTag', value, color);
   return (
-    <Tag color={color} key={value}>
+    <Tag color={color} key={value} variant={variant}>
       {value}
     </Tag>
   );
@@ -222,3 +223,4 @@ export const coloredDateRenderer = (timeZone: string, format: string, date: 'sta
     return <Text type={color}>{text}</Text>;
   };
 };
+


### PR DESCRIPTION
**Issue**:
Missing total number in `Task Performance` chart. [2951](https://github.com/rolling-scopes/rsschool-app/issues/2951)

**Description**:
- Missing total number in `Task Performance` chart
- Tooltips do not show full content
- Course tags in the mentor registry dificult to read

**Changes**
- `TaskPerformanceCard` updated to show full text in tooltips and total number in center of the chart
- `LiquidChart` updated to use app theme color for text in the center and do not show redundant tooltips (with x and y values)
- added optional `variant` argument for the `colorTagRenderer` and use it `MentorRegistryTableContainer` to increase tag readability

**Self-Check**:

<img width="637" height="461" alt="Screenshot 2026-04-18 123255" src="https://github.com/user-attachments/assets/61716624-5b3e-484e-a03b-fa5787e50888" />
<img width="637" height="469" alt="Screenshot 2026-04-18 123307" src="https://github.com/user-attachments/assets/bdc0f478-610b-4c3c-a2fc-58b6dc50ba3e" />
<img width="225" height="264" alt="Screenshot 2026-04-18 131545" src="https://github.com/user-attachments/assets/8083d94b-96da-4de5-b225-07161a143f60" />
<img width="230" height="213" alt="Screenshot 2026-04-18 131554" src="https://github.com/user-attachments/assets/762a2c05-4532-47ad-b266-3730372835bb" />


- [x] Changes tested locally