### PR TITLE
Force source alias to lowercase

### DIFF
--- a/client/src/modules/Registry/hooks/useStudentData/useStudentData.tsx
+++ b/client/src/modules/Registry/hooks/useStudentData/useStudentData.tsx
@@ -1,18 +1,17 @@
-import { useAsync } from 'react-use';
-import { Course } from '@client/services/models';
-import { UserFull, UserService } from '@client/services/user';
-import { StudentStats } from '@common/models';
-import { useCallback, useEffect, useState } from 'react';
-import { CdnService } from '@client/services/cdn';
-import { GeneralSection, DoneSection } from '@client/modules/Registry/components';
-import { Location } from '@common/models';
-import { Form, Modal, theme, Typography } from 'antd';
-import { useRouter } from 'next/router';
-import { ExclamationCircleOutlined } from '@ant-design/icons';
-import { DisciplinesApi, ProfileApi } from '@client/api';
-import { TYPES } from '@client/configs/registry';
-import { ERROR_MESSAGES } from '@client/modules/Registry/constants';
-import { useMessage } from '@client/hooks';
+import {useAsync} from 'react-use';
+import {Course} from '@client/services/models';
+import {UserFull, UserService} from '@client/services/user';
+import {Location, StudentStats} from '@common/models';
+import {useCallback, useEffect, useState} from 'react';
+import {CdnService} from '@client/services/cdn';
+import {DoneSection, GeneralSection} from '@client/modules/Registry/components';
+import {Form, Modal, theme, Typography} from 'antd';
+import {useRouter} from 'next/router';
+import {ExclamationCircleOutlined} from '@ant-design/icons';
+import {DisciplinesApi, ProfileApi} from '@client/api';
+import {TYPES} from '@client/configs/registry';
+import {ERROR_MESSAGES} from '@client/modules/Registry/constants';
+import {useMessage} from '@client/hooks';
 
 const { Title, Text } = Typography;
 
@@ -51,7 +50,7 @@ export function useStudentData(githubId: string, courseAlias?: string) {
     const registeredForCourses = enrolledOtherCourses(profileInfo?.studentStats, courses);
 
     if (courseAlias) {
-      const currentCourse = courses.find(course => course.alias === courseAlias);
+      const currentCourse = courses.find(course => course.alias.toLowerCase() === courseAlias.toLowerCase());
       const value = registeredForCourses.some(({ id }) => id === currentCourse?.id);
 
       if (currentCourse) {
@@ -316,3 +315,4 @@ async function getMissingDisciplines(
 
   return missingDisciplines;
 }
+

--- a/client/src/modules/Registry/hooks/useStudentData/useStudentData.tsx
+++ b/client/src/modules/Registry/hooks/useStudentData/useStudentData.tsx
@@ -1,17 +1,17 @@
-import {useAsync} from 'react-use';
-import {Course} from '@client/services/models';
-import {UserFull, UserService} from '@client/services/user';
-import {Location, StudentStats} from '@common/models';
-import {useCallback, useEffect, useState} from 'react';
-import {CdnService} from '@client/services/cdn';
-import {DoneSection, GeneralSection} from '@client/modules/Registry/components';
-import {Form, Modal, theme, Typography} from 'antd';
-import {useRouter} from 'next/router';
-import {ExclamationCircleOutlined} from '@ant-design/icons';
-import {DisciplinesApi, ProfileApi} from '@client/api';
-import {TYPES} from '@client/configs/registry';
-import {ERROR_MESSAGES} from '@client/modules/Registry/constants';
-import {useMessage} from '@client/hooks';
+import { useAsync } from 'react-use';
+import { Course } from '@client/services/models';
+import { UserFull, UserService } from '@client/services/user';
+import { Location, StudentStats } from '@common/models';
+import { useCallback, useEffect, useState } from 'react';
+import { CdnService } from '@client/services/cdn';
+import { DoneSection, GeneralSection } from '@client/modules/Registry/components';
+import { Form, Modal, theme, Typography } from 'antd';
+import { useRouter } from 'next/router';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
+import { DisciplinesApi, ProfileApi } from '@client/api';
+import { TYPES } from '@client/configs/registry';
+import { ERROR_MESSAGES } from '@client/modules/Registry/constants';
+import { useMessage } from '@client/hooks';
 
 const { Title, Text } = Typography;
 
@@ -315,4 +315,3 @@ async function getMissingDisciplines(
 
   return missingDisciplines;
 }
-


### PR DESCRIPTION

**Description**:
Currently query parameter with course alias case does matter: for example `registry/student?course=rs-2020-q1` !== `registry/student?course=rs-2020-Q1`.

**Changes**
Ensures that all source aliases are forcibly converted to lowercase to prevent any inconsistencies.

**Self-Check**:

- [x] Changes tested locally