### PR TITLE
fix: fix legend labels in TasksChart after migration

### DIFF
--- a/client/src/modules/StudentDashboard/components/TasksChart.tsx
+++ b/client/src/modules/StudentDashboard/components/TasksChart.tsx
@@ -2,6 +2,7 @@ import { Pie, PieConfig } from '@ant-design/plots';
 import { getTaskStatusColor } from '@client/modules/Schedule';
 import { CourseScheduleItemDtoStatusEnum } from '@client/api';
 import { useMemo } from 'react';
+import { useTheme } from '@client/shared/hooks/useTheme';
 import capitalize from 'lodash/capitalize';
 
 type Item = { status: string; value: number };
@@ -16,9 +17,11 @@ export function TasksChart({ data, onItemSelected }: Props) {
     () => data.map(d => getTaskStatusColor(d.status as CourseScheduleItemDtoStatusEnum)),
     [data],
   );
+  const { theme } = useTheme();
 
   const config: PieConfig = {
     data,
+    theme,
     angleField: 'value',
     colorField: 'status',
     radius: 1,
@@ -42,14 +45,23 @@ export function TasksChart({ data, onItemSelected }: Props) {
       color: {
         position: 'right',
         layout: { justifyContent: 'center' },
-        itemLabelText: (datum: Record<string, string>) => {
-          const item = data.find(d => d.status === datum.status);
-          return `${capitalize(datum.status)} ${item?.value ?? ''}`;
+        itemLabelText: (datum: string | { label: string; [key: string]: unknown }) => {
+          const status = typeof datum === 'object' ? datum.label : datum;
+          return status ? capitalize(status) : '';
         },
+
         itemLabelFontSize: 14,
         itemLabelFontFamily: 'sans-serif',
         rowPadding: 20,
       },
+    },
+    tooltip: {
+      items: [
+        (datum: Item) => ({
+          name: capitalize(datum.status),
+          value: datum.value,
+        }),
+      ],
     },
     interaction: {
       elementHighlight: true,


### PR DESCRIPTION
**Description**:
This PR fixes the broken legend labels in the **TasksChart** component that appeared after the recent Ant Design migration.

### The Problem:
After the migration to `antd v6` (which uses the `G2 v5` engine), the `itemLabelText` formatter in the legend started receiving different types of data at different lifecycle stages:
1. **Raw string** during the initial scale inference phase.
2. **Computed object** (e.g., `{ label: string, color: string, ... }`) during the final rendering phase.

The previous implementation did not account for the object type, which caused incorrect label rendering in the legend.

### The Solution:
- Added a type check to safely handle both strings and objects.
- Ensured the `status` is correctly extracted and formatted (capitalized) regardless of the data stage.

**Screenshots**:
| Before | After |
| :--- | :--- |
| <img width="461" height="343" alt="image" src="https://github.com/user-attachments/assets/9ca27766-9c6c-4c1e-a4f0-83516ceaecb6" /> | <img width="464" height="349" alt="image" src="https://github.com/user-attachments/assets/847c0571-71cb-49cd-a1c8-53b30c8a191a" /> |

**Self-Check**:

- [x] Changes tested locally