### PR TITLE
fix(mentor): translate unique_violation to 409 on concurrent mentor registration

### DIFF
--- a/server/src/routes/course/__test__/mentor.test.ts
+++ b/server/src/routes/course/__test__/mentor.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { QueryFailedError } from 'typeorm';
+import { isUniqueViolation } from '../../utils';
+
+describe('isUniqueViolation', () => {
+  it('returns true for postgres unique_violation (23505)', () => {
+    const err = new QueryFailedError('insert', [], { code: '23505' } as unknown as Error);
+    expect(isUniqueViolation(err)).toBe(true);
+  });
+
+  it('returns false for a different postgres error (23502 not_null_violation)', () => {
+    const err = new QueryFailedError('insert', [], { code: '23502' } as unknown as Error);
+    expect(isUniqueViolation(err)).toBe(false);
+  });
+
+  it('returns false when driverError has no code', () => {
+    const err = new QueryFailedError('insert', [], {} as Error);
+    expect(isUniqueViolation(err)).toBe(false);
+  });
+});

--- a/server/src/routes/course/mentor.ts
+++ b/server/src/routes/course/mentor.ts
@@ -1,6 +1,6 @@
 import Router from '@koa/router';
 import { BAD_REQUEST, NOT_FOUND, OK, StatusCodes } from 'http-status-codes';
-import { getCustomRepository, getRepository } from 'typeorm';
+import { getCustomRepository, getRepository, QueryFailedError } from 'typeorm';
 import { PreferredStudentsLocation } from '../../models/mentorRegistry';
 import { ILogger } from '../../logger';
 import { Mentor, MentorRegistry, Student } from '../../models';
@@ -8,7 +8,7 @@ import { StudentRepository } from '../../repositories/student.repository';
 import { courseService } from '../../services';
 import { getUserByGithubId } from '../../services/user.service';
 import { userGuards } from '../guards';
-import { setResponse } from '../utils';
+import { setResponse, isUniqueViolation } from '../utils';
 
 type Params = { courseId: number; githubId: string; courseTaskId: number };
 
@@ -77,14 +77,24 @@ export const postMentor = (_: ILogger) => async (ctx: Router.RouterContext) => {
       setResponse(ctx, StatusCodes.FORBIDDEN);
       return;
     }
-    const {
-      identifiers: [identifier],
-    } = await mentorRepository.insert({
-      courseId,
-      userId: user.id,
-      ...data,
-    });
-    mentorId = identifier['id'];
+    try {
+      const {
+        identifiers: [identifier],
+      } = await mentorRepository.insert({
+        courseId,
+        userId: user.id,
+        ...data,
+      });
+      mentorId = identifier['id'];
+    } catch (err) {
+      if (err instanceof QueryFailedError && isUniqueViolation(err)) {
+        setResponse(ctx, StatusCodes.CONFLICT, {
+          message: 'Mentor is already registered for this course (concurrent request).',
+        });
+        return;
+      }
+      throw err;
+    }
   } else {
     await mentorRepository.update(mentorId, data);
   }

--- a/server/src/routes/utils.ts
+++ b/server/src/routes/utils.ts
@@ -1,6 +1,7 @@
 import { IApiResponse } from '../models';
 import Router from '@koa/router';
 import moment from 'moment-timezone';
+import { QueryFailedError } from 'typeorm';
 
 export function setResponse<T>(
   ctx: Router.RouterContext | Router.RouterContext<any, any>,
@@ -42,3 +43,11 @@ export function setCsvResponse(
 
 export const dateFormatter = (date: string, timeZone: string, format: string) =>
   date ? moment(date).tz(timeZone).format(format) : '';
+
+export function isUniqueViolation(error: QueryFailedError): boolean {
+  // Postgres 23505 unique_violation. Reusable across route handlers that wrap
+  // typeorm insert()/save() calls in try/catch and want to translate
+  // race-condition unique-constraint failures into HTTP 409 Conflict.
+  const driverError = (error as QueryFailedError & { driverError?: { code?: string } }).driverError;
+  return driverError?.code === '23505';
+}


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
_N/A — surfaced during a TypeORM error-handling audit of `server/src/routes/`. No upstream issue. Happy to open one first if preferred per repo convention._

**Description**:

`server/src/routes/course/mentor.ts:83` calls `mentorRepository.insert({ courseId, userId, ...data })` without local error handling. The `(courseId, userId)` pair is enforced by a UNIQUE index on the `mentor` table, so two concurrent `POST /:courseId/mentor/:githubId` requests for the same user — racing past the `findOne(...)` check on line 66 — both pass the "does this mentor already exist?" guard and both attempt `INSERT`. The loser hits the unique-constraint violation, which TypeORM raises as `QueryFailedError` with `driverError.code === '23505'`.

Today that error propagates to the global `errorHandlerMiddleware` (`server/src/routes/logging.ts:13`), which logs it and returns HTTP 500 with a generic Postgres error string in the body (`duplicate key value violates unique constraint "..."`). The client sees a 500 for what is genuinely a client-recoverable conflict (the mentor IS registered — just by the other concurrent request).

This PR adds a local try/catch around the `insert(...)` call, narrows on `QueryFailedError` + the new `isUniqueViolation(err)` helper, and translates the race to HTTP 409 Conflict with `{ message: 'Mentor is already registered for this course (concurrent request).' }`. All other errors (including `QueryFailedError` with non-23505 codes) re-throw to the existing global handler — no swallowing.

The helper `isUniqueViolation(error: QueryFailedError): boolean` is added to `server/src/routes/utils.ts` so other route handlers that wrap `repo.insert()` / `repo.save()` calls can reuse it. The check is minimal (`driverError?.code === '23505'`) and matches Postgres' `unique_violation` error class.

**Self-Check**:

- [ ] Database migration added (if required) — N/A (no schema change)
- [x] Changes tested locally

### Local verification

```sh
cd server
npx vitest run src/routes/course/__test__/mentor.test.ts   # 3/3 passing
npm run compile                                            # 0 type errors
npx eslint src/routes/course/mentor.ts src/routes/utils.ts src/routes/course/__test__/mentor.test.ts   # 0 issues
npx oxfmt --check server/src/routes/course/mentor.ts server/src/routes/utils.ts server/src/routes/course/__test__/mentor.test.ts   # passes
npx vitest run                                              # full server suite: 6 files, 36/36 passing
```

The new test covers the `isUniqueViolation` helper across three branches: 23505 → true, a different SQL state (23502 not_null_violation) → false, missing driverError code → false. Happy to add a route-level integration test (mock `mentorRepository.insert` to throw, assert response status + body) if you'd prefer end-to-end coverage; it'd be one extra test file.
