### PR TITLE
fix: fix ant inputs shrink

### DIFF
--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -213,3 +213,9 @@ thead.ant-table-thead > tr > th {
 .antd-card_action_button_with_icon-fix .ant-card-actions li > span > a {
   display: flex;
 }
+
+/* FIX Issue with Checkbox #2994 https://github.com/rolling-scopes/rsschool-app/issues/2994 */
+.ant-checkbox,
+.ant-radio {
+  flex-shrink: 0;
+}


### PR DESCRIPTION
**Description**:
This PR fixes the layout issue where checkboxes and radio buttons were being compressed in flex containers, as reported in #2994.

### The Problem:
Inside flexbox layouts, checkboxes and radio buttons could shrink when the label text was long or the container width was limited. This caused visual distortion where the selection components would lose their proportions and appear "squashed".

### The Solution:
- Added `flex-shrink: 0;` to `.ant-checkbox` and `.ant-radio` styles.
- This ensures that these elements always maintain their fixed dimensions regardless of the flex container's space distribution.

**Screenshots**:
| Before | After |
| :--- | :--- |
| <img width="256" src="https://github.com/user-attachments/assets/73ec19da-d33a-418a-bc4e-80e3650f25e5" /><br><img width="340" src="https://github.com/user-attachments/assets/306a8310-5fd3-4a55-b6b6-4e87aba1c6a4" /> | <img width="230" src="https://github.com/user-attachments/assets/08a80230-d37f-40ab-81f6-49d831b60d8b" /><br><img width="349" src="https://github.com/user-attachments/assets/109977ef-5341-4f98-9322-d23c8273aa54" /> |

**Self-Check**:
- [x] Changes tested locally