### PR TITLE
feat: add ui-based submit scores

### DIFF
--- a/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
@@ -6,11 +6,7 @@ import { ManualSubmitTab } from './ManualSubmitTab';
 // (Form.Item injects `value` and `onChange` into the child via cloneElement).
 vi.mock('@client/shared/components/StudentSearch', () => ({
   StudentSearch: (props: { value?: string; onChange?: (v: string) => void }) => (
-    <input
-      data-testid="student-input"
-      value={props.value ?? ''}
-      onChange={e => props.onChange?.(e.target.value)}
-    />
+    <input data-testid="student-input" value={props.value ?? ''} onChange={e => props.onChange?.(e.target.value)} />
   ),
 }));
 

--- a/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ManualSubmitTab } from './ManualSubmitTab';
+
+// Replace StudentSearch with a simple text input that integrates with antd Form.Item
+// (Form.Item injects `value` and `onChange` into the child via cloneElement).
+vi.mock('@client/shared/components/StudentSearch', () => ({
+  StudentSearch: (props: { value?: string; onChange?: (v: string) => void }) => (
+    <input
+      data-testid="student-input"
+      value={props.value ?? ''}
+      onChange={e => props.onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+const courseTasks = [
+  { id: 1, name: 'Task A', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31' },
+  { id: 2, name: 'Task B', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31' },
+] as never;
+
+function makeProps(overrides: Partial<Parameters<typeof ManualSubmitTab>[0]> = {}) {
+  return {
+    courseId: 42,
+    courseService: { postMultipleScores: vi.fn().mockResolvedValue([]) } as never,
+    courseTasks,
+    onResults: vi.fn(),
+    onLoadingChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('<ManualSubmitTab />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders one initial row with student input, task select, score input and remove button', () => {
+    render(<ManualSubmitTab {...makeProps()} />);
+
+    expect(screen.getAllByTestId('student-input')).toHaveLength(1);
+    // antd Select renders a combobox; one combobox = one task select for one row.
+    expect(screen.getAllByRole('combobox')).toHaveLength(1);
+    // antd InputNumber renders role="spinbutton".
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /add row/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^submit$/i })).toBeInTheDocument();
+  });
+
+  it('"Add row" button appends a new row', () => {
+    render(<ManualSubmitTab {...makeProps()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add row/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add row/i }));
+
+    expect(screen.getAllByTestId('student-input')).toHaveLength(3);
+    expect(screen.getAllByRole('combobox')).toHaveLength(3);
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(3);
+  });
+
+  it('disables the remove button when only one row exists', () => {
+    render(<ManualSubmitTab {...makeProps()} />);
+
+    const removeBtn = screen.getByRole('button', { name: /remove row/i });
+    expect(removeBtn).toBeDisabled();
+  });
+
+  it('removes a row when the remove button is clicked (with >1 rows)', () => {
+    render(<ManualSubmitTab {...makeProps()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add row/i }));
+    expect(screen.getAllByTestId('student-input')).toHaveLength(2);
+
+    const [firstRemove] = screen.getAllByRole('button', { name: /remove row/i });
+    fireEvent.click(firstRemove);
+
+    expect(screen.getAllByTestId('student-input')).toHaveLength(1);
+  });
+
+  it('does not submit when all rows are empty (validation prevents submit)', async () => {
+    const props = makeProps();
+    render(<ManualSubmitTab {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    // antd validation fires asynchronously; postMultipleScores should never be called.
+    await waitFor(() => {
+      expect(props.courseService.postMultipleScores).not.toHaveBeenCalled();
+    });
+    expect(props.onResults).not.toHaveBeenCalled();
+  });
+
+  it('shows an error and does not submit when a duplicate (student, task) pair exists', async () => {
+    // Build a stub form by filling student inputs directly; tasks/scores can't be set easily
+    // through antd Select in jsdom — so we only assert the negative path of validation.
+    // (Positive submission flow is covered indirectly by aggregateResults tests.)
+    const props = makeProps();
+    render(<ManualSubmitTab {...props} />);
+
+    // Two rows, both with the same student. Task/score remain empty → required validators
+    // will block before our duplicate check, but the key invariant is the same: no network.
+    fireEvent.click(screen.getByRole('button', { name: /add row/i }));
+    const inputs = screen.getAllByTestId('student-input');
+    fireEvent.change(inputs[0], { target: { value: 'alice' } });
+    fireEvent.change(inputs[1], { target: { value: 'alice' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await waitFor(() => {
+      expect(props.courseService.postMultipleScores).not.toHaveBeenCalled();
+    });
+  });
+
+  it('renders the configured task options in each row select', () => {
+    render(<ManualSubmitTab {...makeProps()} />);
+
+    // Open the first row's task combobox; antd renders options into the document body.
+    const combobox = screen.getAllByRole('combobox')[0];
+    fireEvent.mouseDown(combobox);
+
+    // After opening, options become visible somewhere in the document.
+    return waitFor(() => {
+      const popup = document.body;
+      expect(within(popup).getByText('Task A')).toBeInTheDocument();
+      expect(within(popup).getByText('Task B')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
@@ -11,8 +11,8 @@ vi.mock('@client/shared/components/StudentSearch', () => ({
 }));
 
 const courseTasks = [
-  { id: 1, name: 'Task A', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31' },
-  { id: 2, name: 'Task B', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31' },
+  { id: 1, name: 'Task A', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31', maxScore: 100 },
+  { id: 2, name: 'Task B', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31', maxScore: 50 },
 ] as never;
 
 function makeProps(overrides: Partial<Parameters<typeof ManualSubmitTab>[0]> = {}) {
@@ -98,8 +98,8 @@ describe('<ManualSubmitTab />', () => {
     // After opening, options become visible somewhere in the document.
     return waitFor(() => {
       const popup = document.body;
-      expect(within(popup).getByText('Task A')).toBeInTheDocument();
-      expect(within(popup).getByText('Task B')).toBeInTheDocument();
+      expect(within(popup).getByText('Task A (max 100)')).toBeInTheDocument();
+      expect(within(popup).getByText('Task B (max 50)')).toBeInTheDocument();
     });
   });
 });

--- a/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.test.tsx
@@ -84,26 +84,9 @@ describe('<ManualSubmitTab />', () => {
     expect(props.onResults).not.toHaveBeenCalled();
   });
 
-  it('shows an error and does not submit when a duplicate (student, task) pair exists', async () => {
-    // Build a stub form by filling student inputs directly; tasks/scores can't be set easily
-    // through antd Select in jsdom — so we only assert the negative path of validation.
-    // (Positive submission flow is covered indirectly by aggregateResults tests.)
-    const props = makeProps();
-    render(<ManualSubmitTab {...props} />);
-
-    // Two rows, both with the same student. Task/score remain empty → required validators
-    // will block before our duplicate check, but the key invariant is the same: no network.
-    fireEvent.click(screen.getByRole('button', { name: /add row/i }));
-    const inputs = screen.getAllByTestId('student-input');
-    fireEvent.change(inputs[0], { target: { value: 'alice' } });
-    fireEvent.change(inputs[1], { target: { value: 'alice' } });
-
-    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
-
-    await waitFor(() => {
-      expect(props.courseService.postMultipleScores).not.toHaveBeenCalled();
-    });
-  });
+  // Note: the (student, task) duplicate-detection logic itself is covered by unit tests
+  // for `findDuplicateRow` in utils.test.ts. Driving antd Select/InputNumber through
+  // jsdom is too brittle to be worth a parallel integration test here.
 
   it('renders the configured task options in each row select', () => {
     render(<ManualSubmitTab {...makeProps()} />);

--- a/client/src/modules/SubmitScores/ManualSubmitTab.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from 'react';
+import { Button, Form, InputNumber, Select, Space, Table } from 'antd';
+import MinusCircleOutlined from '@ant-design/icons/MinusCircleOutlined';
+import PlusOutlined from '@ant-design/icons/PlusOutlined';
+import groupBy from 'lodash/groupBy';
+import { CourseService } from '@client/services/course';
+import { CourseTaskDto } from '@client/api';
+import { StudentSearch } from '@client/shared/components/StudentSearch';
+import { useMessage } from '@client/hooks';
+import { aggregateResults, SubmitResult } from './utils';
+
+interface ManualRow {
+  studentGithubId?: string;
+  courseTaskId?: number;
+  score?: number;
+}
+
+interface ManualFormValues {
+  rows: ManualRow[];
+}
+
+interface Props {
+  courseId: number;
+  courseService: CourseService;
+  courseTasks: CourseTaskDto[];
+  onResults: (results: SubmitResult[]) => void;
+  onLoadingChange: (loading: boolean) => void;
+}
+
+export function ManualSubmitTab({ courseId, courseService, courseTasks, onResults, onLoadingChange }: Props) {
+  const { message } = useMessage();
+  const [form] = Form.useForm<ManualFormValues>();
+  const [submitting, setSubmitting] = useState(false);
+
+  const taskOptions = useMemo(
+    () =>
+      [...courseTasks]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(task => ({ label: task.name, value: task.id })),
+    [courseTasks],
+  );
+
+  const handleSubmit = async (values: ManualFormValues) => {
+    const rows = (values.rows ?? []).filter(
+      r => r && r.studentGithubId && r.courseTaskId != null && r.score != null,
+    ) as Required<ManualRow>[];
+
+    if (rows.length === 0) {
+      message.error('Add at least one row to submit.');
+      return;
+    }
+
+    // Detect duplicate (student, task) pairs within the batch.
+    const seen = new Set<string>();
+    for (const r of rows) {
+      const key = `${r.courseTaskId}::${r.studentGithubId.toLowerCase()}`;
+      if (seen.has(key)) {
+        message.error(`Duplicate row: ${r.studentGithubId} for the same task. Remove one of them.`);
+        return;
+      }
+      seen.add(key);
+    }
+
+    try {
+      setSubmitting(true);
+      onLoadingChange(true);
+      onResults([]);
+
+      const groups = groupBy(rows, r => String(r.courseTaskId));
+
+      const responses = await Promise.all(
+        Object.entries(groups).map(([courseTaskId, items]) =>
+          courseService.postMultipleScores(
+            Number(courseTaskId),
+            items.map(({ studentGithubId, score }) => ({ studentGithubId, score })),
+          ),
+        ),
+      );
+
+      const flat = responses.flat() as { status: string; value: string | number }[];
+      onResults(aggregateResults(flat));
+      form.resetFields();
+      message.success('Scores have been submitted.');
+    } catch {
+      message.error('An error occurred. Please try later.');
+    } finally {
+      setSubmitting(false);
+      onLoadingChange(false);
+    }
+  };
+
+  return (
+    <Form form={form} onFinish={handleSubmit} layout="vertical" initialValues={{ rows: [{}] }}>
+      <Form.List name="rows">
+        {(fields, { add, remove }) => {
+          const columns = [
+            {
+              title: 'Student (GitHub)',
+              key: 'student',
+              width: '40%',
+              render: (_: unknown, field: (typeof fields)[number]) => (
+                <Form.Item
+                  name={[field.name, 'studentGithubId']}
+                  rules={[{ required: true, message: 'Select a student' }]}
+                  style={{ marginBottom: 0 }}
+                >
+                  <StudentSearch courseId={courseId} keyField="githubId" style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Course Task',
+              key: 'task',
+              width: '40%',
+              render: (_: unknown, field: (typeof fields)[number]) => (
+                <Form.Item
+                  name={[field.name, 'courseTaskId']}
+                  rules={[{ required: true, message: 'Select a task' }]}
+                  style={{ marginBottom: 0 }}
+                >
+                  <Select
+                    showSearch
+                    placeholder="Select task"
+                    optionFilterProp="label"
+                    options={taskOptions}
+                    style={{ width: '100%' }}
+                  />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Score',
+              key: 'score',
+              width: '15%',
+              render: (_: unknown, field: (typeof fields)[number]) => (
+                <Form.Item
+                  name={[field.name, 'score']}
+                  rules={[{ required: true, message: 'Enter score' }]}
+                  style={{ marginBottom: 0 }}
+                >
+                  <InputNumber min={0} style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: '',
+              key: 'actions',
+              width: '5%',
+              render: (_: unknown, field: (typeof fields)[number]) => (
+                <Button
+                  type="text"
+                  icon={<MinusCircleOutlined />}
+                  onClick={() => remove(field.name)}
+                  disabled={fields.length === 1}
+                  aria-label="Remove row"
+                />
+              ),
+            },
+          ];
+
+          return (
+            <>
+              <Table
+                rowKey="key"
+                size="small"
+                pagination={false}
+                dataSource={fields}
+                columns={columns}
+                style={{ marginBottom: '1em' }}
+              />
+              <Form.Item>
+                <Button onClick={() => add({})} icon={<PlusOutlined />} block>
+                  Add row
+                </Button>
+              </Form.Item>
+            </>
+          );
+        }}
+      </Form.List>
+      <Form.Item>
+        <Space>
+          <Button type="primary" htmlType="submit" loading={submitting} size="large">
+            Submit
+          </Button>
+        </Space>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/client/src/modules/SubmitScores/ManualSubmitTab.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.tsx
@@ -7,16 +7,12 @@ import { CourseService } from '@client/services/course';
 import { CourseTaskDto } from '@client/api';
 import { StudentSearch } from '@client/shared/components/StudentSearch';
 import { useMessage } from '@client/hooks';
-import { aggregateResults, SubmitResult } from './utils';
+import { aggregateResults, findDuplicateRow, ManualRow, SubmitResult } from './utils';
 
-interface ManualRow {
-  studentGithubId?: string;
-  courseTaskId?: number;
-  score?: number;
-}
+type ManualFormRow = Partial<ManualRow>;
 
 interface ManualFormValues {
-  rows: ManualRow[];
+  rows: ManualFormRow[];
 }
 
 interface Props {
@@ -39,24 +35,21 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
   );
 
   const handleSubmit = async (values: ManualFormValues) => {
-    const rows = (values.rows ?? []).filter(
-      r => r && r.studentGithubId && r.courseTaskId != null && r.score != null,
-    ) as Required<ManualRow>[];
+    const rows: ManualRow[] = (values.rows ?? []).flatMap(r =>
+      r && r.studentGithubId && r.courseTaskId != null && r.score != null
+        ? [{ studentGithubId: r.studentGithubId, courseTaskId: r.courseTaskId, score: r.score }]
+        : [],
+    );
 
     if (rows.length === 0) {
       message.error('Add at least one row to submit.');
       return;
     }
 
-    // Detect duplicate (student, task) pairs within the batch.
-    const seen = new Set<string>();
-    for (const r of rows) {
-      const key = `${r.courseTaskId}::${r.studentGithubId.toLowerCase()}`;
-      if (seen.has(key)) {
-        message.error(`Duplicate row: ${r.studentGithubId} for the same task. Remove one of them.`);
-        return;
-      }
-      seen.add(key);
+    const duplicate = findDuplicateRow(rows);
+    if (duplicate) {
+      message.error(`Duplicate row: ${duplicate.studentGithubId} for the same task. Remove one of them.`);
+      return;
     }
 
     try {
@@ -75,8 +68,7 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
         ),
       );
 
-      const flat = responses.flat() as { status: string; value: string | number }[];
-      onResults(aggregateResults(flat));
+      onResults(aggregateResults(responses.flat()));
       form.resetFields();
       message.success('Scores have been submitted.');
     } catch {

--- a/client/src/modules/SubmitScores/ManualSubmitTab.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.tsx
@@ -34,9 +34,7 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
 
   const taskOptions = useMemo(
     () =>
-      [...courseTasks]
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(task => ({ label: task.name, value: task.id })),
+      [...courseTasks].sort((a, b) => a.name.localeCompare(b.name)).map(task => ({ label: task.name, value: task.id })),
     [courseTasks],
   );
 

--- a/client/src/modules/SubmitScores/ManualSubmitTab.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.tsx
@@ -31,7 +31,14 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
 
   const taskOptions = useMemo(
     () =>
-      [...courseTasks].sort((a, b) => a.name.localeCompare(b.name)).map(task => ({ label: task.name, value: task.id })),
+      [...courseTasks]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(task => ({ label: `${task.name} (max ${task.maxScore})`, value: task.id })),
+    [courseTasks],
+  );
+
+  const maxScoreByTaskId = useMemo(
+    () => new Map<number, number>(courseTasks.map(t => [t.id, t.maxScore])),
     [courseTasks],
   );
 
@@ -115,6 +122,7 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
                     optionFilterProp="label"
                     options={taskOptions}
                     className={styles.fullWidth}
+                    onChange={() => form.validateFields([['rows', field.name, 'score']]).catch(() => {})}
                   />
                 </Form.Item>
               ),
@@ -125,11 +133,31 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
               width: '15%',
               render: (_: unknown, field: (typeof fields)[number]) => (
                 <Form.Item
-                  name={[field.name, 'score']}
-                  rules={[{ required: true, message: 'Enter score' }]}
-                  className={styles.rowFormItem}
+                  noStyle
+                  shouldUpdate={(prev: ManualFormValues, curr: ManualFormValues) =>
+                    prev?.rows?.[field.name]?.courseTaskId !== curr?.rows?.[field.name]?.courseTaskId
+                  }
                 >
-                  <InputNumber min={0} className={styles.fullWidth} />
+                  {({ getFieldValue }) => {
+                    const taskId = getFieldValue(['rows', field.name, 'courseTaskId']) as number | undefined;
+                    const max = taskId != null ? maxScoreByTaskId.get(taskId) : undefined;
+                    return (
+                      <Form.Item
+                        name={[field.name, 'score']}
+                        rules={[
+                          { required: true, message: 'Enter score' },
+                          {
+                            type: 'number',
+                            max,
+                            message: max != null ? `Max ${max}` : undefined,
+                          },
+                        ]}
+                        className={styles.rowFormItem}
+                      >
+                        <InputNumber min={0} max={max} className={styles.fullWidth} />
+                      </Form.Item>
+                    );
+                  }}
                 </Form.Item>
               ),
             },

--- a/client/src/modules/SubmitScores/ManualSubmitTab.tsx
+++ b/client/src/modules/SubmitScores/ManualSubmitTab.tsx
@@ -8,6 +8,7 @@ import { CourseTaskDto } from '@client/api';
 import { StudentSearch } from '@client/shared/components/StudentSearch';
 import { useMessage } from '@client/hooks';
 import { aggregateResults, findDuplicateRow, ManualRow, SubmitResult } from './utils';
+import styles from './SubmitScores.module.css';
 
 type ManualFormRow = Partial<ManualRow>;
 
@@ -92,9 +93,9 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
                 <Form.Item
                   name={[field.name, 'studentGithubId']}
                   rules={[{ required: true, message: 'Select a student' }]}
-                  style={{ marginBottom: 0 }}
+                  className={styles.rowFormItem}
                 >
-                  <StudentSearch courseId={courseId} keyField="githubId" style={{ width: '100%' }} />
+                  <StudentSearch courseId={courseId} keyField="githubId" className={styles.fullWidth} />
                 </Form.Item>
               ),
             },
@@ -106,14 +107,14 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
                 <Form.Item
                   name={[field.name, 'courseTaskId']}
                   rules={[{ required: true, message: 'Select a task' }]}
-                  style={{ marginBottom: 0 }}
+                  className={styles.rowFormItem}
                 >
                   <Select
                     showSearch
                     placeholder="Select task"
                     optionFilterProp="label"
                     options={taskOptions}
-                    style={{ width: '100%' }}
+                    className={styles.fullWidth}
                   />
                 </Form.Item>
               ),
@@ -126,9 +127,9 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
                 <Form.Item
                   name={[field.name, 'score']}
                   rules={[{ required: true, message: 'Enter score' }]}
-                  style={{ marginBottom: 0 }}
+                  className={styles.rowFormItem}
                 >
-                  <InputNumber min={0} style={{ width: '100%' }} />
+                  <InputNumber min={0} className={styles.fullWidth} />
                 </Form.Item>
               ),
             },
@@ -156,7 +157,7 @@ export function ManualSubmitTab({ courseId, courseService, courseTasks, onResult
                 pagination={false}
                 dataSource={fields}
                 columns={columns}
-                style={{ marginBottom: '1em' }}
+                className={styles.rowsTable}
               />
               <Form.Item>
                 <Button onClick={() => add({})} icon={<PlusOutlined />} block>

--- a/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
+++ b/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
@@ -23,8 +23,22 @@ vi.mock('@client/domain/user', () => ({
 const { getCourseTasks } = vi.hoisted(() => ({
   getCourseTasks: vi.fn().mockResolvedValue({
     data: [
-      { id: 1, name: 'Task A', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31', taskOwner: null },
-      { id: 2, name: 'Task B', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31', taskOwner: null },
+      {
+        id: 1,
+        name: 'Task A',
+        studentStartDate: '2024-01-01',
+        studentEndDate: '2024-12-31',
+        taskOwner: null,
+        maxScore: 100,
+      },
+      {
+        id: 2,
+        name: 'Task B',
+        studentStartDate: '2024-01-01',
+        studentEndDate: '2024-12-31',
+        taskOwner: null,
+        maxScore: 50,
+      },
     ],
   }),
 }));

--- a/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
+++ b/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReactNode } from 'react';
+import { SubmitScorePage } from '@client/pages/course/submit-scores';
+
+// --- Mocks -----------------------------------------------------------------
+
+vi.mock('next/config', () => ({ default: () => ({}) }));
+
+vi.mock('@client/modules/Course/contexts', () => ({
+  SessionProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SessionContext: { Provider: ({ children }: { children: ReactNode }) => <>{children}</>, _currentValue: {} },
+  useActiveCourseContext: () => ({ course: { id: 42, name: 'Test Course' } }),
+}));
+
+// Provide a stub `useContext(SessionContext)` value.
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    useContext: (ctx: unknown) => {
+      // Return a permissive session — course manager for course 42.
+      if (ctx && typeof ctx === 'object') {
+        return { id: 1, isAdmin: true, courses: { 42: { roles: ['manager'] } } };
+      }
+      return actual.useContext(ctx as React.Context<unknown>);
+    },
+  };
+});
+
+vi.mock('@client/domain/user', () => ({
+  isCourseManager: () => true,
+}));
+
+const { getCourseTasks } = vi.hoisted(() => ({
+  getCourseTasks: vi.fn().mockResolvedValue({
+    data: [
+      { id: 1, name: 'Task A', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31', taskOwner: null },
+      { id: 2, name: 'Task B', studentStartDate: '2024-01-01', studentEndDate: '2024-12-31', taskOwner: null },
+    ],
+  }),
+}));
+
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  CoursesTasksApi: function CoursesTasksApi() {
+    return { getCourseTasks };
+  },
+}));
+
+vi.mock('@client/services/course', () => ({
+  CourseService: function CourseService() {
+    return {
+      postMultipleScores: vi.fn().mockResolvedValue([]),
+      searchStudents: vi.fn().mockResolvedValue([]),
+    };
+  },
+}));
+
+vi.mock('@client/shared/components/StudentSearch', () => ({
+  StudentSearch: (props: { value?: string; onChange?: (v: string) => void }) => (
+    <input
+      data-testid="student-input"
+      value={props.value ?? ''}
+      onChange={e => props.onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+// PageLayoutSimple may pull in heavy deps; replace with a passthrough.
+vi.mock('@client/shared/components/PageLayout', () => ({
+  PageLayoutSimple: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+// --- Tests -----------------------------------------------------------------
+
+describe('<SubmitScorePage />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the page with both "Upload CSV" and "Manual Entry" tabs', async () => {
+    render(<SubmitScorePage />);
+
+    expect(screen.getByRole('heading', { name: /submit scores/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /upload csv/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /manual entry/i })).toBeInTheDocument();
+  });
+
+  it('shows the CSV tab by default with the file uploader and uploading rules', async () => {
+    render(<SubmitScorePage />);
+
+    // Default tab — CSV.
+    expect(screen.getByText(/uploading rules/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select files/i })).toBeInTheDocument();
+  });
+
+  it('switches to the Manual Entry tab and shows manual form controls', async () => {
+    render(<SubmitScorePage />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /manual entry/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add row/i })).toBeInTheDocument();
+    });
+    // One initial row → one student input.
+    expect(screen.getAllByTestId('student-input')).toHaveLength(1);
+  });
+
+  it('fetches course tasks on mount', async () => {
+    render(<SubmitScorePage />);
+
+    await waitFor(() => {
+      expect(getCourseTasks).toHaveBeenCalledWith(42);
+    });
+  });
+});

--- a/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
+++ b/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
@@ -59,11 +59,7 @@ vi.mock('@client/services/course', () => ({
 
 vi.mock('@client/shared/components/StudentSearch', () => ({
   StudentSearch: (props: { value?: string; onChange?: (v: string) => void }) => (
-    <input
-      data-testid="student-input"
-      value={props.value ?? ''}
-      onChange={e => props.onChange?.(e.target.value)}
-    />
+    <input data-testid="student-input" value={props.value ?? ''} onChange={e => props.onChange?.(e.target.value)} />
   ),
 }));
 

--- a/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
+++ b/client/src/modules/SubmitScores/SubmitScorePage.test.tsx
@@ -1,32 +1,20 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ReactNode } from 'react';
+import { ReactNode, createContext } from 'react';
 import { SubmitScorePage } from '@client/pages/course/submit-scores';
 
 // --- Mocks -----------------------------------------------------------------
 
 vi.mock('next/config', () => ({ default: () => ({}) }));
 
+// Provide a real React context for SessionContext so `useContext(SessionContext)` in the
+// component returns our test session via the context's default value — without
+// monkey-patching React.useContext globally (which would also affect antd's internals).
 vi.mock('@client/modules/Course/contexts', () => ({
   SessionProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
-  SessionContext: { Provider: ({ children }: { children: ReactNode }) => <>{children}</>, _currentValue: {} },
+  SessionContext: createContext({ id: 1, isAdmin: true, courses: { 42: { roles: ['manager'] } } }),
   useActiveCourseContext: () => ({ course: { id: 42, name: 'Test Course' } }),
 }));
-
-// Provide a stub `useContext(SessionContext)` value.
-vi.mock('react', async () => {
-  const actual = await vi.importActual<typeof import('react')>('react');
-  return {
-    ...actual,
-    useContext: (ctx: unknown) => {
-      // Return a permissive session — course manager for course 42.
-      if (ctx && typeof ctx === 'object') {
-        return { id: 1, isAdmin: true, courses: { 42: { roles: ['manager'] } } };
-      }
-      return actual.useContext(ctx as React.Context<unknown>);
-    },
-  };
-});
 
 vi.mock('@client/domain/user', () => ({
   isCourseManager: () => true,

--- a/client/src/modules/SubmitScores/SubmitScores.module.css
+++ b/client/src/modules/SubmitScores/SubmitScores.module.css
@@ -1,0 +1,29 @@
+/* submit-scores.tsx (page) */
+.rulesList {
+  margin-bottom: 1em;
+}
+
+.submitButton {
+  margin-right: 1.5em;
+}
+
+.resultsSection {
+  margin-top: 1.5em;
+}
+
+.skippedList {
+  margin-bottom: 1em;
+}
+
+/* ManualSubmitTab.tsx */
+.rowFormItem {
+  margin-bottom: 0;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.rowsTable {
+  margin-bottom: 1em;
+}

--- a/client/src/modules/SubmitScores/utils.test.ts
+++ b/client/src/modules/SubmitScores/utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateResults } from './utils';
+
+describe('aggregateResults', () => {
+  it('returns an empty array for empty input', () => {
+    expect(aggregateResults([])).toEqual([]);
+  });
+
+  it('groups results by status and counts occurrences', () => {
+    const result = aggregateResults([
+      { status: 'created', value: 1 },
+      { status: 'created', value: 2 },
+      { status: 'updated', value: 3 },
+    ]);
+
+    expect(result).toEqual([
+      { status: 'created', count: 2, messages: undefined },
+      { status: 'updated', count: 1, messages: undefined },
+    ]);
+  });
+
+  it('collects messages only for "skipped" entries with string values', () => {
+    const result = aggregateResults([
+      { status: 'skipped', value: 'alice' },
+      { status: 'skipped', value: 'bob' },
+      { status: 'created', value: 1 },
+    ]);
+
+    const skipped = result.find(r => r.status === 'skipped');
+    const created = result.find(r => r.status === 'created');
+
+    expect(skipped).toEqual({ status: 'skipped', count: 2, messages: ['alice', 'bob'] });
+    expect(created).toEqual({ status: 'created', count: 1, messages: undefined });
+  });
+
+  it('does not collect messages when "skipped" value is not a string', () => {
+    const result = aggregateResults([
+      { status: 'skipped', value: 42 },
+      { status: 'skipped', value: 'charlie' },
+    ]);
+
+    expect(result).toEqual([{ status: 'skipped', count: 2, messages: ['charlie'] }]);
+  });
+
+  it('handles a mixed batch and preserves first-seen status order', () => {
+    const result = aggregateResults([
+      { status: 'updated', value: 1 },
+      { status: 'created', value: 2 },
+      { status: 'skipped', value: 'no-such-user' },
+      { status: 'updated', value: 3 },
+      { status: 'failed', value: 'boom' },
+      { status: 'skipped', value: 'another-user' },
+    ]);
+
+    expect(result.map(r => r.status)).toEqual(['updated', 'created', 'skipped', 'failed']);
+    expect(result.find(r => r.status === 'updated')?.count).toBe(2);
+    expect(result.find(r => r.status === 'skipped')?.messages).toEqual(['no-such-user', 'another-user']);
+    expect(result.find(r => r.status === 'failed')?.messages).toBeUndefined();
+  });
+
+  it('treats unknown statuses generically without collecting messages', () => {
+    const result = aggregateResults([
+      { status: 'mystery', value: 'whatever' },
+      { status: 'mystery', value: 'else' },
+    ]);
+
+    expect(result).toEqual([{ status: 'mystery', count: 2, messages: undefined }]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { status: 'created', value: 1 },
+      { status: 'skipped', value: 'x' },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    aggregateResults(input);
+
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/client/src/modules/SubmitScores/utils.test.ts
+++ b/client/src/modules/SubmitScores/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { aggregateResults } from './utils';
+import { aggregateResults, findDuplicateRow } from './utils';
 
 describe('aggregateResults', () => {
   it('returns an empty array for empty input', () => {
@@ -67,6 +67,19 @@ describe('aggregateResults', () => {
     expect(result).toEqual([{ status: 'mystery', count: 2, messages: undefined }]);
   });
 
+  it('treats `undefined` value (created/updated) without collecting messages', () => {
+    const result = aggregateResults([
+      { status: 'created', value: undefined },
+      { status: 'updated', value: undefined },
+      { status: 'created', value: undefined },
+    ]);
+
+    expect(result).toEqual([
+      { status: 'created', count: 2, messages: undefined },
+      { status: 'updated', count: 1, messages: undefined },
+    ]);
+  });
+
   it('does not mutate the input array', () => {
     const input = [
       { status: 'created', value: 1 },
@@ -77,5 +90,49 @@ describe('aggregateResults', () => {
     aggregateResults(input);
 
     expect(input).toEqual(snapshot);
+  });
+});
+
+describe('findDuplicateRow', () => {
+  it('returns null for an empty list', () => {
+    expect(findDuplicateRow([])).toBeNull();
+  });
+
+  it('returns null when all rows are unique', () => {
+    expect(
+      findDuplicateRow([
+        { studentGithubId: 'alice', courseTaskId: 1, score: 10 },
+        { studentGithubId: 'bob', courseTaskId: 1, score: 5 },
+        { studentGithubId: 'alice', courseTaskId: 2, score: 7 },
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns the second occurrence when (student, task) repeats', () => {
+    const rows = [
+      { studentGithubId: 'alice', courseTaskId: 1, score: 10 },
+      { studentGithubId: 'bob', courseTaskId: 1, score: 5 },
+      { studentGithubId: 'alice', courseTaskId: 1, score: 99 },
+    ];
+
+    expect(findDuplicateRow(rows)).toEqual(rows[2]);
+  });
+
+  it('treats githubId case-insensitively', () => {
+    const rows = [
+      { studentGithubId: 'Alice', courseTaskId: 1, score: 10 },
+      { studentGithubId: 'alice', courseTaskId: 1, score: 99 },
+    ];
+
+    expect(findDuplicateRow(rows)).toEqual(rows[1]);
+  });
+
+  it('does not flag the same student on different tasks', () => {
+    expect(
+      findDuplicateRow([
+        { studentGithubId: 'alice', courseTaskId: 1, score: 10 },
+        { studentGithubId: 'alice', courseTaskId: 2, score: 10 },
+      ]),
+    ).toBeNull();
   });
 });

--- a/client/src/modules/SubmitScores/utils.ts
+++ b/client/src/modules/SubmitScores/utils.ts
@@ -26,9 +26,7 @@ export function aggregateResults(results: RawResult[]): SubmitResult[] {
         status,
         count: current.count + 1,
         messages:
-          status === 'skipped' && typeof value === 'string'
-            ? (current.messages ?? []).concat(value)
-            : current.messages,
+          status === 'skipped' && typeof value === 'string' ? (current.messages ?? []).concat(value) : current.messages,
       });
     } else {
       groupedByStatus.set(status, {

--- a/client/src/modules/SubmitScores/utils.ts
+++ b/client/src/modules/SubmitScores/utils.ts
@@ -4,9 +4,17 @@ export interface SubmitResult {
   messages?: string[];
 }
 
-interface RawResult {
+export interface RawResult {
   status: string;
-  value: string | number;
+  // Backend (createMultipleScores.ts) returns `value: undefined` for `created`/`updated`
+  // and `value: <message>` for `skipped`/`failed`.
+  value?: string | number;
+}
+
+export interface ManualRow {
+  studentGithubId: string;
+  courseTaskId: number;
+  score: number;
 }
 
 /**
@@ -38,4 +46,20 @@ export function aggregateResults(results: RawResult[]): SubmitResult[] {
   });
 
   return Array.from(groupedByStatus.values());
+}
+
+/**
+ * Returns the first row that duplicates a previous one by (courseTaskId, studentGithubId),
+ * case-insensitive on githubId. Returns null when no duplicates are found.
+ *
+ * Used by the manual submit flow to surface a meaningful error before sending the batch.
+ */
+export function findDuplicateRow(rows: ManualRow[]): ManualRow | null {
+  const seen = new Set<string>();
+  for (const r of rows) {
+    const key = `${r.courseTaskId}::${r.studentGithubId.toLowerCase()}`;
+    if (seen.has(key)) return r;
+    seen.add(key);
+  }
+  return null;
 }

--- a/client/src/modules/SubmitScores/utils.ts
+++ b/client/src/modules/SubmitScores/utils.ts
@@ -1,0 +1,43 @@
+export interface SubmitResult {
+  status: string;
+  count: number;
+  messages?: string[];
+}
+
+interface RawResult {
+  status: string;
+  value: string | number;
+}
+
+/**
+ * Aggregates raw per-student results returned by `POST /course/:id/scores/:taskId`
+ * into a summary grouped by status (`created`, `updated`, `skipped`, `failed`).
+ *
+ * Shared between CSV upload and manual submit flows.
+ */
+export function aggregateResults(results: RawResult[]): SubmitResult[] {
+  const groupedByStatus = new Map<string, SubmitResult>();
+
+  results.forEach(({ status, value }) => {
+    const current = groupedByStatus.get(status);
+
+    if (current) {
+      groupedByStatus.set(status, {
+        status,
+        count: current.count + 1,
+        messages:
+          status === 'skipped' && typeof value === 'string'
+            ? (current.messages ?? []).concat(value)
+            : current.messages,
+      });
+    } else {
+      groupedByStatus.set(status, {
+        status,
+        count: 1,
+        messages: status === 'skipped' && typeof value === 'string' ? [value] : undefined,
+      });
+    }
+  });
+
+  return Array.from(groupedByStatus.values());
+}

--- a/client/src/pages/course/submit-scores.tsx
+++ b/client/src/pages/course/submit-scores.tsx
@@ -153,7 +153,7 @@ export function SubmitScorePage() {
         ]}
       />
       {submitResults.length ? (
-        <Form.Item>
+        <div style={{ marginTop: '1.5em' }}>
           <h3>Summary</h3>
           <Table
             pagination={false}
@@ -171,10 +171,10 @@ export function SubmitScorePage() {
               },
             ]}
           />
-        </Form.Item>
+        </div>
       ) : null}
       {skippedStudents.length ? (
-        <Form.Item>
+        <div style={{ marginTop: '1.5em' }}>
           <h3>Skipped students</h3>
           <List
             size="small"
@@ -183,7 +183,7 @@ export function SubmitScorePage() {
             renderItem={item => <List.Item>{item}</List.Item>}
             style={{ marginBottom: '1em' }}
           />
-        </Form.Item>
+        </div>
       ) : null}
     </PageLayoutSimple>
   );
@@ -247,7 +247,7 @@ async function uploadResults(
   data: StudentScore[],
 ): Promise<SubmitResult[]> {
   const results = await courseService.postMultipleScores(courseTaskId, data);
-  return aggregateResults(results as { status: string; value: string | number }[]);
+  return aggregateResults(results);
 }
 
 function Page() {

--- a/client/src/pages/course/submit-scores.tsx
+++ b/client/src/pages/course/submit-scores.tsx
@@ -1,5 +1,5 @@
 import UploadOutlined from '@ant-design/icons/UploadOutlined';
-import { Button, Form, Space, Table, Typography, Upload } from 'antd';
+import { Button, Form, Space, Table, Tabs, Typography, Upload } from 'antd';
 import type { UploadChangeParam, UploadFile } from 'antd/lib/upload/interface';
 import { PageLayoutSimple } from '@client/shared/components/PageLayout';
 import { CourseTaskSelect } from '@client/shared/components/Forms';
@@ -15,12 +15,8 @@ import { SessionContext, SessionProvider, useActiveCourseContext } from '@client
 import { CourseRole } from '@client/services/models';
 import { useMessage } from '@client/hooks';
 import { List } from '@client/shared/components/List';
-
-interface SubmitResult {
-  status: string;
-  count: number;
-  messages?: string[];
-}
+import { ManualSubmitTab } from '@client/modules/SubmitScores/ManualSubmitTab';
+import { aggregateResults, SubmitResult } from '@client/modules/SubmitScores/utils';
 
 interface SubmitFormValues {
   files: {
@@ -93,85 +89,102 @@ export function SubmitScorePage() {
   const [skipped] = submitResults.filter(({ status }) => status === 'skipped');
   const skippedStudents = skipped && skipped.messages ? skipped.messages : [];
 
+  const csvTab = (
+    <Form form={form} onFinish={handleSubmit} layout="vertical">
+      <CourseTaskSelect data={courseTasks} onChange={handleTaskChange} />
+      <h3>Uploading rules</h3>
+      <List
+        size="small"
+        bordered
+        dataSource={[
+          'CSV-file should contain columns "Score" and "GitHub".',
+          '"GitHub" fields could be links or plain names.',
+          'For duplicated "GitHub" fields the best score would be counted.',
+          'You should upload several files, if you need scoring the best result from two or more tests.',
+          'Only students in the file would be scored. By the way, you can update just several scores.',
+        ]}
+        renderItem={(item, idx) => (
+          <List.Item>
+            <Space>
+              <Typography.Text strong>{idx + 1}</Typography.Text>
+              <Typography.Text>{item}</Typography.Text>
+            </Space>
+          </List.Item>
+        )}
+        style={{ marginBottom: '1em' }}
+      />
+      <Form.Item label="CSV File" name="files" rules={[{ required: true, message: 'Please select csv-file' }]}>
+        <Upload
+          beforeUpload={() => false}
+          fileList={Array.from(selectedFileList).map(([, file]) => file)}
+          onChange={handleFileChose}
+          accept=".csv"
+          multiple
+        >
+          <Button>
+            <UploadOutlined /> Select files
+          </Button>
+        </Upload>
+      </Form.Item>
+      <Button size="large" type="primary" htmlType="submit" style={{ marginRight: '1.5em' }}>
+        Submit
+      </Button>
+    </Form>
+  );
+
+  const manualTab = (
+    <ManualSubmitTab
+      courseId={courseId}
+      courseService={courseService}
+      courseTasks={courseTasks}
+      onResults={setSubmitResults}
+      onLoadingChange={setLoading}
+    />
+  );
+
   return (
     <PageLayoutSimple loading={loading} title="Submit Scores" showCourseName>
-      <Form form={form} onFinish={handleSubmit} layout="vertical">
-        <CourseTaskSelect data={courseTasks} onChange={handleTaskChange} />
-        <h3>Uploading rules</h3>
-        <List
-          size="small"
-          bordered
-          dataSource={[
-            'CSV-file should contain columns "Score" and "GitHub".',
-            '"GitHub" fields could be links or plain names.',
-            'For duplicated "GitHub" fields the best score would be counted.',
-            'You should upload several files, if you need scoring the best result from two or more tests.',
-            'Only students in the file would be scored. By the way, you can update just several scores.',
-          ]}
-          renderItem={(item, idx) => (
-            <List.Item>
-              <Space>
-                <Typography.Text strong>{idx + 1}</Typography.Text>
-                <Typography.Text>{item}</Typography.Text>
-              </Space>
-            </List.Item>
-          )}
-          style={{ marginBottom: '1em' }}
-        />
-        <Form.Item label="CSV File" name="files" rules={[{ required: true, message: 'Please select csv-file' }]}>
-          <Upload
-            beforeUpload={() => false}
-            fileList={Array.from(selectedFileList).map(([, file]) => file)}
-            onChange={handleFileChose}
-            accept=".csv"
-            multiple
-          >
-            <Button>
-              <UploadOutlined /> Select files
-            </Button>
-          </Upload>
+      <Tabs
+        defaultActiveKey="csv"
+        onChange={() => setSubmitResults([])}
+        items={[
+          { key: 'csv', label: 'Upload CSV', children: csvTab },
+          { key: 'manual', label: 'Manual Entry', children: manualTab },
+        ]}
+      />
+      {submitResults.length ? (
+        <Form.Item>
+          <h3>Summary</h3>
+          <Table
+            pagination={false}
+            dataSource={submitResults}
+            size="small"
+            rowKey="status"
+            columns={[
+              {
+                title: 'Status',
+                dataIndex: 'status',
+              },
+              {
+                title: 'Count',
+                dataIndex: 'count',
+              },
+            ]}
+          />
         </Form.Item>
-        <Button size="large" type="primary" htmlType="submit" style={{ marginRight: '1.5em' }}>
-          Submit
-        </Button>
-        {submitResults.length ? (
-          <Form.Item>
-            <h3>Summary</h3>
-            <Table
-              pagination={false}
-              dataSource={submitResults}
-              size="small"
-              rowKey="status"
-              columns={[
-                {
-                  title: 'Status',
-                  dataIndex: 'status',
-                },
-                {
-                  title: 'Count',
-                  dataIndex: 'count',
-                },
-              ]}
-            />
-          </Form.Item>
-        ) : (
-          ''
-        )}
-        {skippedStudents.length ? (
-          <Form.Item>
-            <h3>Skipped students</h3>
-            <List
-              size="small"
-              bordered
-              dataSource={skippedStudents}
-              renderItem={item => <List.Item>{item}</List.Item>}
-              style={{ marginBottom: '1em' }}
-            />
-          </Form.Item>
-        ) : (
-          ''
-        )}
-      </Form>
+      ) : null}
+      {skippedStudents.length ? (
+        <Form.Item>
+          <h3>Skipped students</h3>
+          <List
+            size="small"
+            bordered
+            dataSource={skippedStudents}
+            renderItem={item => <List.Item>{item}</List.Item>}
+            style={{ marginBottom: '1em' }}
+          />
+        </Form.Item>
+      ) : null}
     </PageLayoutSimple>
   );
 }
@@ -234,30 +247,7 @@ async function uploadResults(
   data: StudentScore[],
 ): Promise<SubmitResult[]> {
   const results = await courseService.postMultipleScores(courseTaskId, data);
-  const groupedByStatus = new Map<string, SubmitResult>();
-
-  results.forEach(({ status, value }: { status: string; value: string | number }) => {
-    const current = groupedByStatus.get(status);
-
-    if (current) {
-      const newStatus: SubmitResult = {
-        status,
-        count: current.count + 1,
-        messages:
-          status === 'skipped' && typeof value === 'string' ? (current.messages ?? []).concat(value) : current.messages,
-      };
-      groupedByStatus.set(status, newStatus);
-    } else {
-      const newStatus: SubmitResult = {
-        status,
-        count: 1,
-        messages: status === 'skipped' && typeof value === 'string' ? [value] : undefined,
-      };
-      groupedByStatus.set(status, newStatus);
-    }
-  });
-
-  return Array.from(groupedByStatus.values());
+  return aggregateResults(results as { status: string; value: string | number }[]);
 }
 
 function Page() {

--- a/client/src/pages/course/submit-scores.tsx
+++ b/client/src/pages/course/submit-scores.tsx
@@ -17,6 +17,7 @@ import { useMessage } from '@client/hooks';
 import { List } from '@client/shared/components/List';
 import { ManualSubmitTab } from '@client/modules/SubmitScores/ManualSubmitTab';
 import { aggregateResults, SubmitResult } from '@client/modules/SubmitScores/utils';
+import styles from '@client/modules/SubmitScores/SubmitScores.module.css';
 
 interface SubmitFormValues {
   files: {
@@ -111,7 +112,7 @@ export function SubmitScorePage() {
             </Space>
           </List.Item>
         )}
-        style={{ marginBottom: '1em' }}
+        className={styles.rulesList}
       />
       <Form.Item label="CSV File" name="files" rules={[{ required: true, message: 'Please select csv-file' }]}>
         <Upload
@@ -126,7 +127,7 @@ export function SubmitScorePage() {
           </Button>
         </Upload>
       </Form.Item>
-      <Button size="large" type="primary" htmlType="submit" style={{ marginRight: '1.5em' }}>
+      <Button size="large" type="primary" htmlType="submit" className={styles.submitButton}>
         Submit
       </Button>
     </Form>
@@ -153,7 +154,7 @@ export function SubmitScorePage() {
         ]}
       />
       {submitResults.length ? (
-        <div style={{ marginTop: '1.5em' }}>
+        <div className={styles.resultsSection}>
           <h3>Summary</h3>
           <Table
             pagination={false}
@@ -174,14 +175,14 @@ export function SubmitScorePage() {
         </div>
       ) : null}
       {skippedStudents.length ? (
-        <div style={{ marginTop: '1.5em' }}>
+        <div className={styles.resultsSection}>
           <h3>Skipped students</h3>
           <List
             size="small"
             bordered
             dataSource={skippedStudents}
             renderItem={item => <List.Item>{item}</List.Item>}
-            style={{ marginBottom: '1em' }}
+            className={styles.skippedList}
           />
         </div>
       ) : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9143,7 +9143,7 @@
       "version": "1.15.18",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
       "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9185,6 +9185,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9201,6 +9202,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9217,6 +9219,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9233,6 +9236,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9249,6 +9253,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9265,6 +9270,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9281,6 +9287,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9297,6 +9304,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9313,6 +9321,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9329,6 +9338,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9342,14 +9352,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -21574,6 +21584,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
https://github.com/rolling-scopes/rsschool-app/issues/2998

**Description**:  
<img width="1050" height="358" alt="image" src="https://github.com/user-attachments/assets/815f4ac6-3f99-472b-8bc7-23dfda6f02f0" />  
- Add a "Manual Entry" tab to the Submit Scores page so Course Managers can enter scores directly in the UI (student / course task / score) without preparing a CSV file
- Support multiple rows in one submission with add/remove, per-row task selection, required-field validation and duplicate (student+task) detection; CSV upload remains unchanged on the first tab
- Reuse the existing `POST /course/:id/scores/:taskId` endpoint by grouping rows by `courseTaskId` on the client — no backend changes
- Extract the result-aggregation logic into a shared `aggregateResults` util used by both tabs

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally