### PR TITLE
fix: replace broken docs link

### DIFF
--- a/client/src/components/HeaderMiniBannerCarousel.test.tsx
+++ b/client/src/components/HeaderMiniBannerCarousel.test.tsx
@@ -18,9 +18,9 @@ describe('HeaderMiniBannerCarousel', () => {
   });
 
   it('should render link when item has url', () => {
-    render(<HeaderMiniBannerCarousel items={[{ title: 'Open docs', url: 'https://rs.school/docs/en' }]} />);
+    render(<HeaderMiniBannerCarousel items={[{ title: 'Open docs', url: 'https://rs.school/docs' }]} />);
 
-    expect(screen.getByRole('link', { name: 'Open docs' })).toHaveAttribute('href', 'https://rs.school/docs/en');
+    expect(screen.getByRole('link', { name: 'Open docs' })).toHaveAttribute('href', 'https://rs.school/docs');
   });
 
   it('should render controls for multiple items', () => {

--- a/client/src/shared/components/Header.tsx
+++ b/client/src/shared/components/Header.tsx
@@ -44,7 +44,7 @@ const MENU_ITEMS = [
     title: 'My CV',
   },
   {
-    link: 'https://rs.school/docs/en',
+    link: 'https://rs.school/docs',
     icon: <QuestionCircleFilled />,
     title: 'Help',
     target: '_blank',


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
#2936

**Description**:
Fix broken docs links. The `/docs/{locale}` URL pattern returns 404. Replace with the correct URLs:
- `https://rs.school/docs/en` → `https://rs.school/docs`
- The same fix applied in the test file.

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally