### PR TITLE
fix: render issue-certificate modal inside student drawer

### DIFF
--- a/client/src/components/Student/DashboardDetails.tsx
+++ b/client/src/components/Student/DashboardDetails.tsx
@@ -9,6 +9,7 @@ import { Button, Descriptions, Drawer, Popconfirm, theme } from 'antd';
 import { MentorBasic } from '@common/models';
 import { CommentModal } from '@client/shared/components/CommentModal';
 import { MentorSearch } from '@client/shared/components/MentorSearch';
+import { IssueCertificateModal } from '@client/modules/CourseManagement/components';
 import { useState } from 'react';
 import { StudentDetails } from '@client/services/course';
 import styles from './DashboardDetails.module.css';
@@ -22,7 +23,7 @@ type Props = {
   onCreateRepository: () => void;
   onRestoreStudent: () => void;
   onExpelStudent: (comment: string) => void;
-  onIssueCertificate: () => void;
+  onIssueCertificate: (templateId: string) => void;
   onRemoveCertificate: () => void;
   onUpdateMentor: (githubId: string) => void;
   courseManagerOrSupervisor: boolean;
@@ -30,6 +31,7 @@ type Props = {
 
 export function DashboardDetails(props: Props) {
   const [expelMode, setExpelMode] = useState(false);
+  const [issueOpen, setIssueOpen] = useState(false);
   const { details } = props;
   const { token } = theme.useToken();
   if (details == null) {
@@ -60,7 +62,7 @@ export function DashboardDetails(props: Props) {
                 disabled={!details.isActive}
                 icon={<SolutionOutlined />}
                 loading={props.isLoading}
-                onClick={props.onIssueCertificate}
+                onClick={() => setIssueOpen(true)}
               >
                 Issue Certificate
               </Button>
@@ -107,6 +109,15 @@ export function DashboardDetails(props: Props) {
             </Descriptions>
           )}
         </div>
+        <IssueCertificateModal
+          open={issueOpen}
+          studentName={details.name}
+          onCancel={() => setIssueOpen(false)}
+          onSubmit={templateId => {
+            props.onIssueCertificate(templateId);
+            setIssueOpen(false);
+          }}
+        />
       </Drawer>
       <CommentModal
         title="Expelling Reason"

--- a/client/src/components/Student/DashboardDetails.tsx
+++ b/client/src/components/Student/DashboardDetails.tsx
@@ -10,7 +10,7 @@ import { MentorBasic } from '@common/models';
 import { CommentModal } from '@client/shared/components/CommentModal';
 import { MentorSearch } from '@client/shared/components/MentorSearch';
 import { IssueCertificateModal } from '@client/modules/CourseManagement/components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { StudentDetails } from '@client/services/course';
 import styles from './DashboardDetails.module.css';
 
@@ -23,7 +23,7 @@ type Props = {
   onCreateRepository: () => void;
   onRestoreStudent: () => void;
   onExpelStudent: (comment: string) => void;
-  onIssueCertificate: (templateId: string) => void;
+  onIssueCertificate: (templateId: string) => Promise<boolean | void>;
   onRemoveCertificate: () => void;
   onUpdateMentor: (githubId: string) => void;
   courseManagerOrSupervisor: boolean;
@@ -34,6 +34,14 @@ export function DashboardDetails(props: Props) {
   const [issueOpen, setIssueOpen] = useState(false);
   const { details } = props;
   const { token } = theme.useToken();
+
+  // The component is rendered unconditionally and only returns null when details is empty,
+  // so it never unmounts when switching students — reset transient modal state manually.
+  useEffect(() => {
+    setExpelMode(false);
+    setIssueOpen(false);
+  }, [details?.githubId]);
+
   if (details == null) {
     return null;
   }
@@ -113,9 +121,9 @@ export function DashboardDetails(props: Props) {
           open={issueOpen}
           studentName={details.name}
           onCancel={() => setIssueOpen(false)}
-          onSubmit={templateId => {
-            props.onIssueCertificate(templateId);
-            setIssueOpen(false);
+          onSubmit={async templateId => {
+            const ok = await props.onIssueCertificate(templateId);
+            if (ok) setIssueOpen(false);
           }}
         />
       </Drawer>

--- a/client/src/modules/CourseManagement/components/CertificateTemplatePicker/IssueCertificateModal.tsx
+++ b/client/src/modules/CourseManagement/components/CertificateTemplatePicker/IssueCertificateModal.tsx
@@ -6,7 +6,7 @@ type Props = {
   open: boolean;
   studentName?: string;
   onCancel: () => void;
-  onSubmit: (templateId: string) => void;
+  onSubmit: (templateId: string) => void | Promise<unknown>;
 };
 
 export function IssueCertificateModal({ open, studentName, onCancel, onSubmit }: Props) {

--- a/client/src/pages/course/admin/students.tsx
+++ b/client/src/pages/course/admin/students.tsx
@@ -16,11 +16,7 @@ import { isAdmin, isCourseManager, isCourseSupervisor } from '@client/domain/use
 import { useMessage } from '@client/hooks';
 import keys from 'lodash/keys';
 import { SessionContext, SessionProvider, useActiveCourseContext } from '@client/modules/Course/contexts';
-import {
-  CertificateCriteriaModal,
-  ExpelCriteriaModal,
-  IssueCertificateModal,
-} from '@client/modules/CourseManagement/components';
+import { CertificateCriteriaModal, ExpelCriteriaModal } from '@client/modules/CourseManagement/components';
 import { useContext, useMemo, useState } from 'react';
 import { useAsync, useToggle } from 'react-use';
 import { CourseService, StudentDetails } from '@client/services/course';
@@ -61,21 +57,13 @@ function Page() {
   const [details, setDetails] = useState<StudentDetails | null>(null);
   const [isExpelModalOpen, toggleExpelModal] = useToggle(false);
   const [isCertificateModalOpen, toggleCertificateModal] = useToggle(false);
-  const [isIssueModalOpen, setIssueModalOpen] = useState(false);
 
   useAsync(withLoading(loadStudents), [activeOnly, details]);
-
-  const openIssueCertificate = () => {
-    if (details?.githubId != null) {
-      setIssueModalOpen(true);
-    }
-  };
 
   const issueCertificate = withLoading(async (templateId: string) => {
     const githubId = details?.githubId;
     if (githubId != null) {
       await courseService.createCertificate(githubId, templateId);
-      setIssueModalOpen(false);
       message.info('The certificate has been requested.');
     }
   });
@@ -166,7 +154,7 @@ function Page() {
           isAdmin={hasAdminRole}
           onUpdateMentor={updateMentor}
           onRestoreStudent={restoreStudent}
-          onIssueCertificate={openIssueCertificate}
+          onIssueCertificate={issueCertificate}
           onRemoveCertificate={removeCertificate}
           onExpelStudent={expelStudent}
           onCreateRepository={createRepository}
@@ -189,12 +177,6 @@ function Page() {
           onClose={toggleCertificateModal}
           onSubmit={issueCertificates}
           isModalOpen={isCertificateModalOpen}
-        />
-        <IssueCertificateModal
-          open={isIssueModalOpen}
-          studentName={details?.name}
-          onCancel={() => setIssueModalOpen(false)}
-          onSubmit={issueCertificate}
         />
       </AdminPageLayout>
     );

--- a/client/src/pages/course/admin/students.tsx
+++ b/client/src/pages/course/admin/students.tsx
@@ -62,10 +62,12 @@ function Page() {
 
   const issueCertificate = withLoading(async (templateId: string) => {
     const githubId = details?.githubId;
-    if (githubId != null) {
-      await courseService.createCertificate(githubId, templateId);
-      message.info('The certificate has been requested.');
+    if (githubId == null) {
+      return false;
     }
+    await courseService.createCertificate(githubId, templateId);
+    message.info('The certificate has been requested.');
+    return true;
   });
 
   const removeCertificate = withLoading(async () => {


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
#3006

**Description**:

Fixes the single-student **Issue Certificate** modal / drawer overlay conflict introduced with the custom-certificate-template feature (#3002).

The certificate modal was rendered as a sibling of the `DashboardDetails` drawer at the page level (`students.tsx`), so it sat outside the drawer's z-index context (antd 6). The drawer mask overlapped the modal and intercepted clicks, firing the drawer's `onClose` → `setDetails(null)`. Because the modal read `studentName` and the issue action read `githubId` live from `details`, clearing it wiped the name from the modal title and left the **Issue** action without a `githubId` (silent no-op).

Fix: move ownership of `IssueCertificateModal` into `DashboardDetails` and render it **inside** the `<Drawer>`, so it inherits the drawer's z-index context. The modal now stacks above the drawer, clicking the dimmed area closes only the modal, the drawer stays open, and `details` is preserved throughout the flow.

Changes:

- `client/src/components/Student/DashboardDetails.tsx` — render `IssueCertificateModal` inside the `Drawer`, controlled by local `issueOpen` state; the **Issue Certificate** button now opens it; `onIssueCertificate` prop signature is now `(templateId: string) => void`.
- `client/src/pages/course/admin/students.tsx` — drop the page-level `isIssueModalOpen` state, `openIssueCertificate`, and the sibling `<IssueCertificateModal>`; pass `issueCertificate` directly as `onIssueCertificate`.

No API / DB changes; the batch issuance flow is untouched.

**Self-Check**:

- [ ] Database migration added (if required) — _not required; UI-only change_
- [x] Changes tested locally