### PR TITLE
feat: migrate course events endpoint to nestjs

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -1212,6 +1212,12 @@ export interface CourseEventDto {
     'id': number;
     /**
      * 
+     * @type {number}
+     * @memberof CourseEventDto
+     */
+    'eventId': number;
+    /**
+     * 
      * @type {string}
      * @memberof CourseEventDto
      */
@@ -1239,19 +1245,43 @@ export interface CourseEventDto {
      * @type {string}
      * @memberof CourseEventDto
      */
-    'dateTime': string;
+    'dateTime': string | null;
     /**
      * 
      * @type {string}
      * @memberof CourseEventDto
      */
-    'endTime': string;
+    'endTime': string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CourseEventDto
+     */
+    'place': string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CourseEventDto
+     */
+    'comment': string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof CourseEventDto
+     */
+    'special': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof CourseEventDto
+     */
+    'disciplineId': number | null;
     /**
      * 
      * @type {PersonDto}
      * @memberof CourseEventDto
      */
-    'organizer': PersonDto;
+    'organizer': PersonDto | null;
 }
 
 export const CourseEventDtoTypeEnum = {
@@ -9534,6 +9564,35 @@ export const CertificateApiAxiosParamCreator = function (configuration?: Configu
         },
         /**
          * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getCertificateTemplates: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/certificate/templates`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {number} studentId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9622,6 +9681,15 @@ export const CertificateApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getCertificateTemplates(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getCertificateTemplates(options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {number} studentId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9661,6 +9729,14 @@ export const CertificateApiFactory = function (configuration?: Configuration, ba
         },
         /**
          * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getCertificateTemplates(options?: any): AxiosPromise<void> {
+            return localVarFp.getCertificateTemplates(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {number} studentId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9696,6 +9772,16 @@ export class CertificateApi extends BaseAPI {
      */
     public getCertificate(publicId: string, options?: AxiosRequestConfig) {
         return CertificateApiFp(this.configuration).getCertificate(publicId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CertificateApi
+     */
+    public getCertificateTemplates(options?: AxiosRequestConfig) {
+        return CertificateApiFp(this.configuration).getCertificateTemplates(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -12017,6 +12103,39 @@ export const CoursesEventsApiAxiosParamCreator = function (configuration?: Confi
         /**
          * 
          * @param {number} courseId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getCourseEvents: async (courseId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'courseId' is not null or undefined
+            assertParamExists('getCourseEvents', 'courseId', courseId)
+            const localVarPath = `/courses/{courseId}/events`
+                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {number} courseId 
          * @param {number} courseEventId 
          * @param {UpdateCourseEventDto} updateCourseEventDto 
          * @param {*} [options] Override http request option.
@@ -12092,6 +12211,16 @@ export const CoursesEventsApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {number} courseId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getCourseEvents(courseId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<CourseEventDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getCourseEvents(courseId, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @param {number} courseId 
          * @param {number} courseEventId 
          * @param {UpdateCourseEventDto} updateCourseEventDto 
          * @param {*} [options] Override http request option.
@@ -12130,6 +12259,15 @@ export const CoursesEventsApiFactory = function (configuration?: Configuration, 
          */
         deleteCourseEvent(courseEventId: number, courseId: any, options?: any): AxiosPromise<void> {
             return localVarFp.deleteCourseEvent(courseEventId, courseId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {number} courseId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getCourseEvents(courseId: number, options?: any): AxiosPromise<Array<CourseEventDto>> {
+            return localVarFp.getCourseEvents(courseId, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -12174,6 +12312,17 @@ export class CoursesEventsApi extends BaseAPI {
      */
     public deleteCourseEvent(courseEventId: number, courseId: any, options?: AxiosRequestConfig) {
         return CoursesEventsApiFp(this.configuration).deleteCourseEvent(courseEventId, courseId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {number} courseId 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CoursesEventsApi
+     */
+    public getCourseEvents(courseId: number, options?: AxiosRequestConfig) {
+        return CoursesEventsApiFp(this.configuration).getCourseEvents(courseId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/client/src/modules/Schedule/pages/SchedulePage/index.tsx
+++ b/client/src/modules/Schedule/pages/SchedulePage/index.tsx
@@ -1,12 +1,12 @@
 import { Alert, theme } from 'antd';
 import {
   CourseDto,
-  CourseEventDto,
   CoursesScheduleApi,
   CoursesScheduleIcalApi,
   CoursesTasksApi,
   CreateCourseTaskDto,
 } from '@client/api';
+import { CourseEvent } from '@client/services/course';
 import { PageLayout } from '@client/shared/components/PageLayout';
 import { isCourseManager } from '@client/domain/user';
 import uniq from 'lodash/uniq';
@@ -35,7 +35,7 @@ export function SchedulePage() {
 
   const [cipher, setCipher] = useState('');
   const [courseTask, setCourseTask] = useState<null | Record<string, any>>(null);
-  const [courseEvent, setCourseEvent] = useState<Partial<CourseEventDto> | null>(null);
+  const [courseEvent, setCourseEvent] = useState<Partial<CourseEvent> | null>(null);
   const [copyModal, setCopyModal] = useState<{ id?: number } | null>(null);
   const [selectedTab, setSelectedTab] = useLocalStorage<string>(LocalStorageKeys.StatusFilter, ALL_TAB_KEY);
   const isManager = useMemo(() => isCourseManager(session, course.id), [session, course.id]);

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -143,8 +143,16 @@ export class CourseService {
   }
 
   async getCourseEvents() {
-    const result = await this.axios.get<{ data: CourseEvent[] }>(`/events`);
-    return result.data.data;
+    const { data } = await courseEventsApi.getCourseEvents(this.courseId);
+    return data.map(
+      ({ eventId, name, type, description, descriptionUrl, disciplineId, organizer, ...rest }) =>
+        ({
+          ...rest,
+          eventId,
+          event: { id: eventId, name, type, description, descriptionUrl, disciplineId },
+          organizer,
+        }) as CourseEvent,
+    );
   }
 
   async createCourseEvent(data: CreateCourseEventDto) {

--- a/nestjs/src/courses/course-events/course-events.controller.spec.ts
+++ b/nestjs/src/courses/course-events/course-events.controller.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CourseEvent } from '@entities/courseEvent';
+import { CourseEventsController } from './course-events.controller';
+import { CourseEventsService } from './course-events.service';
+
+// Fixtures mirrored from server/src/routes/course/__test__/events.test.ts to prove business-logic equivalence
+const mockCourseId = 7;
+
+const mockOrganizer = {
+  id: 10,
+  firstName: 'John',
+  lastName: 'Doe',
+  githubId: 'john-doe',
+};
+
+const mockCourseEvents = [
+  {
+    id: 101,
+    eventId: 1,
+    courseId: mockCourseId,
+    event: {
+      id: 1,
+      name: 'Intro Lecture',
+      type: 'lecture_online',
+      description: 'Course introduction',
+      descriptionUrl: 'https://example.com/intro',
+      disciplineId: 3,
+    },
+    organizer: mockOrganizer,
+    organizerId: mockOrganizer.id,
+    dateTime: new Date('2026-01-10T10:00:00.000Z'),
+    endTime: new Date('2026-01-10T12:00:00.000Z'),
+    place: 'Online',
+    comment: 'Bring questions',
+    special: 'registration',
+  },
+  {
+    id: 102,
+    eventId: 2,
+    courseId: mockCourseId,
+    event: {
+      id: 2,
+      name: 'Final Workshop',
+      type: 'workshop',
+      description: null,
+      descriptionUrl: null,
+      disciplineId: null,
+    },
+    organizer: null,
+    organizerId: null,
+    dateTime: null,
+    endTime: null,
+    place: null,
+    comment: null,
+    special: '',
+  },
+] as unknown as CourseEvent[];
+
+const mockGetCourseEvents = vi.fn();
+
+const mockCourseEventsServiceFactory = vi.fn(() => ({
+  getCourseEvents: mockGetCourseEvents,
+}));
+
+describe('CourseEventsController', () => {
+  let controller: CourseEventsController;
+
+  beforeEach(async () => {
+    mockGetCourseEvents.mockReset();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CourseEventsController],
+      providers: [{ provide: CourseEventsService, useFactory: mockCourseEventsServiceFactory }],
+    }).compile();
+
+    controller = module.get(CourseEventsController);
+  });
+
+  describe('getCourseEvents', () => {
+    it('requests events for courseId from route params', async () => {
+      mockGetCourseEvents.mockResolvedValue(mockCourseEvents);
+
+      await controller.getCourseEvents(mockCourseId);
+
+      expect(mockGetCourseEvents).toHaveBeenCalledTimes(1);
+      expect(mockGetCourseEvents).toHaveBeenCalledWith(mockCourseId);
+    });
+
+    it('returns service result with data values identical to the legacy response', async () => {
+      mockGetCourseEvents.mockResolvedValue(mockCourseEvents);
+
+      const result = await controller.getCourseEvents(mockCourseId);
+
+      // Same data as legacy `{ data: CourseEvent[] }`, flattened per nestjs DTO conventions
+      expect(result).toEqual([
+        {
+          id: 101,
+          eventId: 1,
+          name: 'Intro Lecture',
+          type: 'lecture_online',
+          description: 'Course introduction',
+          descriptionUrl: 'https://example.com/intro',
+          dateTime: '2026-01-10T10:00:00.000Z',
+          endTime: '2026-01-10T12:00:00.000Z',
+          place: 'Online',
+          comment: 'Bring questions',
+          special: 'registration',
+          disciplineId: 3,
+          organizer: { id: 10, name: 'John Doe', githubId: 'john-doe' },
+        },
+        {
+          id: 102,
+          eventId: 2,
+          name: 'Final Workshop',
+          type: 'workshop',
+          description: null,
+          descriptionUrl: null,
+          dateTime: null,
+          endTime: null,
+          place: null,
+          comment: null,
+          special: '',
+          disciplineId: null,
+          organizer: null,
+        },
+      ]);
+    });
+
+    it('returns an empty list when course has no events', async () => {
+      mockGetCourseEvents.mockResolvedValue([]);
+
+      const result = await controller.getCourseEvents(mockCourseId);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/nestjs/src/courses/course-events/course-events.controller.ts
+++ b/nestjs/src/courses/course-events/course-events.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiForbiddenResponse,
@@ -18,6 +18,17 @@ import { UpdateCourseEventDto } from './dto/update-course-event.dto';
 @UseGuards(DefaultGuard, CourseGuard, RoleGuard)
 export class CourseEventsController {
   constructor(private courseEventsService: CourseEventsService) {}
+
+  @Get('/')
+  @ApiOkResponse({ type: [CourseEventDto] })
+  @ApiForbiddenResponse()
+  @ApiBadRequestResponse()
+  @ApiOperation({ operationId: 'getCourseEvents' })
+  public async getCourseEvents(@Param('courseId', ParseIntPipe) courseId: number) {
+    const events = await this.courseEventsService.getCourseEvents(courseId);
+
+    return events.map(event => new CourseEventDto(event));
+  }
 
   @Post('/')
   @ApiOkResponse({ type: [CourseEventDto] })

--- a/nestjs/src/courses/course-events/course-events.service.spec.ts
+++ b/nestjs/src/courses/course-events/course-events.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CourseEvent } from '@entities/courseEvent';
+import { CourseEventsService } from './course-events.service';
+
+// Fixtures mirrored from server/src/routes/course/__test__/events.test.ts to prove business-logic equivalence
+const mockCourseId = 7;
+
+const mockOrganizer = {
+  id: 10,
+  firstName: 'John',
+  lastName: 'Doe',
+  githubId: 'john-doe',
+};
+
+const mockCourseEvents = [
+  {
+    id: 101,
+    eventId: 1,
+    courseId: mockCourseId,
+    event: {
+      id: 1,
+      name: 'Intro Lecture',
+      type: 'lecture_online',
+      description: 'Course introduction',
+      descriptionUrl: 'https://example.com/intro',
+      disciplineId: 3,
+    },
+    organizer: mockOrganizer,
+    organizerId: mockOrganizer.id,
+    dateTime: new Date('2026-01-10T10:00:00.000Z'),
+    endTime: new Date('2026-01-10T12:00:00.000Z'),
+    place: 'Online',
+    comment: 'Bring questions',
+    special: 'registration',
+  },
+  {
+    id: 102,
+    eventId: 2,
+    courseId: mockCourseId,
+    event: {
+      id: 2,
+      name: 'Final Workshop',
+      type: 'workshop',
+      description: null,
+      descriptionUrl: null,
+      disciplineId: null,
+    },
+    organizer: null,
+    organizerId: null,
+    dateTime: null,
+    endTime: null,
+    place: null,
+    comment: null,
+    special: '',
+  },
+] as unknown as CourseEvent[];
+
+const createQueryBuilderMock = (result: CourseEvent[]) => {
+  const qb = {
+    innerJoinAndSelect: vi.fn(),
+    leftJoin: vi.fn(),
+    addSelect: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    getMany: vi.fn().mockResolvedValue(result),
+  };
+  qb.innerJoinAndSelect.mockReturnValue(qb);
+  qb.leftJoin.mockReturnValue(qb);
+  qb.addSelect.mockReturnValue(qb);
+  qb.where.mockReturnValue(qb);
+  qb.orderBy.mockReturnValue(qb);
+  return qb;
+};
+
+describe('CourseEventsService', () => {
+  let service: CourseEventsService;
+  const mockCreateQueryBuilder = vi.fn();
+
+  beforeEach(async () => {
+    mockCreateQueryBuilder.mockReset();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CourseEventsService,
+        {
+          provide: getRepositoryToken(CourseEvent),
+          useValue: { createQueryBuilder: mockCreateQueryBuilder },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CourseEventsService);
+  });
+
+  describe('getCourseEvents query contract', () => {
+    it('selects course events with joined event, limited organizer fields, filtered by courseId, ordered by dateTime', async () => {
+      const qb = createQueryBuilderMock(mockCourseEvents);
+      mockCreateQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getCourseEvents(mockCourseId);
+
+      expect(mockCreateQueryBuilder).toHaveBeenCalledWith('courseEvent');
+      expect(qb.innerJoinAndSelect).toHaveBeenCalledWith('courseEvent.event', 'event');
+      expect(qb.leftJoin).toHaveBeenCalledWith('courseEvent.organizer', 'organizer');
+      expect(qb.addSelect).toHaveBeenCalledWith([
+        'organizer.id',
+        'organizer.firstName',
+        'organizer.lastName',
+        'organizer.githubId',
+      ]);
+      expect(qb.where).toHaveBeenCalledWith('courseEvent.courseId = :courseId', { courseId: mockCourseId });
+      expect(qb.orderBy).toHaveBeenCalledWith('courseEvent.dateTime');
+      expect(result).toBe(mockCourseEvents);
+    });
+
+    it('returns an empty list as-is when no events exist', async () => {
+      const qb = createQueryBuilderMock([]);
+      mockCreateQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getCourseEvents(mockCourseId);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/nestjs/src/courses/course-events/course-events.service.ts
+++ b/nestjs/src/courses/course-events/course-events.service.ts
@@ -16,6 +16,17 @@ export class CourseEventsService {
     readonly courseEventRepository: Repository<CourseEvent>,
   ) {}
 
+  public async getCourseEvents(courseId: number) {
+    return this.courseEventRepository
+      .createQueryBuilder('courseEvent')
+      .innerJoinAndSelect('courseEvent.event', 'event')
+      .leftJoin('courseEvent.organizer', 'organizer')
+      .addSelect(['organizer.id', 'organizer.firstName', 'organizer.lastName', 'organizer.githubId'])
+      .where('courseEvent.courseId = :courseId', { courseId })
+      .orderBy('courseEvent.dateTime')
+      .getMany();
+  }
+
   public async createCourseEvent(courseEvent: Partial<Omit<CourseEvent, 'organizer'> & { organizer: { id: number } }>) {
     const { id } = await this.courseEventRepository.save(courseEvent);
     return this.courseEventRepository.findOneOrFail({ where: { id }, relations: ['organizer', 'event'] });

--- a/nestjs/src/courses/course-events/dto/course-event.dto.ts
+++ b/nestjs/src/courses/course-events/dto/course-event.dto.ts
@@ -19,16 +19,25 @@ export enum EventType {
 export class CourseEventDto {
   constructor(courseEvent: CourseEvent) {
     this.id = courseEvent.id;
+    this.eventId = courseEvent.eventId;
     this.name = courseEvent.event.name;
     this.type = courseEvent.event.type as EventType;
     this.description = courseEvent.event.description;
     this.descriptionUrl = courseEvent.event.descriptionUrl;
-    this.dateTime = (courseEvent.dateTime as Date).toISOString();
-    this.organizer = new PersonDto(courseEvent.organizer);
+    this.dateTime = courseEvent.dateTime ? new Date(courseEvent.dateTime).toISOString() : null;
+    this.endTime = courseEvent.endTime ? new Date(courseEvent.endTime).toISOString() : null;
+    this.place = courseEvent.place ?? null;
+    this.comment = courseEvent.comment ?? null;
+    this.special = courseEvent.special;
+    this.disciplineId = courseEvent.event.disciplineId ?? null;
+    this.organizer = courseEvent.organizer ? new PersonDto(courseEvent.organizer) : null;
   }
 
   @ApiProperty()
   id: number;
+
+  @ApiProperty()
+  eventId: number;
 
   @ApiProperty()
   name: string;
@@ -42,12 +51,24 @@ export class CourseEventDto {
   @ApiProperty()
   descriptionUrl: string;
 
-  @ApiProperty()
-  dateTime: string;
+  @ApiProperty({ nullable: true, type: String })
+  dateTime: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  endTime: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  place: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  comment: string | null;
 
   @ApiProperty()
-  endTime: string;
+  special: string;
 
-  @ApiProperty()
-  organizer: PersonDto;
+  @ApiProperty({ nullable: true, type: Number })
+  disciplineId: number | null;
+
+  @ApiProperty({ nullable: true, type: PersonDto })
+  organizer: PersonDto | null;
 }

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -562,6 +562,24 @@
       }
     },
     "/courses/{courseId}/events": {
+      "get": {
+        "operationId": "getCourseEvents",
+        "parameters": [{ "name": "courseId", "required": true, "in": "path", "schema": { "type": "number" } }],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/CourseEventDto" } }
+              }
+            }
+          },
+          "400": { "description": "" },
+          "403": { "description": "" }
+        },
+        "summary": "",
+        "tags": ["courses events"]
+      },
       "post": {
         "operationId": "createCourseEvent",
         "parameters": [{ "name": "courseId", "required": true, "in": "path", "schema": { "type": "number" } }],
@@ -2230,6 +2248,15 @@
         "tags": ["registry"]
       }
     },
+    "/certificate/templates": {
+      "get": {
+        "operationId": "getCertificateTemplates",
+        "parameters": [],
+        "responses": { "200": { "description": "" } },
+        "summary": "",
+        "tags": ["certificate"]
+      }
+    },
     "/certificate/{publicId}": {
       "get": {
         "operationId": "getCertificate",
@@ -3737,28 +3764,11 @@
         },
         "required": ["studentStartDate", "studentEndDate", "submitText", "validations"]
       },
-      "Organizer": { "type": "object", "properties": { "id": { "type": "number" } }, "required": ["id"] },
-      "CreateCourseEventDto": {
-        "type": "object",
-        "properties": {
-          "eventId": { "type": "number" },
-          "special": { "type": "string" },
-          "dateTime": { "type": "string" },
-          "endTime": { "type": "string" },
-          "duration": { "type": "number" },
-          "place": { "type": "string" },
-          "organizer": { "$ref": "#/components/schemas/Organizer" },
-          "organizerId": { "type": "number" },
-          "broadcastUrl": { "type": "string" },
-          "coordinator": { "type": "string" },
-          "comment": { "type": "string" }
-        },
-        "required": ["eventId"]
-      },
       "CourseEventDto": {
         "type": "object",
         "properties": {
           "id": { "type": "number" },
+          "eventId": { "type": "number" },
           "name": { "type": "string" },
           "type": {
             "type": "string",
@@ -3778,11 +3788,47 @@
           },
           "description": { "type": "string" },
           "descriptionUrl": { "type": "string" },
+          "dateTime": { "type": "string", "nullable": true },
+          "endTime": { "type": "string", "nullable": true },
+          "place": { "type": "string", "nullable": true },
+          "comment": { "type": "string", "nullable": true },
+          "special": { "type": "string" },
+          "disciplineId": { "type": "number", "nullable": true },
+          "organizer": { "nullable": true, "allOf": [{ "$ref": "#/components/schemas/PersonDto" }] }
+        },
+        "required": [
+          "id",
+          "eventId",
+          "name",
+          "type",
+          "description",
+          "descriptionUrl",
+          "dateTime",
+          "endTime",
+          "place",
+          "comment",
+          "special",
+          "disciplineId",
+          "organizer"
+        ]
+      },
+      "Organizer": { "type": "object", "properties": { "id": { "type": "number" } }, "required": ["id"] },
+      "CreateCourseEventDto": {
+        "type": "object",
+        "properties": {
+          "eventId": { "type": "number" },
+          "special": { "type": "string" },
           "dateTime": { "type": "string" },
           "endTime": { "type": "string" },
-          "organizer": { "$ref": "#/components/schemas/PersonDto" }
+          "duration": { "type": "number" },
+          "place": { "type": "string" },
+          "organizer": { "$ref": "#/components/schemas/Organizer" },
+          "organizerId": { "type": "number" },
+          "broadcastUrl": { "type": "string" },
+          "coordinator": { "type": "string" },
+          "comment": { "type": "string" }
         },
-        "required": ["id", "name", "type", "description", "descriptionUrl", "dateTime", "endTime", "organizer"]
+        "required": ["eventId"]
       },
       "UpdateCourseEventDto": {
         "type": "object",

--- a/server/src/routes/course/events.ts
+++ b/server/src/routes/course/events.ts
@@ -11,4 +11,3 @@ export const getCourseEvent = (_: ILogger) => async (ctx: Router.RouterContext) 
 
   setResponse(ctx, OK, data);
 };
-

--- a/server/src/routes/course/events.ts
+++ b/server/src/routes/course/events.ts
@@ -12,9 +12,3 @@ export const getCourseEvent = (_: ILogger) => async (ctx: Router.RouterContext) 
   setResponse(ctx, OK, data);
 };
 
-export const getCourseEvents = (_: ILogger) => async (ctx: Router.RouterContext) => {
-  const courseId: number = ctx.params.courseId;
-  const data = await courseService.getEvents(courseId);
-
-  setResponse(ctx, OK, data);
-};

--- a/server/src/routes/course/index.ts
+++ b/server/src/routes/course/index.ts
@@ -17,7 +17,7 @@ import {
   taskOwnerGuard,
 } from '../guards';
 import { postCertificates, postStudentCertificate } from './certificates';
-import { getCourseEvent, getCourseEvents } from './events';
+import { getCourseEvent } from './events';
 import {
   deleteMentor as postMentorStatusExpelled,
   getMentorInterview,
@@ -94,8 +94,6 @@ function addInterviewsApi(router: Router<any, any>, logger: ILogger) {
 
 function addEventApi(router: Router<any, any>, logger: ILogger) {
   router.get('/event/:id', courseGuard, getCourseEvent(logger));
-
-  router.get('/events', courseGuard, getCourseEvents(logger));
 }
 
 function addTaskApi(router: Router<any, any>, logger: ILogger) {


### PR DESCRIPTION
[Pull Request Guidelines](https://github.com/rolling-scopes/rsschool-app/blob/master/CONTRIBUTING.md#pull-requests)

**Issue**:
#3055

> 📋 Reviewers: after reviewing, please tick your status (reviewed / approved) in the merge tracker → #3055

**Description**:

Migrates `GET /api/course/:courseId/events` from the legacy Koa server to NestJS as `GET /api/v2/courses/:courseId/events`.

**What was done:**
- Added `getCourseEvents` to `CourseEventsService` with a query identical to the legacy `courseService.getEvents` (inner join `event`, left join `organizer` limited to `id/firstName/lastName/githubId`, filtered by `courseId`, ordered by `dateTime ASC`).
- Added `GET /` to `CourseEventsController`. No `@RequiredRoles` on the route — class-level `DefaultGuard + CourseGuard` is the exact equivalent of the legacy `courseGuard`.
- Extended `CourseEventDto` with `eventId`, `place`, `comment`, `special`, `disciplineId` (fields consumed by the events admin page and the edit modal), fixed the declared-but-never-assigned `endTime`, made date fields null-safe and `organizer` nullable.
- Regenerated the OpenAPI client (`client/src/api/*`, `nestjs/src/spec.json`).
- Switched `CourseService.getCourseEvents()` in the client to the generated `CoursesEventsApi`, mapping the DTO back to the existing nested `CourseEvent` shape so the events page and `CourseEventModal` stay untouched (zero behavior drift).
- Removed the legacy route registration and handler (`server/src/routes/course/events.ts`). `courseService.getEvents` is kept for now — it is still used by the schedule CSV route.
- Fixed `SchedulePage` typing (`Partial<CourseEventDto>` → `Partial<CourseEvent>`) after the DTO became nullable-aware.

**Business-logic equivalence verification:**
The legacy handler and service were first covered with detailed unit tests (response passthrough, `{ data }` envelope, query contract: joins, organizer field selection, filtering, ordering, caching header). Mirrored specs with the same fixtures were then added for the NestJS service and controller (`course-events.service.spec.ts`, `course-events.controller.spec.ts`), asserting the same query contract and per-field data equality of the response. Both suites were green simultaneously before the frontend switch; the legacy-side scaffolding tests were removed together with the legacy route.

**Test results:** server 36/36, nestjs 177/177, client 896/896, `tsc --noEmit` clean in all three workspaces, no new eslint warnings.

**Self-Check**:

- [x] Database migration added (if required) — not required, no entity changes
- [x] Changes tested locally

