### PR TITLE
fix(nestjs): cross-check cron calls service directly instead of removed legacy HTTP routes

### DIFF
--- a/nestjs/src/courses/courses.module.ts
+++ b/nestjs/src/courses/courses.module.ts
@@ -169,6 +169,13 @@ import { CourseLeaveSurveyResponse } from '@entities/index';
     MentorReviewsService,
     ExpelledStatsService,
   ],
-  exports: [CourseTasksService, CourseUsersService, CoursesService, StudentsService, ExpelledStatsService],
+  exports: [
+    CourseTasksService,
+    CourseUsersService,
+    CoursesService,
+    StudentsService,
+    ExpelledStatsService,
+    CourseCrossCheckService,
+  ],
 })
 export class CoursesModule {}

--- a/nestjs/src/courses/cross-checks/check-checkers.spec.ts
+++ b/nestjs/src/courses/cross-checks/check-checkers.spec.ts
@@ -9,6 +9,7 @@ import { Task } from '@entities/task';
 import { Student } from '@entities/student';
 import { User } from '@entities/user';
 import { CourseCrossCheckService } from './course-cross-checks.service';
+import { WriteScoreService } from '../score/write-score.service';
 
 // Fixtures mirrored from server/src/services/__test__/check.service.test.ts to prove business-logic equivalence
 const maxScoreRows = [
@@ -66,6 +67,7 @@ describe('CourseCrossCheckService checkers queries', () => {
         { provide: getRepositoryToken(Student), useValue: {} },
         { provide: getRepositoryToken(User), useValue: {} },
         { provide: DataSource, useValue: {} },
+        { provide: WriteScoreService, useValue: {} },
       ],
     }).compile();
 

--- a/nestjs/src/courses/cross-checks/course-cross-checks.controller.ts
+++ b/nestjs/src/courses/cross-checks/course-cross-checks.controller.ts
@@ -33,7 +33,6 @@ import { UserNotificationsService } from 'src/users-notifications';
 import { TaskSolution } from '@entities/taskSolution';
 import { CourseGuard, CourseRole, CurrentRequest, DefaultGuard, RequiredRoles, Role, RoleGuard } from '../../auth';
 import { CourseTasksService } from '../course-tasks';
-import { WriteScoreService } from '../score';
 import { OrderField, OrderDirection, CourseCrossCheckService } from './course-cross-checks.service';
 import {
   BadCommentCheckerDto,
@@ -56,12 +55,9 @@ export class CourseCrossCheckController {
   constructor(
     private courseCrossCheckService: CourseCrossCheckService,
     private courseTasksService: CourseTasksService,
-    private writeScoreService: WriteScoreService,
     private userNotificationsService: UserNotificationsService,
     private configService: ConfigService,
   ) {}
-
-  private static readonly DEFAULT_PAIRS_COUNT = 4;
 
   @Post(':courseTaskId/distribution')
   @ApiOperation({ operationId: 'createCrossCheckDistribution' })
@@ -73,16 +69,7 @@ export class CourseCrossCheckController {
     @Param('courseId', ParseIntPipe) _courseId: number,
     @Param('courseTaskId', ParseIntPipe) courseTaskId: number,
   ) {
-    const courseTask = await this.courseCrossCheckService.getCourseTask(courseTaskId);
-
-    if (courseTask == null) {
-      throw new BadRequestException();
-    }
-    if (!CourseCrossCheckService.isSubmissionDeadlinePassed(courseTask)) {
-      throw new BadRequestException();
-    }
-
-    return this.courseCrossCheckService.distributeCrossCheck(courseTask, courseTaskId);
+    return this.courseCrossCheckService.runDistribution(courseTaskId);
   }
 
   @Post(':courseTaskId/completion')
@@ -95,27 +82,7 @@ export class CourseCrossCheckController {
     @Param('courseId', ParseIntPipe) _courseId: number,
     @Param('courseTaskId', ParseIntPipe) courseTaskId: number,
   ) {
-    const courseTask = await this.courseCrossCheckService.getCourseTask(courseTaskId);
-
-    if (courseTask == null) {
-      throw new BadRequestException();
-    }
-    if (
-      !CourseCrossCheckService.isSubmissionDeadlinePassed(courseTask) ||
-      courseTask.crossCheckStatus === CrossCheckStatus.Initial
-    ) {
-      throw new BadRequestException();
-    }
-
-    const pairsCount = Math.max((courseTask.pairsCount ?? CourseCrossCheckController.DEFAULT_PAIRS_COUNT) - 1, 1);
-    const studentScores = await this.courseCrossCheckService.getTaskSolutionCheckers(courseTaskId, pairsCount);
-
-    for (const studentScore of studentScores) {
-      const data = { authorId: -1, comment: 'Cross-Check score', score: studentScore.score };
-      await this.writeScoreService.saveScore(studentScore.studentId, courseTaskId, data);
-    }
-
-    await this.courseCrossCheckService.changeCourseTaskStatus(courseTask, CrossCheckStatus.Completed);
+    await this.courseCrossCheckService.runCompletion(courseTaskId);
   }
 
   @Get('/:courseTaskId/max-score-checkers')

--- a/nestjs/src/courses/cross-checks/course-cross-checks.service.spec.ts
+++ b/nestjs/src/courses/cross-checks/course-cross-checks.service.spec.ts
@@ -8,6 +8,7 @@ import { CourseTask } from '@entities/courseTask';
 import { DataSource } from 'typeorm';
 import { Student } from '@entities/student';
 import { User } from '@entities/user';
+import { WriteScoreService } from '../score/write-score.service';
 
 const mockRawData = [
   {
@@ -68,6 +69,10 @@ describe('CourseCrossCheckService', () => {
         },
         {
           provide: DataSource,
+          useValue: {},
+        },
+        {
+          provide: WriteScoreService,
           useValue: {},
         },
       ],

--- a/nestjs/src/courses/cross-checks/course-cross-checks.service.ts
+++ b/nestjs/src/courses/cross-checks/course-cross-checks.service.ts
@@ -19,6 +19,7 @@ import { UsersService } from 'src/users/users.service';
 import { PersonDto } from 'src/core/dto';
 import { CrossCheckCriteriaDataDto, CrossCheckMessageDto } from './dto';
 import { Discord } from 'src/profile/dto';
+import { WriteScoreService } from '../score/write-score.service';
 import { CrossCheckDistributionService } from './cross-check-distribution';
 
 export type CrossCheckPair = {
@@ -115,10 +116,52 @@ export class CourseCrossCheckService {
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     private readonly dataSource: DataSource,
+    private readonly writeScoreService: WriteScoreService,
   ) {}
+
+  private static readonly DEFAULT_PAIRS_COUNT = 4;
 
   public static isCrossCheckTask(courseTask: Partial<CourseTask>) {
     return courseTask.checker === 'crossCheck';
+  }
+
+  // Orchestrates cross-check distribution; shared by the controller endpoint and the daily cron.
+  public async runDistribution(courseTaskId: number) {
+    const courseTask = await this.getCourseTask(courseTaskId);
+
+    if (courseTask == null) {
+      throw new BadRequestException();
+    }
+    if (!CourseCrossCheckService.isSubmissionDeadlinePassed(courseTask)) {
+      throw new BadRequestException();
+    }
+
+    return this.distributeCrossCheck(courseTask, courseTaskId);
+  }
+
+  // Orchestrates cross-check completion (scoring + status change); shared by the controller endpoint and the daily cron.
+  public async runCompletion(courseTaskId: number) {
+    const courseTask = await this.getCourseTask(courseTaskId);
+
+    if (courseTask == null) {
+      throw new BadRequestException();
+    }
+    if (
+      !CourseCrossCheckService.isSubmissionDeadlinePassed(courseTask) ||
+      courseTask.crossCheckStatus === CrossCheckStatus.Initial
+    ) {
+      throw new BadRequestException();
+    }
+
+    const pairsCount = Math.max((courseTask.pairsCount ?? CourseCrossCheckService.DEFAULT_PAIRS_COUNT) - 1, 1);
+    const studentScores = await this.getTaskSolutionCheckers(courseTaskId, pairsCount);
+
+    for (const studentScore of studentScores) {
+      const data = { authorId: -1, comment: 'Cross-Check score', score: studentScore.score };
+      await this.writeScoreService.saveScore(studentScore.studentId, courseTaskId, data);
+    }
+
+    await this.changeCourseTaskStatus(courseTask, CrossCheckStatus.Completed);
   }
 
   public async getCourseTaskWithCourse(courseTaskId: number) {

--- a/nestjs/src/courses/cross-checks/cross-check-distribution.spec.ts
+++ b/nestjs/src/courses/cross-checks/cross-check-distribution.spec.ts
@@ -1,13 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
-import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CrossCheckStatus } from '@entities/courseTask';
-import { CourseCrossCheckController } from './course-cross-checks.controller';
 import { CourseCrossCheckService } from './course-cross-checks.service';
-import { CourseTasksService } from '../course-tasks';
-import { WriteScoreService } from '../score';
-import { UserNotificationsService } from 'src/users-notifications';
-import { ConfigService } from 'src/config';
 import { CrossCheckDistributionService } from './cross-check-distribution';
 
 describe('CrossCheckDistributionService.distribute', () => {
@@ -37,91 +31,82 @@ const pastTask = {
   studentEndDate: '2000-01-01',
 };
 
-describe('CourseCrossCheckController distribution/completion', () => {
-  const mockGetCourseTask = vi.fn();
-  const mockDistributeCrossCheck = vi.fn();
-  const mockGetTaskSolutionCheckers = vi.fn();
-  const mockChangeCourseTaskStatus = vi.fn();
+// Orchestration lives in CourseCrossCheckService (shared by the controller endpoints and the daily cron).
+describe('CourseCrossCheckService runDistribution/runCompletion', () => {
+  let service: CourseCrossCheckService;
   const mockSaveScore = vi.fn();
-  let controller: CourseCrossCheckController;
 
-  beforeEach(async () => {
-    mockGetCourseTask.mockReset().mockResolvedValue(pastTask);
-    mockDistributeCrossCheck.mockReset().mockResolvedValue({ crossCheckPairs: [{ studentId: 31, checkerId: 32 }] });
-    mockGetTaskSolutionCheckers.mockReset().mockResolvedValue([
+  beforeEach(() => {
+    service = new CourseCrossCheckService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { saveScore: mockSaveScore } as never,
+    );
+    vi.spyOn(service, 'getCourseTask').mockResolvedValue(pastTask as never);
+    vi.spyOn(service, 'distributeCrossCheck').mockResolvedValue({
+      crossCheckPairs: [{ studentId: 31, checkerId: 32 }],
+    } as never);
+    vi.spyOn(service, 'getTaskSolutionCheckers').mockResolvedValue([
       { studentId: 31, score: 80 },
       { studentId: 32, score: 60 },
     ]);
-    mockChangeCourseTaskStatus.mockReset();
+    vi.spyOn(service, 'changeCourseTaskStatus').mockResolvedValue(undefined as never);
     mockSaveScore.mockReset();
-
-    const module = await Test.createTestingModule({
-      controllers: [CourseCrossCheckController],
-      providers: [
-        {
-          provide: CourseCrossCheckService,
-          useValue: {
-            getCourseTask: mockGetCourseTask,
-            distributeCrossCheck: mockDistributeCrossCheck,
-            getTaskSolutionCheckers: mockGetTaskSolutionCheckers,
-            changeCourseTaskStatus: mockChangeCourseTaskStatus,
-          },
-        },
-        { provide: CourseTasksService, useValue: {} },
-        { provide: WriteScoreService, useValue: { saveScore: mockSaveScore } },
-        { provide: UserNotificationsService, useValue: {} },
-        { provide: ConfigService, useValue: {} },
-      ],
-    }).compile();
-
-    controller = module.get(CourseCrossCheckController);
   });
 
   it('distributes when the deadline has passed', async () => {
-    const result = await controller.createCrossCheckDistribution(11, 15);
+    const result = await service.runDistribution(15);
 
-    expect(mockDistributeCrossCheck).toHaveBeenCalledWith(pastTask, 15);
+    expect(service.distributeCrossCheck).toHaveBeenCalledWith(pastTask, 15);
     expect(result).toEqual({ crossCheckPairs: [{ studentId: 31, checkerId: 32 }] });
   });
 
   it('distribution responds 400 when the task is missing', async () => {
-    mockGetCourseTask.mockResolvedValue(null);
-    await expect(controller.createCrossCheckDistribution(11, 15)).rejects.toThrow(BadRequestException);
+    vi.spyOn(service, 'getCourseTask').mockResolvedValue(null as never);
+    await expect(service.runDistribution(15)).rejects.toThrow(BadRequestException);
   });
 
   it('distribution responds 400 when the deadline has not passed', async () => {
-    mockGetCourseTask.mockResolvedValue({ ...pastTask, studentEndDate: '2999-01-01' });
-    await expect(controller.createCrossCheckDistribution(11, 15)).rejects.toThrow(BadRequestException);
-    expect(mockDistributeCrossCheck).not.toHaveBeenCalled();
+    vi.spyOn(service, 'getCourseTask').mockResolvedValue({ ...pastTask, studentEndDate: '2999-01-01' } as never);
+    await expect(service.runDistribution(15)).rejects.toThrow(BadRequestException);
+    expect(service.distributeCrossCheck).not.toHaveBeenCalled();
   });
 
   it('writes averaged cross-check scores and completes the task', async () => {
-    await controller.createCrossCheckCompletion(11, 15);
+    await service.runCompletion(15);
 
     // pairsCount = max(3 - 1, 1) = 2
-    expect(mockGetTaskSolutionCheckers).toHaveBeenCalledWith(15, 2);
+    expect(service.getTaskSolutionCheckers).toHaveBeenCalledWith(15, 2);
     expect(mockSaveScore).toHaveBeenCalledWith(31, 15, { authorId: -1, comment: 'Cross-Check score', score: 80 });
     expect(mockSaveScore).toHaveBeenCalledWith(32, 15, { authorId: -1, comment: 'Cross-Check score', score: 60 });
-    expect(mockChangeCourseTaskStatus).toHaveBeenCalledWith(pastTask, CrossCheckStatus.Completed);
+    expect(service.changeCourseTaskStatus).toHaveBeenCalledWith(pastTask, CrossCheckStatus.Completed);
   });
 
   it('completion defaults pairsCount to 4 (minCheckedCount 3) when not set', async () => {
-    mockGetCourseTask.mockResolvedValue({ ...pastTask, pairsCount: null });
-    mockGetTaskSolutionCheckers.mockResolvedValue([]);
+    vi.spyOn(service, 'getCourseTask').mockResolvedValue({ ...pastTask, pairsCount: null } as never);
+    vi.spyOn(service, 'getTaskSolutionCheckers').mockResolvedValue([]);
 
-    await controller.createCrossCheckCompletion(11, 15);
+    await service.runCompletion(15);
 
-    expect(mockGetTaskSolutionCheckers).toHaveBeenCalledWith(15, 3);
+    expect(service.getTaskSolutionCheckers).toHaveBeenCalledWith(15, 3);
   });
 
   it('completion responds 400 when status is initial', async () => {
-    mockGetCourseTask.mockResolvedValue({ ...pastTask, crossCheckStatus: CrossCheckStatus.Initial });
-    await expect(controller.createCrossCheckCompletion(11, 15)).rejects.toThrow(BadRequestException);
-    expect(mockChangeCourseTaskStatus).not.toHaveBeenCalled();
+    vi.spyOn(service, 'getCourseTask').mockResolvedValue({
+      ...pastTask,
+      crossCheckStatus: CrossCheckStatus.Initial,
+    } as never);
+    await expect(service.runCompletion(15)).rejects.toThrow(BadRequestException);
+    expect(service.changeCourseTaskStatus).not.toHaveBeenCalled();
   });
 
   it('completion responds 400 when the deadline has not passed', async () => {
-    mockGetCourseTask.mockResolvedValue({ ...pastTask, studentEndDate: '2999-01-01' });
-    await expect(controller.createCrossCheckCompletion(11, 15)).rejects.toThrow(BadRequestException);
+    vi.spyOn(service, 'getCourseTask').mockResolvedValue({ ...pastTask, studentEndDate: '2999-01-01' } as never);
+    await expect(service.runCompletion(15)).rejects.toThrow(BadRequestException);
   });
 });

--- a/nestjs/src/cross-check/cross-check.module.ts
+++ b/nestjs/src/cross-check/cross-check.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { HttpModule } from '@nestjs/axios';
 import { CourseTask } from '@entities/courseTask';
-import { ConfigModule } from '../config/config.module';
+import { CoursesModule } from '../courses/courses.module';
 import { CrossCheckService } from './cross-check.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CourseTask]), HttpModule, ConfigModule],
+  imports: [TypeOrmModule.forFeature([CourseTask]), CoursesModule],
   providers: [CrossCheckService],
 })
 export class CrossCheckModule {}

--- a/nestjs/src/cross-check/cross-check.service.spec.ts
+++ b/nestjs/src/cross-check/cross-check.service.spec.ts
@@ -1,33 +1,10 @@
-import { HttpService } from '@nestjs/axios';
-import { ConfigService } from '../config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CrossCheckService } from './cross-check.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CourseTask } from '../../../server/src/models/courseTask';
+import { CourseCrossCheckService } from '../courses/cross-checks';
 
 const MOCK_CURRENT_TIMESTAMP = new Date('2022-03-22 00:05 UTC').getTime();
-
-const MOCK_HOST = 'https://testhost';
-
-const MOCK_ADMIN_USERNAME = 'TEST_USERNAME';
-const MOCK_ADMIN_PASSWORD = 'TEST_PASSWORD';
-
-const mockConfigService = {
-  users: {
-    root: {
-      username: MOCK_ADMIN_USERNAME,
-      password: MOCK_ADMIN_PASSWORD,
-    },
-  },
-  host: MOCK_HOST,
-};
-
-const expectedAxiosRequestConfig = {
-  auth: {
-    username: MOCK_ADMIN_USERNAME,
-    password: MOCK_ADMIN_PASSWORD,
-  },
-};
 
 enum MockDate {
   DateBefore = '2022-03-21T00:00:00.000Z',
@@ -99,9 +76,8 @@ const tasks = [
   },
 ];
 
-const mockPost = vi.fn(() => ({
-  pipe: vi.fn(() => []),
-}));
+const mockRunDistribution = vi.fn();
+const mockRunCompletion = vi.fn();
 
 const mockCourseTaskRepositoryFind = vi.fn(() => tasks);
 
@@ -117,14 +93,11 @@ describe('CrossCheckService', () => {
       providers: [
         CrossCheckService,
         {
-          provide: HttpService,
+          provide: CourseCrossCheckService,
           useValue: {
-            post: mockPost,
+            runDistribution: mockRunDistribution,
+            runCompletion: mockRunCompletion,
           },
-        },
-        {
-          provide: ConfigService,
-          useValue: mockConfigService,
         },
         {
           provide: getRepositoryToken(CourseTask),
@@ -146,42 +119,22 @@ describe('CrossCheckService', () => {
 
   describe('executeCronJobs should work correctly', () => {
     beforeEach(async () => {
+      mockRunDistribution.mockClear();
+      mockRunCompletion.mockClear();
       vi.spyOn(Date, 'now').mockImplementation(() => MOCK_CURRENT_TIMESTAMP);
       await service.executeCronJobs();
     });
 
-    it('httpService.post should be called right amout of times', () => {
-      expect(mockPost).toHaveBeenCalledTimes(4);
+    it('tasks with submission deadline passed should be distributed (via service, no HTTP)', () => {
+      expect(mockRunDistribution).toHaveBeenCalledTimes(2);
+      expect(mockRunDistribution).toHaveBeenNthCalledWith(1, 2);
+      expect(mockRunDistribution).toHaveBeenNthCalledWith(2, 3);
     });
 
-    it('tasks with submission deadline passed should be distributed', () => {
-      expect(mockPost).toHaveBeenNthCalledWith(
-        1,
-        `${MOCK_HOST}/api/course/2/task/2/cross-check/distribution`,
-        null,
-        expectedAxiosRequestConfig,
-      );
-      expect(mockPost).toHaveBeenNthCalledWith(
-        2,
-        `${MOCK_HOST}/api/course/3/task/3/cross-check/distribution`,
-        null,
-        expectedAxiosRequestConfig,
-      );
-    });
-
-    it('tasks with cross-check deadline passed should be completed', () => {
-      expect(mockPost).toHaveBeenNthCalledWith(
-        3,
-        `${MOCK_HOST}/api/course/22/task/22/cross-check/completion`,
-        null,
-        expectedAxiosRequestConfig,
-      );
-      expect(mockPost).toHaveBeenNthCalledWith(
-        4,
-        `${MOCK_HOST}/api/course/33/task/33/cross-check/completion`,
-        null,
-        expectedAxiosRequestConfig,
-      );
+    it('tasks with cross-check deadline passed should be completed (via service, no HTTP)', () => {
+      expect(mockRunCompletion).toHaveBeenCalledTimes(2);
+      expect(mockRunCompletion).toHaveBeenNthCalledWith(1, 22);
+      expect(mockRunCompletion).toHaveBeenNthCalledWith(2, 33);
     });
   });
 });

--- a/nestjs/src/cross-check/cross-check.service.ts
+++ b/nestjs/src/cross-check/cross-check.service.ts
@@ -1,12 +1,10 @@
 import { Repository } from 'typeorm';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { HttpService } from '@nestjs/axios';
 import { Cron } from '@nestjs/schedule';
-import { ConfigService } from '../config';
 import { isTaskNeededToStart, isTaskNeededToFinish } from './tasks-filtering';
 import { Checker, CourseTask } from '@entities/courseTask';
-import { from, catchError, mergeMap, EMPTY, toArray, lastValueFrom } from 'rxjs';
+import { CourseCrossCheckService } from '../courses/cross-checks';
 
 const ONCE_A_DAY_AT_00_05 = '5 0 * * *';
 
@@ -17,8 +15,7 @@ export class CrossCheckService {
   constructor(
     @InjectRepository(CourseTask)
     private readonly courseTaskRepository: Repository<CourseTask>,
-    private readonly httpService: HttpService,
-    private readonly conf: ConfigService,
+    private readonly courseCrossCheckService: CourseCrossCheckService,
   ) {}
 
   @Cron(ONCE_A_DAY_AT_00_05, { timeZone: 'UTC' })
@@ -28,46 +25,21 @@ export class CrossCheckService {
     await this.initCrossCheckAction(tasksToFinish, 'completion');
   }
 
-  private getInitialDataForRequest() {
-    const { username, password } = this.conf.users.root;
-    const host = this.conf.host;
-
-    return {
-      host,
-      auth: {
-        username,
-        password,
-      },
-    };
-  }
-
-  private makeCrossCheckRequest(url: string, auth: { username: string; password: string }) {
-    return this.httpService.post(url, null, {
-      auth,
-    });
-  }
-
   private async initCrossCheckAction(courseTasks: CourseTask[], action: 'distribution' | 'completion') {
-    const { host, auth } = this.getInitialDataForRequest();
-    const baseurl = `${host}/api/course`;
-
-    const courseTaskRequests$ = from(courseTasks).pipe(
-      mergeMap(({ id, courseId }) => {
-        const requestUrl = `${baseurl}/${courseId}/task/${id}/cross-check/${action}`;
-        return this.makeCrossCheckRequest(requestUrl, auth).pipe(
-          catchError(err => {
-            this.logger.error({
-              message: `Cross-Check ${action} failed for task with id ${id}!`,
-              reason: err,
-            });
-            return EMPTY;
-          }),
-        );
-      }),
-      toArray(),
-    );
-
-    await lastValueFrom(courseTaskRequests$);
+    for (const { id } of courseTasks) {
+      try {
+        if (action === 'distribution') {
+          await this.courseCrossCheckService.runDistribution(id);
+        } else {
+          await this.courseCrossCheckService.runCompletion(id);
+        }
+      } catch (err) {
+        this.logger.error({
+          message: `Cross-Check ${action} failed for task with id ${id}!`,
+          reason: err,
+        });
+      }
+    }
   }
 
   private async getCrossCheckTasks() {


### PR DESCRIPTION
## Problem
The daily cross-check cron (`nestjs/src/cross-check/cross-check.service.ts`, 00:05 UTC) POSTed over HTTP to the **legacy Koa** routes:
- `POST /api/course/:courseId/task/:id/cross-check/distribution`
- `POST /api/course/:courseId/task/:id/cross-check/completion`

Those legacy routes were removed when cross-check distribution/completion was migrated to NestJS (#3053). The cron now 404s → automatic cross-check distribution (after submission deadline) and completion/scoring stopped working. The existing cron test mocked the old URLs, so CI didn't catch it.

## Fix (direct service call — no nest→nest HTTP)
- Extract the orchestration (previously inline in the controller) into `CourseCrossCheckService.runDistribution(courseTaskId)` / `runCompletion(courseTaskId)` — single source of truth shared by the controller endpoints and the cron. `WriteScoreService` injected into the service for the completion score-writing loop.
- Controller endpoints (`createCrossCheckDistribution`/`createCrossCheckCompletion`) now delegate to those methods — behaviour, guards, validation, and 400 gates unchanged.
- Wiring: `CoursesModule` exports `CourseCrossCheckService`; `CrossCheckModule` imports `CoursesModule` and drops `HttpModule`/`ConfigModule`.
- Cron `initCrossCheckAction` calls the service per task with the same per-task try/catch + error log.
- Tests: cron spec asserts the service methods are invoked for the right tasks (no HTTP); orchestration tests relocated to the service (`runDistribution`/`runCompletion`); `WriteScoreService` mock added to the two service specs.

## Verification
- nestjs `tsc -p tsconfig.build.json` clean; `eslint src` clean; `oxfmt --check` clean
- full nestjs vitest: **390 passed** (incl. updated cron + cross-check specs)
- app boots: DI graph resolves with `CrossCheckModule → CoursesModule`, no circular/resolve errors
- client `tsc` clean (no client changes)

Follow-up to #3057 (dead legacy route removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)