### PR TITLE
fix(nestjs): allow credentialed CORS for course registration

### DIFF
--- a/nestjs/src/setup.spec.ts
+++ b/nestjs/src/setup.spec.ts
@@ -1,0 +1,47 @@
+import { INestApplication } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { Logger } from 'nestjs-pino';
+import { ConfigService } from './config';
+import { setupApp } from './setup';
+
+function createAppMock(host: string) {
+  const enableCors = vi.fn();
+  const app = {
+    get: vi.fn((token: unknown) => {
+      if (token === ConfigService) return { host };
+      if (token === HttpAdapterHost) return { httpAdapter: {} };
+      if (token === Logger) return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      return {};
+    }),
+    enableCors,
+    useLogger: vi.fn(),
+    use: vi.fn(),
+    useGlobalFilters: vi.fn(),
+    useGlobalPipes: vi.fn(),
+  } as unknown as INestApplication;
+
+  return { app, enableCors };
+}
+
+describe('setupApp CORS', () => {
+  it('scopes the origin to the app host and allows credentials (never wildcard)', () => {
+    const { app, enableCors } = createAppMock('https://app.rs.school');
+
+    setupApp(app);
+
+    expect(enableCors).toHaveBeenCalledWith({ origin: 'https://app.rs.school', credentials: true });
+    // Guard against a regression to the bare `enableCors()` (wildcard, no credentials).
+    expect(enableCors).not.toHaveBeenCalledWith();
+    const options = enableCors.mock.calls[0]?.[0];
+    expect(options?.origin).not.toBe('*');
+    expect(options?.credentials).toBe(true);
+  });
+
+  it('falls back to localhost when the host is unset', () => {
+    const { app, enableCors } = createAppMock('');
+
+    setupApp(app);
+
+    expect(enableCors).toHaveBeenCalledWith({ origin: 'http://localhost:3000', credentials: true });
+  });
+});

--- a/nestjs/src/setup.ts
+++ b/nestjs/src/setup.ts
@@ -6,10 +6,19 @@ import { Logger } from 'nestjs-pino';
 import { EntityNotFoundFilter, SentryFilter } from './core/filters';
 import { ValidationFilter } from './core/validation';
 import { HttpAdapterHost } from '@nestjs/core';
+import { ConfigService } from './config';
 
 export function setupApp(app: INestApplication) {
   const logger = app.get(Logger);
-  app.enableCors();
+  const config = app.get(ConfigService);
+  // Scope CORS to the app origin and allow credentials. The registry endpoint is
+  // called cross-origin (app.rs.school -> cdn.rs.school) with the auth-token cookie,
+  // so a wildcard `Access-Control-Allow-Origin: *` (the bare enableCors() default) is
+  // rejected by the browser. Mirrors the legacy koa config: origin = RSSHCOOL_HOST.
+  app.enableCors({
+    origin: config.host || 'http://localhost:3000',
+    credentials: true,
+  });
   app.useLogger(logger);
   app.use(cookieParser());
   // Register a global JSON body parser. NestJS skips registering its own default


### PR DESCRIPTION
## What & why

Course registration (student & mentor) is broken in production: submitting the form shows **"An error occurred. Please try later"** and the browser blocks the request with a **CORS** error.

Root cause: the NestJS bootstrap used a bare `app.enableCors()` in `nestjs/src/setup.ts`, which returns the `cors` package defaults — `Access-Control-Allow-Origin: *` and no `Access-Control-Allow-Credentials`. The registration request is cross-origin and **credentialed** (`app.rs.school` → `cdn.rs.school`, `withCredentials: true`, JWT in the `auth-token` cookie), and the browser forbids a wildcard origin for credentialed requests. This regressed during the Koa → NestJS migration; the old Koa server used `cors({ credentials: true, origin: config.host })`.

```
Access to XMLHttpRequest at 'https://cdn.rs.school/api/v2/registry' from origin
'https://app.rs.school' has been blocked by CORS policy: The value of the
'Access-Control-Allow-Origin' header ... must not be the wildcard '*' when the
request's credentials mode is 'include'.
```

## Change

`nestjs/src/setup.ts` — scope CORS to the app origin and allow credentials (parity with legacy Koa):

```ts
const config = app.get(ConfigService);
app.enableCors({
  origin: config.host || 'http://localhost:3000',
  credentials: true,
});
```

`ConfigService.host` = `RSSHCOOL_HOST` (wired via `${RS_HOST}` in `docker-compose.yml`). A specific origin (not `*`) is also CloudFront-friendly. Fixes both `POST /api/v2/registry` and `POST /api/v2/registry/mentor`.

## Tests

Added `nestjs/src/setup.spec.ts` — asserts `setupApp` calls `enableCors` with a concrete origin + `credentials: true` and **never** the bare wildcard form. (A full app-boot e2e needs a DB; vitest only runs `src/**/*.spec.ts`.)

## Deployment note

Ensure `RS_HOST` is set to the app origin in each environment (`https://app.rs.school` in prod, the staging host in staging) so the emitted `Access-Control-Allow-Origin` matches the frontend.

Closes #3068
Related: #3055
