### PR TITLE
test(nestjs): scope coverage reporting and gate test:ci on it

### DIFF
--- a/nestjs/package.json
+++ b/nestjs/package.json
@@ -14,7 +14,7 @@
     "start:prod": "node dist/nestjs/src/main.js",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",
-    "test:ci": "vitest run",
+    "test:ci": "vitest run --coverage",
     "test:watch": "vitest watch",
     "test:cov": "vitest run --coverage",
     "test:debug": "vitest run --inspect-brk --no-file-parallelism",

--- a/nestjs/vitest.config.mts
+++ b/nestjs/vitest.config.mts
@@ -21,7 +21,38 @@ export default mergeConfig(
       include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
       coverage: {
         include: ['src/**/*.(t|j)s'],
+        // Exclude non-logic files so coverage measures real branching logic.
+        exclude: [
+          'src/**/*.spec.ts',
+          'src/**/*.test.ts',
+          'src/**/migrations/**',
+          'src/**/*.module.ts',
+          'src/**/dto/**',
+          'src/**/*.dto.ts',
+          'src/models/**', // pure TypeORM entities
+          'src/**/index.ts', // barrel re-export files (no testable logic)
+          'src/**/*.decorator.ts',
+          'src/**/*.constants.ts',
+          'src/**/*.{types,enum,interface}.ts',
+          'src/**/types.ts', // pure type-alias files (no runtime logic)
+          'src/**/*.d.ts',
+          'src/main.ts',
+          'src/setup.ts',
+          'src/data-source.ts',
+          'src/ormconfig.ts',
+          'src/openapi-spec.ts',
+          'src/constants.ts',
+        ],
         reportsDirectory: './coverage',
+        // Ratcheted floor enforced in CI: starts just below the post-exclude
+        // baseline so this config-only change passes, then bumps up as each
+        // unit-test tier lands so coverage can only move up, never regress.
+        thresholds: {
+          statements: 34,
+          branches: 32,
+          functions: 27,
+          lines: 34,
+        },
       },
       deps: {
         interopDefault: true,


### PR DESCRIPTION
## What & why

The nestjs backend had low, hard-to-interpret unit-test coverage (~30% over a denominator inflated by 66 migrations, 53 entities, all DTOs and `*.module.ts`). This is **phase 1 of 4** of a coverage initiative that brings the backend to **90%+ meaningful coverage**. This PR lays the groundwork: it makes the coverage number measure real logic and enforces it in CI so the upcoming test tiers (and all future work) can't regress.

Config only — no test or source files change here.

## Changes
- **Scope coverage to real logic** (`nestjs/vitest.config.mts`): add `coverage.exclude` for files with no testable branching — migrations, `*.module.ts`, `dto/**` & `*.dto.ts`, `src/models/**` (TypeORM entities), `src/**/index.ts` barrels, `*.decorator.ts`, `*.constants.ts` / bare `constants.ts` / `types.ts`, and bootstrap files (`main.ts`, `setup.ts`, `data-source.ts`, `ormconfig.ts`, `openapi-spec.ts`).
- **Gate the existing test step on coverage** (`nestjs/package.json`): `test:ci` now runs `vitest run --coverage`. The CI pipeline keeps calling `npm run test:ci` (it's still the "run the tests" step) — no workflow change — but it now also enforces the `coverage.thresholds` from the vitest config.
- **Ratcheted threshold**: set just below the post-exclude baseline (`statements 34 / branches 32 / functions 27 / lines 34`) so this config-only change passes today; each subsequent tier PR bumps it up, ending at 95/93/95/95.

## Verification
- ✅ `npm run test:ci` (nestjs) passes: the existing suite clears the new floor over the corrected denominator (~35% vs floor 34), and now fails on any coverage regression.
- ✅ eslint + oxfmt clean.

## Result
Coverage now reflects branching logic in services/controllers/guards rather than generated/boilerplate files, and is enforced by the existing `test:ci` step. Follow-up PRs add the test tiers and ratchet the floor toward 90%+.

Phase 1 of 4 — nestjs unit-test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)