### PR TITLE
test(nestjs): unit tests for auth, permissions & core (tier 1)

### DIFF
--- a/nestjs/src/auth/auth-user.model.spec.ts
+++ b/nestjs/src/auth/auth-user.model.spec.ts
@@ -1,6 +1,7 @@
+import { CourseTask } from '@entities/courseTask';
 import { CourseUser } from '@entities/courseUser';
 import { CourseRole } from '@entities/session';
-import { AuthUser } from './auth-user.model';
+import { AuthUser, Role } from './auth-user.model';
 import type { AuthDetails } from './auth.service';
 
 describe('AuthUser', () => {
@@ -15,6 +16,157 @@ describe('AuthUser', () => {
     const user = new AuthUser({ courseUsers: [{ courseId: 2, isManager: true } as CourseUser] } as AuthDetails);
     expect(user.courses).toStrictEqual({
       2: { roles: [CourseRole.Manager] },
+    });
+  });
+
+  describe('constructor identity and defaults', () => {
+    it('defaults to non-admin user role, no hirer, empty courses when only id/githubId given', () => {
+      const user = new AuthUser({ id: 5, githubId: 'john' } as AuthDetails);
+
+      expect(user.id).toBe(5);
+      expect(user.githubId).toBe('john');
+      expect(user.isAdmin).toBe(false);
+      expect(user.isHirer).toBe(false);
+      expect(user.appRoles).toStrictEqual([Role.User]);
+      expect(user.roles).toStrictEqual({});
+      expect(user.courses).toStrictEqual({});
+    });
+
+    it('marks app role as admin when admin flag is set', () => {
+      const user = new AuthUser({ id: 1, githubId: 'a' } as AuthDetails, [], true);
+
+      expect(user.isAdmin).toBe(true);
+      expect(user.appRoles).toStrictEqual([Role.Admin]);
+    });
+
+    it('appends the hirer app role when hirer flag is set', () => {
+      const user = new AuthUser({ id: 1, githubId: 'a' } as AuthDetails, [], false, true);
+
+      expect(user.isHirer).toBe(true);
+      expect(user.appRoles).toStrictEqual([Role.User, Role.Hirer]);
+    });
+  });
+
+  describe('student aggregation', () => {
+    it('records student role, studentId and roles map', () => {
+      const user = new AuthUser({
+        students: [{ courseId: 1, id: 42, isExpelled: false }],
+      } as AuthDetails);
+
+      expect(user.roles).toStrictEqual({ 1: 'student' });
+      expect(user.courses).toStrictEqual({
+        1: { roles: [CourseRole.Student], studentId: 42, isExpelled: undefined },
+      });
+    });
+
+    it('keeps isExpelled flag when the student is expelled', () => {
+      const user = new AuthUser({
+        students: [{ courseId: 1, id: 42, isExpelled: true }],
+      } as AuthDetails);
+
+      expect(user.courses[1]).toStrictEqual({
+        roles: [CourseRole.Student],
+        studentId: 42,
+        isExpelled: true,
+      });
+    });
+  });
+
+  describe('mentor aggregation', () => {
+    it('records mentor role and mentorId', () => {
+      const user = new AuthUser({
+        mentors: [{ courseId: 3, id: 7 }],
+      } as AuthDetails);
+
+      expect(user.roles).toStrictEqual({ 3: 'mentor' });
+      expect(user.courses).toStrictEqual({
+        3: { roles: [CourseRole.Mentor], mentorId: 7 },
+      });
+    });
+
+    it('merges mentor and student data on the same course (mentor overrides roles map)', () => {
+      const user = new AuthUser({
+        students: [{ courseId: 1, id: 42, isExpelled: false }],
+        mentors: [{ courseId: 1, id: 7 }],
+      } as AuthDetails);
+
+      // roles map reflects the last write (mentor)
+      expect(user.roles).toStrictEqual({ 1: 'mentor' });
+      expect(user.courses[1]).toStrictEqual({
+        roles: [CourseRole.Student, CourseRole.Mentor],
+        studentId: 42,
+        mentorId: 7,
+        isExpelled: undefined,
+      });
+    });
+  });
+
+  describe('courseUser role aggregation (manager/supervisor/dementor)', () => {
+    it('collects every enabled courseUser role for a course', () => {
+      const user = new AuthUser({
+        courseUsers: [{ courseId: 9, isManager: true, isSupervisor: true, isDementor: true } as CourseUser],
+      } as AuthDetails);
+
+      expect(user.courses[9]?.roles).toStrictEqual([CourseRole.Manager, CourseRole.Supervisor, CourseRole.Dementor]);
+    });
+
+    it('ignores courseUsers without any enabled flag', () => {
+      const user = new AuthUser({
+        courseUsers: [{ courseId: 9, isManager: false, isSupervisor: false, isDementor: false } as CourseUser],
+      } as AuthDetails);
+
+      expect(user.courses).toStrictEqual({});
+    });
+
+    it('records only the dementor role when only dementor flag is set', () => {
+      const user = new AuthUser({
+        courseUsers: [{ courseId: 9, isDementor: true } as CourseUser],
+      } as AuthDetails);
+
+      expect(user.courses[9]?.roles).toStrictEqual([CourseRole.Dementor]);
+    });
+  });
+
+  describe('taskOwner aggregation', () => {
+    it('adds the taskOwner role from courseTasks', () => {
+      const user = new AuthUser({ courseUsers: [] } as unknown as AuthDetails, [{ courseId: 4 } as CourseTask]);
+
+      expect(user.courses[4]?.roles).toStrictEqual([CourseRole.TaskOwner]);
+    });
+
+    it('deduplicates the taskOwner role across multiple tasks of the same course', () => {
+      const user = new AuthUser({ courseUsers: [] } as unknown as AuthDetails, [
+        { courseId: 4 } as CourseTask,
+        { courseId: 4 } as CourseTask,
+      ]);
+
+      expect(user.courses[4]?.roles).toStrictEqual([CourseRole.TaskOwner]);
+    });
+
+    it('appends taskOwner alongside existing student/courseUser roles on the same course', () => {
+      const user = new AuthUser(
+        {
+          students: [{ courseId: 4, id: 42, isExpelled: false }],
+          courseUsers: [{ courseId: 4, isManager: true } as CourseUser],
+        } as AuthDetails,
+        [{ courseId: 4 } as CourseTask],
+      );
+
+      expect(user.courses[4]?.roles).toStrictEqual([CourseRole.Student, CourseRole.Manager, CourseRole.TaskOwner]);
+    });
+  });
+
+  describe('createAdmin', () => {
+    it('builds an admin user with empty course data', () => {
+      const user = AuthUser.createAdmin();
+
+      expect(user.isAdmin).toBe(true);
+      expect(user.isHirer).toBe(false);
+      expect(user.id).toBe(0);
+      expect(user.githubId).toBe('');
+      expect(user.appRoles).toStrictEqual([Role.Admin]);
+      expect(user.courses).toStrictEqual({});
+      expect(user.roles).toStrictEqual({});
     });
   });
 });

--- a/nestjs/src/auth/auth.controller.spec.ts
+++ b/nestjs/src/auth/auth.controller.spec.ts
@@ -1,16 +1,39 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { AuthService } from '.';
 import { AuthController } from './auth.controller';
 import { GithubStrategy } from './strategies/github.strategy';
+import { CurrentRequest } from './auth.service';
+import { JWT_COOKIE_NAME } from './constants';
+
+const mockAuthService = {
+  validateGithub: vi.fn(),
+  onConnectionComplete: vi.fn(),
+  getRedirectUrl: vi.fn(),
+  clearAuthUserSessionCache: vi.fn(),
+};
+
+const mockGithubStrategy = {
+  getAuthorizeUrl: vi.fn(),
+};
+
+const createRes = () => ({
+  cookie: vi.fn(),
+  clearCookie: vi.fn(),
+  redirect: vi.fn(),
+});
 
 describe('AuthController', () => {
   let controller: AuthController;
 
   beforeEach(async () => {
+    Object.values(mockAuthService).forEach(fn => fn.mockReset());
+    Object.values(mockGithubStrategy).forEach(fn => fn.mockReset());
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        { provide: AuthService, useValue: {} },
-        { provide: GithubStrategy, useValue: {} },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: GithubStrategy, useValue: mockGithubStrategy },
       ],
       controllers: [AuthController],
     }).compile();
@@ -20,5 +43,102 @@ describe('AuthController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('githubLogin', () => {
+    it('is a no-op handler whose access is gated by the auth guard', () => {
+      expect(controller.githubLogin()).toBeUndefined();
+    });
+  });
+
+  describe('githubCallback', () => {
+    it('sets the jwt cookie and redirects to the resolved url when there is no connection login state', async () => {
+      mockAuthService.validateGithub.mockReturnValue('jwt-token');
+      mockAuthService.getRedirectUrl.mockReturnValue('/home');
+      const req = { user: { id: 11 }, loginState: undefined } as unknown as CurrentRequest;
+      const res = createRes();
+
+      await controller.githubCallback(req, res as never);
+
+      expect(mockAuthService.validateGithub).toHaveBeenCalledWith(req);
+      expect(res.cookie).toHaveBeenCalledWith(
+        JWT_COOKIE_NAME,
+        'jwt-token',
+        expect.objectContaining({ httpOnly: true, secure: true, sameSite: 'none' }),
+      );
+      expect(mockAuthService.getRedirectUrl).toHaveBeenCalledWith(undefined);
+      expect(res.redirect).toHaveBeenCalledWith('/home');
+      expect(mockAuthService.onConnectionComplete).not.toHaveBeenCalled();
+    });
+
+    it('completes a connection and redirects to the confirmation page when loginState has a channelId', async () => {
+      mockAuthService.validateGithub.mockReturnValue('jwt-token');
+      mockAuthService.onConnectionComplete.mockResolvedValue(undefined);
+      const loginState = { channelId: 'telegram', externalId: 'tg-1' };
+      const req = { user: { id: 11 }, loginState } as unknown as CurrentRequest;
+      const res = createRes();
+
+      await controller.githubCallback(req, res as never);
+
+      expect(mockAuthService.onConnectionComplete).toHaveBeenCalledWith(loginState, 11);
+      expect(res.redirect).toHaveBeenCalledWith('/profile/connection-confirmed?connectionType=telegram');
+      expect(mockAuthService.getRedirectUrl).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows when token validation fails', async () => {
+      const error = new Error('boom');
+      mockAuthService.validateGithub.mockImplementation(() => {
+        throw error;
+      });
+      const req = { user: { id: 11 } } as unknown as CurrentRequest;
+      const res = createRes();
+
+      await expect(controller.githubCallback(req, res as never)).rejects.toBe(error);
+      expect(res.cookie).not.toHaveBeenCalled();
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('githubLogout', () => {
+    it('clears the jwt cookie and redirects to the login page', () => {
+      const res = createRes();
+
+      controller.githubLogout(res as never);
+
+      expect(res.clearCookie).toHaveBeenCalledWith(JWT_COOKIE_NAME, expect.objectContaining({ path: '/' }));
+      expect(res.redirect).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  describe('createConnectLinkViaGithub', () => {
+    it('builds an authorize url from the dto and returns it wrapped in a link', async () => {
+      const dto = { channelId: 'telegram', externalId: 'tg-1' } as never;
+      mockGithubStrategy.getAuthorizeUrl.mockResolvedValue('https://gh/authorize');
+
+      const result = await controller.createConnectLinkViaGithub(dto);
+
+      expect(mockGithubStrategy.getAuthorizeUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ data: dto, expires: expect.any(String) }),
+      );
+      expect(result).toEqual({ link: 'https://gh/authorize' });
+    });
+  });
+
+  describe('clearAuthUserSessionCache', () => {
+    it('clears the cache for the current user', async () => {
+      const req = { user: { id: 11 } } as unknown as CurrentRequest;
+      mockAuthService.clearAuthUserSessionCache.mockResolvedValue(undefined);
+
+      await controller.clearAuthUserSessionCache(11, req);
+
+      expect(mockAuthService.clearAuthUserSessionCache).toHaveBeenCalledWith(11);
+    });
+
+    it('throws ForbiddenException when clearing another user cache', async () => {
+      const req = { user: { id: 11 } } as unknown as CurrentRequest;
+
+      await expect(controller.clearAuthUserSessionCache(99, req)).rejects.toBeInstanceOf(ForbiddenException);
+      expect(mockAuthService.clearAuthUserSessionCache).not.toHaveBeenCalled();
+    });
   });
 });

--- a/nestjs/src/auth/auth.service.spec.ts
+++ b/nestjs/src/auth/auth.service.spec.ts
@@ -14,11 +14,22 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Profile } from 'passport';
 import { AuthUser } from './auth-user.model';
 import { User } from '@entities/user';
+import { NotFoundException } from '@nestjs/common';
+import { of } from 'rxjs';
+import type { Repository } from 'typeorm';
+import type { Cache } from '@nestjs/cache-manager';
+import type { CurrentRequest } from './auth.service';
+import type { LoginData } from '@entities/loginState';
 
 describe('AuthService', () => {
   let service: AuthService;
   let usersService: Mocked<UsersService>;
   let courseTasksService: Mocked<CourseTasksService>;
+  let jwtService: Mocked<JwtService>;
+  let loginStateRepository: Mocked<Repository<LoginState>>;
+  let notificationUserConnectionRepository: Mocked<Repository<NotificationUserConnection>>;
+  let httpService: Mocked<HttpService>;
+  let cacheManager: Mocked<Cache>;
 
   const mockProfile: Profile = {
     provider: 'github',
@@ -47,11 +58,37 @@ describe('AuthService', () => {
     courseUsers: [],
   };
 
+  // Sub-query builder handed to the `addSelect(qb => ...)` callbacks in getAuthDetails.
+  const mockSubQueryBuilder = {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+  };
+
+  const mockQueryBuilder = {
+    select: vi.fn().mockReturnThis(),
+    // Execute any sub-query callback so its arrow function body is exercised.
+    addSelect: vi.fn(function (this: unknown, arg: unknown) {
+      if (typeof arg === 'function') {
+        (arg as (qb: typeof mockSubQueryBuilder) => unknown)(mockSubQueryBuilder);
+      }
+      return this;
+    }),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    getRawOne: vi.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
-        { provide: JwtService, useValue: {} },
+        {
+          provide: JwtService,
+          useValue: {
+            createToken: vi.fn(),
+          },
+        },
         {
           provide: CourseTasksService,
           useValue: {
@@ -71,12 +108,33 @@ describe('AuthService', () => {
           provide: ConfigService,
           useValue: {
             users: { admins: ['admin'], hirers: ['hirer'] },
+            awsServices: { restApiUrl: 'https://aws.example.com', restApiKey: 'secret-key' },
           },
         },
-        { provide: getRepositoryToken(LoginState), useValue: {} },
+        {
+          provide: getRepositoryToken(LoginState),
+          useValue: {
+            save: vi.fn(),
+            findOne: vi.fn(),
+            delete: vi.fn(),
+            manager: {
+              createQueryBuilder: vi.fn().mockReturnValue(mockQueryBuilder),
+            },
+          },
+        },
         { provide: UserNotificationsService, useValue: {} },
-        { provide: HttpService, useValue: {} },
-        { provide: getRepositoryToken(NotificationUserConnection), useValue: {} },
+        {
+          provide: HttpService,
+          useValue: {
+            post: vi.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(NotificationUserConnection),
+          useValue: {
+            save: vi.fn(),
+          },
+        },
         { provide: CACHE_MANAGER, useValue: { del: vi.fn() } },
       ],
     }).compile();
@@ -84,6 +142,11 @@ describe('AuthService', () => {
     service = module.get<AuthService>(AuthService);
     usersService = module.get(UsersService);
     courseTasksService = module.get(CourseTasksService);
+    jwtService = module.get(JwtService);
+    loginStateRepository = module.get(getRepositoryToken(LoginState));
+    notificationUserConnectionRepository = module.get(getRepositoryToken(NotificationUserConnection));
+    httpService = module.get(HttpService);
+    cacheManager = module.get(CACHE_MANAGER);
   });
 
   it('should be defined', () => {
@@ -287,6 +350,16 @@ describe('AuthService', () => {
       expect(usersService.getByGithubId).toHaveBeenCalled();
     });
 
+    it('should skip getUserByProvider lookup when the profile provider is empty', async () => {
+      const profileWithoutProvider = { ...mockProfile, provider: '' };
+      usersService.getByGithubId.mockResolvedValue(mockUser as User);
+
+      await service.createAuthUser(profileWithoutProvider);
+
+      expect(usersService.getUserByProvider).not.toHaveBeenCalled();
+      expect(usersService.getByGithubId).toHaveBeenCalledWith('johndoe');
+    });
+
     it('should call getAuthUser with correct parameters', async () => {
       usersService.getUserByProvider.mockResolvedValue(mockUser as User);
       const getAuthUserSpy = vi.spyOn(service, 'getAuthUser');
@@ -303,6 +376,281 @@ describe('AuthService', () => {
 
       expect(usersService.saveUser).not.toHaveBeenCalled();
       expect(usersService.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAuthUser', () => {
+    it('should build an AuthUser from auth details and owned course tasks', async () => {
+      vi.spyOn(service, 'getAuthDetails').mockResolvedValue(mockAuthDetails);
+      courseTasksService.getByOwner.mockResolvedValue([]);
+
+      const result = await service.getAuthUser('johndoe');
+
+      expect(service.getAuthDetails).toHaveBeenCalledWith('johndoe');
+      expect(courseTasksService.getByOwner).toHaveBeenCalledWith('johndoe');
+      expect(result).toBeInstanceOf(AuthUser);
+      expect(result.isAdmin).toBe(false);
+      expect(result.isHirer).toBe(false);
+    });
+
+    it('should mark the user as admin when present in the admins config list', async () => {
+      const adminDetails = { ...mockAuthDetails, githubId: 'admin' };
+      vi.spyOn(service, 'getAuthDetails').mockResolvedValue(adminDetails);
+      courseTasksService.getByOwner.mockResolvedValue([]);
+
+      const result = await service.getAuthUser('admin');
+
+      expect(result.isAdmin).toBe(true);
+    });
+
+    it('should mark the user as admin when the admin flag is true', async () => {
+      vi.spyOn(service, 'getAuthDetails').mockResolvedValue(mockAuthDetails);
+      courseTasksService.getByOwner.mockResolvedValue([]);
+
+      const result = await service.getAuthUser('johndoe', true);
+
+      expect(result.isAdmin).toBe(true);
+    });
+
+    it('should mark the user as hirer when present in the hirers config list', async () => {
+      const hirerDetails = { ...mockAuthDetails, githubId: 'hirer' };
+      vi.spyOn(service, 'getAuthDetails').mockResolvedValue(hirerDetails);
+      courseTasksService.getByOwner.mockResolvedValue([]);
+
+      const result = await service.getAuthUser('hirer');
+
+      expect(result.isHirer).toBe(true);
+      expect(result.isAdmin).toBe(false);
+    });
+  });
+
+  describe('validateGithub', () => {
+    it('should return null when the request has no user', () => {
+      const req = { user: undefined } as unknown as CurrentRequest;
+
+      const result = service.validateGithub(req);
+
+      expect(result).toBeNull();
+      expect(jwtService.createToken).not.toHaveBeenCalled();
+    });
+
+    it('should create and return a token when the request has a user', () => {
+      const authUser = { id: 1, githubId: 'johndoe' } as unknown as AuthUser;
+      const req = { user: authUser } as unknown as CurrentRequest;
+      jwtService.createToken.mockReturnValue('jwt-token');
+
+      const result = service.validateGithub(req);
+
+      expect(jwtService.createToken).toHaveBeenCalledWith(authUser);
+      expect(result).toBe('jwt-token');
+    });
+  });
+
+  describe('createLoginState', () => {
+    it('should persist the login state and return the generated id', async () => {
+      loginStateRepository.save.mockResolvedValue({} as LoginState);
+      const data: LoginData = { redirectUrl: '/home' };
+
+      const id = await service.createLoginState({ userId: 7, expires: '2030-01-01', data });
+
+      expect(typeof id).toBe('string');
+      expect(id).toHaveLength(10);
+      expect(id).toMatch(/^[0-9a-f]{10}$/);
+      expect(loginStateRepository.save).toHaveBeenCalledWith({
+        id,
+        data,
+        userId: 7,
+        expires: '2030-01-01',
+      });
+    });
+
+    it('should persist the login state without an optional userId/expires', async () => {
+      loginStateRepository.save.mockResolvedValue({} as LoginState);
+      const data: LoginData = {};
+
+      const id = await service.createLoginState({ data });
+
+      expect(loginStateRepository.save).toHaveBeenCalledWith({
+        id,
+        data,
+        userId: undefined,
+        expires: undefined,
+      });
+    });
+  });
+
+  describe('getLoginStateById', () => {
+    it('should look up a non-expired login state by id ordered by newest', () => {
+      const state = { id: 'abc' } as LoginState;
+      loginStateRepository.findOne.mockResolvedValue(state);
+
+      const result = service.getLoginStateById('abc');
+
+      expect(loginStateRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          id: 'abc',
+          expires: expect.anything(),
+        },
+        order: {
+          createdDate: 'DESC',
+        },
+      });
+      return expect(result).resolves.toBe(state);
+    });
+  });
+
+  describe('getLoginStateByUserId', () => {
+    it('should look up a non-expired login state by userId ordered by newest', () => {
+      const state = { id: 'abc', userId: 5 } as LoginState;
+      loginStateRepository.findOne.mockResolvedValue(state);
+
+      const result = service.getLoginStateByUserId(5);
+
+      expect(loginStateRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          userId: 5,
+          expires: expect.anything(),
+        },
+        order: {
+          createdDate: 'DESC',
+        },
+      });
+      return expect(result).resolves.toBe(state);
+    });
+  });
+
+  describe('deleteLoginState', () => {
+    it('should delegate deletion to the repository', () => {
+      const deleteResult = { affected: 1, raw: [] };
+      loginStateRepository.delete.mockResolvedValue(deleteResult);
+
+      const result = service.deleteLoginState('abc');
+
+      expect(loginStateRepository.delete).toHaveBeenCalledWith('abc');
+      return expect(result).resolves.toBe(deleteResult);
+    });
+  });
+
+  describe('getRedirectUrl', () => {
+    it('should decode the redirect url from login data', () => {
+      const result = service.getRedirectUrl({ redirectUrl: '%2Fcourse%2F1' });
+
+      expect(result).toBe('/course/1');
+    });
+
+    it('should return root when login data has no redirect url', () => {
+      const result = service.getRedirectUrl({});
+
+      expect(result).toBe('/');
+    });
+
+    it('should return root when login data is undefined', () => {
+      const result = service.getRedirectUrl(undefined);
+
+      expect(result).toBe('/');
+    });
+  });
+
+  describe('onConnectionComplete', () => {
+    it('should do nothing when channelId is missing', async () => {
+      await service.onConnectionComplete({ externalId: 'ext-1' }, 1);
+
+      expect(notificationUserConnectionRepository.save).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when externalId is missing', async () => {
+      await service.onConnectionComplete({ channelId: 'telegram' }, 1);
+
+      expect(notificationUserConnectionRepository.save).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should save the connection and notify the AWS rest api for telegram', async () => {
+      notificationUserConnectionRepository.save.mockResolvedValue({} as NotificationUserConnection);
+      httpService.post.mockReturnValue(of({}) as never);
+
+      await service.onConnectionComplete({ channelId: 'telegram', externalId: 'ext-1' }, 42);
+
+      expect(notificationUserConnectionRepository.save).toHaveBeenCalledWith({
+        channelId: 'telegram',
+        enabled: true,
+        externalId: 'ext-1',
+        userId: 42,
+      });
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://aws.example.com/connection/complete',
+        { channelId: 'telegram', externalId: 'ext-1' },
+        { headers: { 'x-api-key': 'secret-key' } },
+      );
+    });
+
+    it('should save the connection but skip the AWS call for non-telegram channels', async () => {
+      notificationUserConnectionRepository.save.mockResolvedValue({} as NotificationUserConnection);
+
+      await service.onConnectionComplete({ channelId: 'discord' as never, externalId: 'ext-2' }, 9);
+
+      expect(notificationUserConnectionRepository.save).toHaveBeenCalledWith({
+        channelId: 'discord',
+        enabled: true,
+        externalId: 'ext-2',
+        userId: 9,
+      });
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAuthDetails', () => {
+    it('should return mapped auth details when the user is found', async () => {
+      const rawResult = {
+        id: 3,
+        githubId: 'johndoe',
+        students: [{ id: 10, courseId: 100, isExpelled: false }],
+        mentors: [{ id: 20, courseId: 200 }],
+        courseUsers: [{ id: 30 }],
+      };
+      mockQueryBuilder.getRawOne.mockResolvedValue(rawResult);
+
+      const result = await service.getAuthDetails('johndoe');
+
+      expect(result).toEqual(rawResult);
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith({ githubId: 'johndoe' });
+    });
+
+    it('should default students, mentors and courseUsers to empty arrays when null', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({
+        id: 4,
+        githubId: 'janedoe',
+        students: null,
+        mentors: null,
+        courseUsers: null,
+      });
+
+      const result = await service.getAuthDetails('janedoe');
+
+      expect(result).toEqual({
+        id: 4,
+        githubId: 'janedoe',
+        students: [],
+        mentors: [],
+        courseUsers: [],
+      });
+    });
+
+    it('should throw NotFoundException when the user is not found', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue(null);
+
+      await expect(service.getAuthDetails('ghost')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('clearAuthUserSessionCache', () => {
+    it('should delete the cached auth-user entry for the given user id', async () => {
+      cacheManager.del.mockResolvedValue(true as never);
+
+      await service.clearAuthUserSessionCache(123);
+
+      expect(cacheManager.del).toHaveBeenCalledWith('auth-user-123');
     });
   });
 });

--- a/nestjs/src/auth/course.guard.spec.ts
+++ b/nestjs/src/auth/course.guard.spec.ts
@@ -1,0 +1,53 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CourseGuard } from './course.guard';
+
+type GuardUser = {
+  isAdmin: boolean;
+  courses: Record<number, unknown>;
+};
+
+const createContext = (user: Partial<GuardUser>, params: Record<string, unknown> = {}): ExecutionContext =>
+  ({
+    getArgs: () => [{ user, params }],
+  }) as unknown as ExecutionContext;
+
+describe('CourseGuard', () => {
+  let guard: CourseGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CourseGuard],
+    }).compile();
+
+    guard = module.get<CourseGuard>(CourseGuard);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('allows admins regardless of course membership', () => {
+    const context = createContext({ isAdmin: true, courses: {} }, { courseId: '5' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows a non-admin who belongs to the requested course', () => {
+    const context = createContext({ isAdmin: false, courses: { 5: { roles: [] } } }, { courseId: '5' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('denies a non-admin who does not belong to the requested course', () => {
+    const context = createContext({ isAdmin: false, courses: { 9: { roles: [] } } }, { courseId: '5' });
+
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('denies a non-admin when courseId is missing (NaN lookup)', () => {
+    const context = createContext({ isAdmin: false, courses: { 5: { roles: [] } } });
+
+    expect(guard.canActivate(context)).toBe(false);
+  });
+});

--- a/nestjs/src/auth/role.guard.spec.ts
+++ b/nestjs/src/auth/role.guard.spec.ts
@@ -1,0 +1,194 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Mocked } from 'vitest';
+import { RoleGuard } from './role.guard';
+import { Role, CourseRole } from './auth-user.model';
+
+type GuardUser = {
+  appRoles: Role[];
+  courses: Record<number, { roles: CourseRole[] }>;
+};
+
+const createContext = (user: Partial<GuardUser>, params: Record<string, unknown> = {}): ExecutionContext =>
+  ({
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+    getArgs: () => [{ user, params }],
+  }) as unknown as ExecutionContext;
+
+describe('RoleGuard', () => {
+  let guard: RoleGuard;
+  let reflector: Mocked<Reflector>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleGuard,
+        {
+          provide: Reflector,
+          useValue: {
+            getAllAndOverride: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<RoleGuard>(RoleGuard);
+    reflector = module.get(Reflector);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('allows access when no metadata is set (reflector returns undefined)', () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    const context = createContext({ appRoles: [Role.User], courses: {} });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows access when roles array is empty', () => {
+    reflector.getAllAndOverride.mockReturnValue({ roles: [], requireCourseMatch: false });
+
+    const context = createContext({ appRoles: [Role.User], courses: {} });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  describe('app roles', () => {
+    it('allows access when the user has a required app role', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [Role.Admin], requireCourseMatch: false });
+
+      const context = createContext({ appRoles: [Role.Admin], courses: {} });
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('denies access when the user lacks the required app role and no course roles are required', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [Role.Admin], requireCourseMatch: false });
+
+      const context = createContext({ appRoles: [Role.User], courses: {} });
+
+      expect(guard.canActivate(context)).toBe(false);
+    });
+  });
+
+  describe('course roles with requireCourseMatch', () => {
+    it('allows access when the user has the required role in the matched course', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Mentor], requireCourseMatch: true });
+
+      const context = createContext(
+        { appRoles: [Role.User], courses: { 5: { roles: [CourseRole.Mentor] } } },
+        {
+          courseId: '5',
+        },
+      );
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('denies access when the user lacks the required role in the matched course', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Mentor], requireCourseMatch: true });
+
+      const context = createContext(
+        { appRoles: [Role.User], courses: { 5: { roles: [CourseRole.Student] } } },
+        {
+          courseId: '5',
+        },
+      );
+
+      expect(guard.canActivate(context)).toBe(false);
+    });
+
+    it('denies access when the matched course is not in the user courses', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Mentor], requireCourseMatch: true });
+
+      const context = createContext({ appRoles: [Role.User], courses: {} }, { courseId: '5' });
+
+      expect(guard.canActivate(context)).toBe(false);
+    });
+
+    it('denies access when courseId resolves to 0 (falsy)', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Mentor], requireCourseMatch: true });
+
+      const context = createContext(
+        { appRoles: [Role.User], courses: { 0: { roles: [CourseRole.Mentor] } } },
+        {
+          courseId: '0',
+        },
+      );
+
+      expect(guard.canActivate(context)).toBe(false);
+    });
+
+    it('falls back to any-course check when requireCourseMatch is set but courseId is missing', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Mentor], requireCourseMatch: true });
+
+      const context = createContext({ appRoles: [Role.User], courses: { 7: { roles: [CourseRole.Mentor] } } });
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+  });
+
+  describe('course roles in any course', () => {
+    it('allows access when the user has the required role in any course', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Manager], requireCourseMatch: false });
+
+      const context = createContext({
+        appRoles: [Role.User],
+        courses: { 1: { roles: [CourseRole.Student] }, 2: { roles: [CourseRole.Manager] } },
+      });
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('denies access when the user has the role in no course', () => {
+      reflector.getAllAndOverride.mockReturnValue({ roles: [CourseRole.Manager], requireCourseMatch: false });
+
+      const context = createContext({
+        appRoles: [Role.User],
+        courses: { 1: { roles: [CourseRole.Student] } },
+      });
+
+      expect(guard.canActivate(context)).toBe(false);
+    });
+  });
+
+  describe('combined app and course roles', () => {
+    it('short-circuits to true via the app role even when the course role is absent', () => {
+      reflector.getAllAndOverride.mockReturnValue({
+        roles: [Role.Admin, CourseRole.Mentor],
+        requireCourseMatch: false,
+      });
+
+      const context = createContext({ appRoles: [Role.Admin], courses: {} });
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('falls through to the course role when the app role does not match', () => {
+      reflector.getAllAndOverride.mockReturnValue({
+        roles: [Role.Admin, CourseRole.Mentor],
+        requireCourseMatch: false,
+      });
+
+      const context = createContext({ appRoles: [Role.User], courses: { 3: { roles: [CourseRole.Mentor] } } });
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('denies access when neither the app role nor the course role matches', () => {
+      reflector.getAllAndOverride.mockReturnValue({
+        roles: [Role.Admin, CourseRole.Mentor],
+        requireCourseMatch: false,
+      });
+
+      const context = createContext({ appRoles: [Role.User], courses: { 3: { roles: [CourseRole.Student] } } });
+
+      expect(guard.canActivate(context)).toBe(false);
+    });
+  });
+});

--- a/nestjs/src/auth/strategies/basic.strategy.spec.ts
+++ b/nestjs/src/auth/strategies/basic.strategy.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { BasicStrategy } from './basic.strategy';
+import { ConfigService } from 'src/config';
+import { AuthUser } from '..';
+
+const ROOT_USERNAME = 'root';
+const ROOT_PASSWORD = 'root-password';
+
+const mockConfig = {
+  users: {
+    root: { username: ROOT_USERNAME, password: ROOT_PASSWORD },
+  },
+} as Partial<ConfigService> as ConfigService;
+
+describe('BasicStrategy', () => {
+  let strategy: BasicStrategy;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BasicStrategy, { provide: ConfigService, useValue: mockConfig }],
+    }).compile();
+
+    strategy = module.get<BasicStrategy>(BasicStrategy);
+  });
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  describe('validate', () => {
+    it('returns an admin AuthUser for valid root credentials', async () => {
+      const result = await strategy.validate(undefined, ROOT_USERNAME, ROOT_PASSWORD);
+
+      expect(result).toBeInstanceOf(AuthUser);
+      expect(result.isAdmin).toBe(true);
+    });
+
+    it('throws UnauthorizedException when the username does not match', async () => {
+      await expect(strategy.validate(undefined, 'wrong-user', ROOT_PASSWORD)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException when the password does not match', async () => {
+      await expect(strategy.validate(undefined, ROOT_USERNAME, 'wrong-password')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException when both username and password are wrong', async () => {
+      await expect(strategy.validate(undefined, 'wrong-user', 'wrong-password')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('requires both fields to match (short-circuits when username matches but password differs)', async () => {
+      // Exercises the && right-hand side: username equal, password not.
+      await expect(strategy.validate(undefined, ROOT_USERNAME, '')).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+});

--- a/nestjs/src/auth/strategies/dev.strategy.spec.ts
+++ b/nestjs/src/auth/strategies/dev.strategy.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DevStrategy } from './dev.strategy';
+import { AuthService, CurrentRequest } from '../auth.service';
+import { ConfigService } from '../../config';
+import { JWT_COOKIE_NAME } from '../constants';
+
+const DEV_USERNAME = 'dev-user';
+
+const mockConfig = {
+  auth: { dev: { username: DEV_USERNAME, admin: true } },
+} as Partial<ConfigService> as ConfigService;
+
+const mockAuthUser = { id: 11, githubId: DEV_USERNAME, isAdmin: true };
+
+const mockAuthService = {
+  createAuthUser: vi.fn(),
+  validateGithub: vi.fn(),
+};
+
+describe('DevStrategy', () => {
+  let strategy: DevStrategy;
+
+  beforeEach(async () => {
+    Object.values(mockAuthService).forEach(fn => fn.mockReset());
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DevStrategy,
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    strategy = module.get<DevStrategy>(DevStrategy);
+  });
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  describe('validate', () => {
+    it('creates the dev auth user, sets a redirect cookie header and returns true on a valid token', async () => {
+      mockAuthService.createAuthUser.mockResolvedValue(mockAuthUser);
+      mockAuthService.validateGithub.mockReturnValue('dev-token');
+      const writeHead = vi.fn();
+      const req = { res: { writeHead } } as unknown as CurrentRequest;
+
+      const result = await strategy.validate(req);
+
+      expect(mockAuthService.createAuthUser).toHaveBeenCalledWith(
+        expect.objectContaining({ username: DEV_USERNAME }),
+        true,
+      );
+      expect(req.user).toBe(mockAuthUser);
+      expect(mockAuthService.validateGithub).toHaveBeenCalledWith(req);
+      expect(writeHead).toHaveBeenCalledWith(
+        302,
+        expect.objectContaining({
+          'Set-Cookie': `${JWT_COOKIE_NAME}=dev-token; HttpOnly; path=/;`,
+          Location: '/',
+        }),
+      );
+      expect(result).toBe(true);
+    });
+
+    it('throws when the generated token is falsy', async () => {
+      mockAuthService.createAuthUser.mockResolvedValue(mockAuthUser);
+      mockAuthService.validateGithub.mockReturnValue(null);
+      const writeHead = vi.fn();
+      const req = { res: { writeHead } } as unknown as CurrentRequest;
+
+      await expect(strategy.validate(req)).rejects.toThrow('Invalid token');
+      expect(writeHead).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a missing response object via optional chaining', async () => {
+      mockAuthService.createAuthUser.mockResolvedValue(mockAuthUser);
+      mockAuthService.validateGithub.mockReturnValue('dev-token');
+      const req = {} as unknown as CurrentRequest;
+
+      const result = await strategy.validate(req);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/nestjs/src/auth/strategies/github.strategy.spec.ts
+++ b/nestjs/src/auth/strategies/github.strategy.spec.ts
@@ -1,0 +1,211 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { Strategy as OAuth2Strategy } from 'passport-oauth2';
+import type { Profile } from 'passport-github2';
+import { GithubStrategy } from './github.strategy';
+import { ConfigService } from '../../config';
+import { AuthService, CurrentRequest, LoginStateParams } from '../auth.service';
+import { AuthUser } from '..';
+
+const mockConfig = {
+  auth: {
+    github: {
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      callbackUrl: 'https://app.example/callback',
+      scope: ['user:email'],
+    },
+    dev: {
+      admin: false,
+    },
+  },
+} as Partial<ConfigService> as ConfigService;
+
+const mockProfile = {
+  provider: 'github',
+  id: '12345',
+  username: 'johndoe',
+} as Profile;
+
+const mockAuthUser = {
+  id: 1,
+  githubId: 'johndoe',
+} as AuthUser;
+
+const mockLoginState = {
+  id: 'state-id',
+  data: { redirectUrl: '/home' },
+};
+
+describe('GithubStrategy', () => {
+  let strategy: GithubStrategy;
+  let authService: Mocked<AuthService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GithubStrategy,
+        { provide: ConfigService, useValue: mockConfig },
+        {
+          provide: AuthService,
+          useValue: {
+            createLoginState: vi.fn(),
+            getLoginStateById: vi.fn(),
+            createAuthUser: vi.fn(),
+            deleteLoginState: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    strategy = module.get<GithubStrategy>(GithubStrategy);
+    authService = module.get(AuthService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  describe('authenticate', () => {
+    let superAuthenticate: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // super.authenticate resolves to passport-oauth2's prototype method.
+      superAuthenticate = vi.spyOn(OAuth2Strategy.prototype, 'authenticate').mockImplementation(() => undefined);
+    });
+
+    it('creates a login state and injects it as `state` when no code is present', async () => {
+      authService.createLoginState.mockResolvedValue('new-state-id');
+      const req = { query: { url: 'https://app.example/dashboard' } } as unknown as CurrentRequest;
+      const options = { scope: ['user:email'] };
+
+      await strategy.authenticate(req, options);
+
+      expect(authService.createLoginState).toHaveBeenCalledWith({
+        data: { redirectUrl: 'https://app.example/dashboard' },
+        expires: expect.any(String),
+      });
+      expect(superAuthenticate).toHaveBeenCalledWith(req, { scope: ['user:email'], state: 'new-state-id' });
+    });
+
+    it('does not create a login state and forwards the original options when a code is present', async () => {
+      const req = { query: { code: 'oauth-code', url: 'https://app.example/dashboard' } } as unknown as CurrentRequest;
+      const options = { scope: ['user:email'] };
+
+      await strategy.authenticate(req, options);
+
+      expect(authService.createLoginState).not.toHaveBeenCalled();
+      expect(superAuthenticate).toHaveBeenCalledWith(req, { scope: ['user:email'] });
+    });
+
+    it('passes undefined redirectUrl through when the url query param is missing', async () => {
+      authService.createLoginState.mockResolvedValue('new-state-id');
+      const req = { query: {} } as unknown as CurrentRequest;
+
+      await strategy.authenticate(req, {});
+
+      expect(authService.createLoginState).toHaveBeenCalledWith({
+        data: { redirectUrl: undefined },
+        expires: expect.any(String),
+      });
+      expect(superAuthenticate).toHaveBeenCalledWith(req, { state: 'new-state-id' });
+    });
+
+    it('sets the state expiry roughly one hour in the future', async () => {
+      authService.createLoginState.mockResolvedValue('new-state-id');
+      const req = { query: { url: '/x' } } as unknown as CurrentRequest;
+      const before = Date.now();
+
+      await strategy.authenticate(req, {});
+
+      const arg = authService.createLoginState.mock.calls[0][0];
+      const expiresMs = new Date(arg.expires as string).getTime();
+      // ~1 hour ahead (allow a wide window for test execution time).
+      expect(expiresMs).toBeGreaterThan(before + 59 * 60 * 1000);
+      expect(expiresMs).toBeLessThan(before + 61 * 60 * 1000);
+    });
+  });
+
+  describe('validate', () => {
+    it('throws UnauthorizedException when the login state is not found', async () => {
+      authService.getLoginStateById.mockResolvedValue(null);
+      const request = { query: { state: 'missing-state' } } as unknown as CurrentRequest;
+
+      await expect(strategy.validate(request, 'access', 'refresh', mockProfile)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(authService.createAuthUser).not.toHaveBeenCalled();
+      expect(authService.deleteLoginState).not.toHaveBeenCalled();
+    });
+
+    it('creates the auth user, deletes the state, sets loginState and returns the user on a valid state', async () => {
+      authService.getLoginStateById.mockResolvedValue(mockLoginState as never);
+      authService.createAuthUser.mockResolvedValue(mockAuthUser);
+      authService.deleteLoginState.mockResolvedValue({} as never);
+      const request = { query: { state: 'state-id' } } as unknown as CurrentRequest;
+
+      const result = await strategy.validate(request, 'access', 'refresh', mockProfile);
+
+      expect(authService.getLoginStateById).toHaveBeenCalledWith('state-id');
+      expect(authService.createAuthUser).toHaveBeenCalledWith(mockProfile, false);
+      expect(authService.deleteLoginState).toHaveBeenCalledWith('state-id');
+      expect(request.loginState).toEqual(mockLoginState.data);
+      expect(result).toBe(mockAuthUser);
+    });
+
+    it('passes the dev admin flag through to createAuthUser', async () => {
+      const adminConfig = {
+        ...mockConfig,
+        auth: { ...mockConfig.auth, dev: { admin: true } },
+      } as ConfigService;
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          GithubStrategy,
+          { provide: ConfigService, useValue: adminConfig },
+          {
+            provide: AuthService,
+            useValue: {
+              createLoginState: vi.fn(),
+              getLoginStateById: vi.fn().mockResolvedValue(mockLoginState),
+              createAuthUser: vi.fn().mockResolvedValue(mockAuthUser),
+              deleteLoginState: vi.fn().mockResolvedValue({}),
+            },
+          },
+        ],
+      }).compile();
+      const adminStrategy = module.get<GithubStrategy>(GithubStrategy);
+      const adminAuthService = module.get<Mocked<AuthService>>(AuthService);
+      const request = { query: { state: 'state-id' } } as unknown as CurrentRequest;
+
+      await adminStrategy.validate(request, 'access', 'refresh', mockProfile);
+
+      expect(adminAuthService.createAuthUser).toHaveBeenCalledWith(mockProfile, true);
+    });
+  });
+
+  describe('getAuthorizeUrl', () => {
+    it('creates a login state and builds the authorize url from the oauth2 client', async () => {
+      authService.createLoginState.mockResolvedValue('state-id');
+      const getAuthorizeUrl = vi.fn().mockReturnValue('https://github.com/login/oauth/authorize?state=state-id');
+      (strategy as unknown as { _oauth2: { getAuthorizeUrl: typeof getAuthorizeUrl } })._oauth2 = {
+        getAuthorizeUrl,
+      };
+      const params: LoginStateParams = { data: { redirectUrl: '/home' } };
+
+      const url = await strategy.getAuthorizeUrl(params);
+
+      expect(authService.createLoginState).toHaveBeenCalledWith(params);
+      expect(getAuthorizeUrl).toHaveBeenCalledWith({
+        redirect_uri: 'https://app.example/callback',
+        state: 'state-id',
+        scope: ['user:email'],
+      });
+      expect(url).toBe('https://github.com/login/oauth/authorize?state=state-id');
+    });
+  });
+});

--- a/nestjs/src/auth/strategies/jwt.strategy.spec.ts
+++ b/nestjs/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,170 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
+import { JwtStrategy } from './jwt.strategy';
+import { ConfigService } from '../../config';
+import { AuthService } from '../auth.service';
+import { JWT_COOKIE_NAME } from '../constants';
+import { AuthUser, JwtToken } from '../auth-user.model';
+
+const SECRET = 'test-secret-key';
+
+const mockConfig = {
+  auth: { jwt: { secretKey: SECRET } },
+} as Partial<ConfigService> as ConfigService;
+
+const mockPayload: JwtToken = {
+  id: 42,
+  githubId: 'johndoe',
+  isAdmin: false,
+  isHirer: false,
+};
+
+const mockAuthUser = {
+  id: 42,
+  githubId: 'johndoe',
+  isAdmin: false,
+  isHirer: false,
+} as AuthUser;
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+  let cacheManager: Mocked<Cache>;
+  let authService: Mocked<AuthService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JwtStrategy,
+        { provide: ConfigService, useValue: mockConfig },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: vi.fn(),
+            set: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            getAuthUser: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    strategy = module.get<JwtStrategy>(JwtStrategy);
+    cacheManager = module.get(CACHE_MANAGER);
+    authService = module.get(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  describe('jwtFromRequest (token extraction)', () => {
+    // The extractor is the function passed to passport-jwt via super();
+    // passport-jwt stores it on the instance as `_jwtFromRequest`.
+    const getExtractor = () =>
+      (strategy as unknown as { _jwtFromRequest: (req: Request) => string | null })._jwtFromRequest;
+
+    it('extracts the token from the auth cookie when present', () => {
+      const req = {
+        cookies: { [JWT_COOKIE_NAME]: 'cookie-token' },
+        headers: {},
+      } as unknown as Request;
+
+      expect(getExtractor()(req)).toBe('cookie-token');
+    });
+
+    it('falls back to the Authorization bearer header when the cookie is absent', () => {
+      const req = {
+        cookies: {},
+        headers: { authorization: 'Bearer header-token' },
+      } as unknown as Request;
+
+      expect(getExtractor()(req)).toBe('header-token');
+    });
+
+    it('falls back to the bearer header when cookies object is undefined (?. short-circuit)', () => {
+      const req = {
+        headers: { authorization: 'Bearer header-token' },
+      } as unknown as Request;
+
+      expect(getExtractor()(req)).toBe('header-token');
+    });
+
+    it('returns null when neither cookie nor bearer header is present', () => {
+      const req = {
+        cookies: {},
+        headers: {},
+      } as unknown as Request;
+
+      expect(getExtractor()(req)).toBeNull();
+    });
+
+    it('prefers the cookie over the bearer header when both are present', () => {
+      const req = {
+        cookies: { [JWT_COOKIE_NAME]: 'cookie-token' },
+        headers: { authorization: 'Bearer header-token' },
+      } as unknown as Request;
+
+      expect(getExtractor()(req)).toBe('cookie-token');
+    });
+  });
+
+  describe('validate', () => {
+    it('returns the cached user on a cache hit without calling AuthService', async () => {
+      cacheManager.get.mockResolvedValue(mockAuthUser);
+
+      const result = await strategy.validate(mockPayload);
+
+      expect(cacheManager.get).toHaveBeenCalledWith('auth-user-42');
+      expect(authService.getAuthUser).not.toHaveBeenCalled();
+      expect(cacheManager.set).not.toHaveBeenCalled();
+      expect(result).toBe(mockAuthUser);
+    });
+
+    it('loads from AuthService and caches the user on a cache miss', async () => {
+      cacheManager.get.mockResolvedValue(undefined);
+      authService.getAuthUser.mockResolvedValue(mockAuthUser);
+
+      const result = await strategy.validate(mockPayload);
+
+      expect(cacheManager.get).toHaveBeenCalledWith('auth-user-42');
+      expect(authService.getAuthUser).toHaveBeenCalledWith('johndoe');
+      expect(cacheManager.set).toHaveBeenCalledWith('auth-user-42', mockAuthUser, 1000 * 60 * 10);
+      expect(result).toBe(mockAuthUser);
+    });
+
+    it('treats a null cached value as a miss and loads from AuthService', async () => {
+      cacheManager.get.mockResolvedValue(null);
+      authService.getAuthUser.mockResolvedValue(mockAuthUser);
+
+      const result = await strategy.validate(mockPayload);
+
+      expect(authService.getAuthUser).toHaveBeenCalledWith('johndoe');
+      expect(result).toBe(mockAuthUser);
+    });
+
+    it('builds the cache key from the payload id', async () => {
+      cacheManager.get.mockResolvedValue(undefined);
+      authService.getAuthUser.mockResolvedValue(mockAuthUser);
+
+      await strategy.validate({ ...mockPayload, id: 7 });
+
+      expect(cacheManager.get).toHaveBeenCalledWith('auth-user-7');
+      expect(cacheManager.set).toHaveBeenCalledWith('auth-user-7', mockAuthUser, expect.any(Number));
+    });
+
+    it('propagates an AuthService rejection on a cache miss', async () => {
+      const error = new Error('user not found');
+      cacheManager.get.mockResolvedValue(undefined);
+      authService.getAuthUser.mockRejectedValue(error);
+
+      await expect(strategy.validate(mockPayload)).rejects.toThrow('user not found');
+      expect(cacheManager.set).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/nestjs/src/core/decorators/student-id.decorator.spec.ts
+++ b/nestjs/src/core/decorators/student-id.decorator.spec.ts
@@ -1,0 +1,64 @@
+import { ExecutionContext } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { StudentId } from './student-id.decorator';
+
+type ParamFactory = (data: unknown, ctx: ExecutionContext) => unknown;
+
+// `createParamDecorator` hides its factory; recover it from the route-args metadata
+// it writes when the decorator is applied to a parameter.
+const getParamDecoratorFactory = (decorator: () => ParameterDecorator): ParamFactory => {
+  class TestController {
+    public test(@decorator() _value: unknown) {}
+  }
+
+  const args = Reflect.getMetadata(ROUTE_ARGS_METADATA, TestController, 'test');
+  const key = Object.keys(args)[0];
+  return args[key].factory as ParamFactory;
+};
+
+const buildContext = (request: unknown): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('StudentId decorator', () => {
+  const factory = getParamDecoratorFactory(StudentId);
+
+  it('returns the studentId for the matched course', () => {
+    const ctx = buildContext({
+      params: { courseId: '5' },
+      user: { courses: { 5: { studentId: 123 } } },
+    });
+
+    expect(factory(undefined, ctx)).toBe(123);
+  });
+
+  it('returns undefined when the user is not enrolled in the course (optional chaining)', () => {
+    const ctx = buildContext({
+      params: { courseId: '5' },
+      user: { courses: { 7: { studentId: 123 } } },
+    });
+
+    expect(factory(undefined, ctx)).toBeUndefined();
+  });
+
+  it('returns undefined when the matched course has no studentId', () => {
+    const ctx = buildContext({
+      params: { courseId: '5' },
+      user: { courses: { 5: {} } },
+    });
+
+    expect(factory(undefined, ctx)).toBeUndefined();
+  });
+
+  it('reads the courseId from the request params', () => {
+    const ctx = buildContext({
+      params: { courseId: '42' },
+      user: { courses: { 42: { studentId: 999 }, 5: { studentId: 1 } } },
+    });
+
+    expect(factory(undefined, ctx)).toBe(999);
+  });
+});

--- a/nestjs/src/core/filters/entity-not-found.filter.spec.ts
+++ b/nestjs/src/core/filters/entity-not-found.filter.spec.ts
@@ -1,0 +1,56 @@
+import { ArgumentsHost, NotFoundException } from '@nestjs/common';
+import { EntityNotFoundError } from 'typeorm';
+import { EntityNotFoundFilter } from './entity-not-found.filter';
+
+const mockResponse = {
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn(),
+};
+
+const mockHost = {
+  switchToHttp: () => ({
+    getResponse: () => mockResponse,
+    getRequest: () => ({}),
+  }),
+} as unknown as ArgumentsHost;
+
+describe('EntityNotFoundFilter', () => {
+  let filter: EntityNotFoundFilter;
+
+  beforeEach(() => {
+    filter = new EntityNotFoundFilter();
+    mockResponse.status.mockClear().mockReturnThis();
+    mockResponse.json.mockClear();
+  });
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined();
+  });
+
+  describe('catch', () => {
+    const exception = new EntityNotFoundError('SomeEntity', {});
+
+    it('should respond with a 404 status code', () => {
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should respond with the NotFoundException body as JSON', () => {
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.json).toHaveBeenCalledWith(new NotFoundException().getResponse());
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Not Found',
+        statusCode: 404,
+      });
+    });
+
+    it('should chain status().json() on the same response object', () => {
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledTimes(1);
+      expect(mockResponse.json).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/nestjs/src/core/filters/sentry.filter.spec.ts
+++ b/nestjs/src/core/filters/sentry.filter.spec.ts
@@ -1,0 +1,87 @@
+import { ArgumentsHost } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import * as Sentry from '@sentry/node';
+import { SentryFilter } from './sentry.filter';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+const mockHost = {
+  switchToHttp: () => ({
+    getResponse: () => ({
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    }),
+    getRequest: () => ({}),
+  }),
+} as unknown as ArgumentsHost;
+
+describe('SentryFilter', () => {
+  let filter: SentryFilter;
+  let superCatchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    filter = new SentryFilter();
+    // Stub the base NestJS catch so it doesn't try to build a real HTTP response.
+    superCatchSpy = vi.spyOn(BaseExceptionFilter.prototype, 'catch').mockImplementation(() => undefined);
+    vi.mocked(Sentry.captureException).mockClear();
+  });
+
+  afterEach(() => {
+    superCatchSpy.mockRestore();
+  });
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined();
+  });
+
+  it('should be an instance of BaseExceptionFilter', () => {
+    expect(filter).toBeInstanceOf(BaseExceptionFilter);
+  });
+
+  describe('catch', () => {
+    it('should report the exception to Sentry', () => {
+      const exception = new Error('boom');
+
+      filter.catch(exception, mockHost);
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledWith(exception);
+    });
+
+    it('should delegate to the base exception filter with the same arguments', () => {
+      const exception = new Error('boom');
+
+      filter.catch(exception, mockHost);
+
+      expect(superCatchSpy).toHaveBeenCalledTimes(1);
+      expect(superCatchSpy).toHaveBeenCalledWith(exception, mockHost);
+    });
+
+    it('should capture before delegating to the base filter', () => {
+      const exception = new Error('order');
+      const callOrder: string[] = [];
+      vi.mocked(Sentry.captureException).mockImplementation(() => {
+        callOrder.push('sentry');
+        return '' as never;
+      });
+      superCatchSpy.mockImplementation(() => {
+        callOrder.push('super');
+      });
+
+      filter.catch(exception, mockHost);
+
+      expect(callOrder).toEqual(['sentry', 'super']);
+    });
+
+    it('should handle non-Error exception values (unknown)', () => {
+      const exception = { weird: 'shape' };
+
+      filter.catch(exception, mockHost);
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(exception);
+      expect(superCatchSpy).toHaveBeenCalledWith(exception, mockHost);
+    });
+  });
+});

--- a/nestjs/src/core/jwt/jwt.service.spec.ts
+++ b/nestjs/src/core/jwt/jwt.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { verify } from 'jsonwebtoken';
+import { JwtService } from './jwt.service';
+import { ConfigService } from '../../config';
+import { AuthUser, JwtToken } from '../../auth/auth-user.model';
+
+const SECRET = 'test-secret-key';
+
+const mockAuthUser = {
+  id: 42,
+  githubId: 'johndoe',
+  isAdmin: true,
+  isHirer: false,
+} as AuthUser;
+
+describe('JwtService', () => {
+  let service: JwtService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JwtService,
+        {
+          provide: ConfigService,
+          useValue: {
+            auth: { jwt: { secretKey: SECRET } },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<JwtService>(JwtService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createToken', () => {
+    it('signs only the JwtToken fields and round-trips via verify', () => {
+      const token = service.createToken(mockAuthUser);
+      const decoded = verify(token, SECRET) as JwtToken & { exp: number; iat: number };
+
+      expect(decoded).toMatchObject({
+        id: 42,
+        githubId: 'johndoe',
+        isAdmin: true,
+        isHirer: false,
+      });
+      expect(decoded.exp).toBeGreaterThan(decoded.iat);
+    });
+
+    it('produces a token that fails verification with a wrong secret', () => {
+      const token = service.createToken(mockAuthUser);
+
+      expect(() => verify(token, 'other-secret')).toThrow();
+    });
+  });
+
+  describe('createPublicCalendarToken', () => {
+    it('signs an arbitrary serializable payload', () => {
+      const token = service.createPublicCalendarToken({ courseId: 7, userId: 3 });
+      const decoded = verify(token, SECRET) as { courseId: number; userId: number };
+
+      expect(decoded).toMatchObject({ courseId: 7, userId: 3 });
+    });
+
+    it('strips non-serializable values through JSON round-trip', () => {
+      const token = service.createPublicCalendarToken({ keep: 1, drop: undefined, fn: () => 1 });
+      const decoded = verify(token, SECRET) as Record<string, unknown>;
+
+      expect(decoded).toMatchObject({ keep: 1 });
+      expect(decoded).not.toHaveProperty('drop');
+      expect(decoded).not.toHaveProperty('fn');
+    });
+  });
+
+  describe('validateToken', () => {
+    it('returns the decoded payload for a valid token', () => {
+      const token = service.createToken(mockAuthUser);
+
+      const result = service.validateToken<JwtToken>(token);
+
+      expect(result).toMatchObject({ id: 42, githubId: 'johndoe' });
+    });
+
+    it('throws for an invalid token', () => {
+      expect(() => service.validateToken('not-a-jwt')).toThrow();
+    });
+  });
+});

--- a/nestjs/src/core/middlewares/logger.middleware.spec.ts
+++ b/nestjs/src/core/middlewares/logger.middleware.spec.ts
@@ -1,0 +1,106 @@
+import { Logger } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { LoggingMiddleware } from './logger.middleware';
+
+type FinishListener = () => void;
+
+describe('LoggingMiddleware', () => {
+  let middleware: LoggingMiddleware;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let next: NextFunction;
+  let finishListener: FinishListener | undefined;
+  let res: Response;
+
+  const buildRes = (statusCode = 200): Response => {
+    finishListener = undefined;
+    return {
+      statusCode,
+      on: vi.fn((event: string, cb: FinishListener) => {
+        if (event === 'finish') finishListener = cb;
+      }),
+    } as Partial<Response> as Response;
+  };
+
+  const buildReq = (overrides: Partial<Request> = {}): Request =>
+    ({
+      url: '/api/courses',
+      query: { page: '1' },
+      method: 'GET',
+      ...overrides,
+    }) as Partial<Request> as Request;
+
+  beforeEach(() => {
+    middleware = new LoggingMiddleware();
+    // Logger.prototype.log is shared across instances, so spying on the prototype
+    // captures the call made by the middleware's private logger.
+    logSpy = vi.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    next = vi.fn();
+    res = buildRes();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('should be defined', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('registers a finish listener on the response', () => {
+    middleware.use(buildReq(), res, next);
+
+    expect(res.on).toHaveBeenCalledWith('finish', expect.any(Function));
+  });
+
+  it('calls next()', () => {
+    middleware.use(buildReq(), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log until the response finishes', () => {
+    middleware.use(buildReq(), res, next);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs request metadata when the response finishes', () => {
+    res = buildRes(201);
+    const req = buildReq({ url: '/api/x', method: 'POST', query: { a: 'b' } });
+
+    middleware.use(req, res, next);
+    finishListener?.();
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const payload = logSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      msg: 'Processed request',
+      url: '/api/x',
+      query: { a: 'b' },
+      method: 'POST',
+      status: 201,
+      userId: null,
+    });
+    expect(typeof payload.duration).toBe('number');
+    expect(payload.duration as number).toBeGreaterThanOrEqual(0);
+  });
+
+  it('includes the user id when a user is attached to the request', () => {
+    const req = buildReq();
+    (req as Request & { user: { id: number } }).user = { id: 42 };
+
+    middleware.use(req, res, next);
+    finishListener?.();
+
+    const payload = logSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.userId).toBe(42);
+  });
+
+  it('falls back to null userId when there is no user', () => {
+    middleware.use(buildReq(), res, next);
+    finishListener?.();
+
+    const payload = logSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.userId).toBeNull();
+  });
+});

--- a/nestjs/src/core/middlewares/no-cache.middleware.spec.ts
+++ b/nestjs/src/core/middlewares/no-cache.middleware.spec.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from 'express';
+import { NoCacheMiddleware } from './no-cache.middleware';
+
+describe('NoCacheMiddleware', () => {
+  let middleware: NoCacheMiddleware;
+  let setHeader: ReturnType<typeof vi.fn>;
+  let next: NextFunction;
+  let res: Response;
+
+  beforeEach(() => {
+    middleware = new NoCacheMiddleware();
+    setHeader = vi.fn();
+    next = vi.fn();
+    res = { setHeader } as Partial<Response> as Response;
+  });
+
+  it('should be defined', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('sets the Cache-Control header to no-cache', () => {
+    middleware.use({} as Request, res, next);
+
+    expect(setHeader).toHaveBeenCalledTimes(1);
+    expect(setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+  });
+
+  it('calls next()', () => {
+    middleware.use({} as Request, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets the header before calling next', () => {
+    const order: string[] = [];
+    setHeader.mockImplementation(() => order.push('setHeader'));
+    (next as ReturnType<typeof vi.fn>).mockImplementation(() => order.push('next'));
+
+    middleware.use({} as Request, res, next);
+
+    expect(order).toEqual(['setHeader', 'next']);
+  });
+});

--- a/nestjs/src/core/paginate/paginate.spec.ts
+++ b/nestjs/src/core/paginate/paginate.spec.ts
@@ -1,0 +1,59 @@
+import { SelectQueryBuilder } from 'typeorm';
+import { paginate } from './index';
+
+type QbMock = {
+  take: ReturnType<typeof vi.fn>;
+  skip: ReturnType<typeof vi.fn>;
+  getManyAndCount: ReturnType<typeof vi.fn>;
+};
+
+const createQueryBuilder = (items: unknown[], total: number): QbMock => {
+  const qb = {
+    take: vi.fn(),
+    skip: vi.fn(),
+    getManyAndCount: vi.fn().mockResolvedValue([items, total]),
+  };
+  qb.take.mockReturnValue(qb);
+  qb.skip.mockReturnValue(qb);
+  return qb;
+};
+
+describe('paginate', () => {
+  it('applies limit and zero offset for the first page', async () => {
+    const qb = createQueryBuilder([{ id: 1 }, { id: 2 }], 2);
+
+    const result = await paginate(qb as unknown as SelectQueryBuilder<{ id: number }>, { page: 1, limit: 10 });
+
+    expect(qb.take).toHaveBeenCalledWith(10);
+    expect(qb.skip).toHaveBeenCalledWith(0);
+    expect(result.items).toHaveLength(2);
+    expect(result.meta).toEqual({ itemCount: 2, total: 2, current: 1, pageSize: 10, totalPages: 1 });
+  });
+
+  it('computes a non-zero offset for later pages and ceils totalPages', async () => {
+    const qb = createQueryBuilder([{ id: 11 }], 21);
+
+    const result = await paginate(qb as unknown as SelectQueryBuilder<{ id: number }>, { page: 3, limit: 10 });
+
+    expect(qb.skip).toHaveBeenCalledWith(20);
+    expect(result.meta.totalPages).toBe(3); // ceil(21 / 10)
+    expect(result.meta.current).toBe(3);
+  });
+
+  it('clamps the offset to 0 for non-positive page numbers', async () => {
+    const qb = createQueryBuilder([], 0);
+
+    await paginate(qb as unknown as SelectQueryBuilder<{ id: number }>, { page: 0, limit: 10 });
+
+    expect(qb.skip).toHaveBeenCalledWith(0); // Math.max((0 - 1) * 10, 0)
+  });
+
+  it('reports an empty result set', async () => {
+    const qb = createQueryBuilder([], 0);
+
+    const result = await paginate(qb as unknown as SelectQueryBuilder<{ id: number }>, { page: 1, limit: 25 });
+
+    expect(result.items).toEqual([]);
+    expect(result.meta).toEqual({ itemCount: 0, total: 0, current: 1, pageSize: 25, totalPages: 0 });
+  });
+});

--- a/nestjs/src/core/pino.spec.ts
+++ b/nestjs/src/core/pino.spec.ts
@@ -1,0 +1,112 @@
+const cloudwatchStreamMock = vi.fn(() => ({ __stream: true }));
+
+vi.mock('@apalchys/pino-cloudwatch', () => ({
+  default: cloudwatchStreamMock,
+}));
+
+// pino.ts reads env vars at module-load time, so each scenario resets the module
+// registry and re-imports with a tailored process.env.
+const loadGetPinoHttp = async (env: Record<string, string | undefined>) => {
+  vi.resetModules();
+  cloudwatchStreamMock.mockClear();
+
+  const original = { ...process.env };
+  // Start from a clean slate for the vars the module reads.
+  delete process.env.NODE_ENV;
+  delete process.env.AWS_LAMBDA;
+  delete process.env.RSSHCOOL_AWS_ACCESS_KEY_ID;
+  delete process.env.RSSHCOOL_AWS_SECRET_ACCESS_KEY;
+  delete process.env.RSSHCOOL_AWS_REGION;
+  Object.assign(process.env, env);
+
+  const mod = await import('./pino');
+  const result = mod.getPinoHttp();
+
+  process.env = original;
+  return result;
+};
+
+const BASE_OPTIONS = { base: {}, autoLogging: false, quietReqLogger: true };
+
+describe('getPinoHttp', () => {
+  it('returns plain pino options in dev mode (NODE_ENV != production)', async () => {
+    const result = await loadGetPinoHttp({
+      NODE_ENV: 'development',
+      RSSHCOOL_AWS_ACCESS_KEY_ID: 'key',
+      RSSHCOOL_AWS_SECRET_ACCESS_KEY: 'secret',
+    });
+
+    expect(result).toEqual(BASE_OPTIONS);
+    expect(cloudwatchStreamMock).not.toHaveBeenCalled();
+  });
+
+  it('returns plain pino options in dev (no AWS_LAMBDA, non-production) even with credentials', async () => {
+    // devMode = NODE_ENV !== production && !AWS_LAMBDA -> true here, so no cloudwatch stream.
+    const result = await loadGetPinoHttp({
+      NODE_ENV: 'test',
+      RSSHCOOL_AWS_ACCESS_KEY_ID: 'key',
+      RSSHCOOL_AWS_SECRET_ACCESS_KEY: 'secret',
+      RSSHCOOL_AWS_REGION: 'eu-central-1',
+    });
+
+    expect(result).toEqual(BASE_OPTIONS);
+    expect(cloudwatchStreamMock).not.toHaveBeenCalled();
+  });
+
+  it('attaches a cloudwatch stream under AWS_LAMBDA when credentials are present (devMode forced false)', async () => {
+    // AWS_LAMBDA forces devMode false regardless of NODE_ENV, so with creds the stream is added.
+    const result = await loadGetPinoHttp({
+      NODE_ENV: 'development',
+      AWS_LAMBDA: 'true',
+      RSSHCOOL_AWS_ACCESS_KEY_ID: 'key',
+      RSSHCOOL_AWS_SECRET_ACCESS_KEY: 'secret',
+      RSSHCOOL_AWS_REGION: 'eu-central-1',
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(cloudwatchStreamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns plain pino options when AWS credentials are missing', async () => {
+    const result = await loadGetPinoHttp({ NODE_ENV: 'production' });
+
+    expect(result).toEqual(BASE_OPTIONS);
+    expect(cloudwatchStreamMock).not.toHaveBeenCalled();
+  });
+
+  it('returns plain pino options when only the access key id is set', async () => {
+    const result = await loadGetPinoHttp({
+      NODE_ENV: 'production',
+      RSSHCOOL_AWS_ACCESS_KEY_ID: 'key',
+    });
+
+    expect(result).toEqual(BASE_OPTIONS);
+    expect(cloudwatchStreamMock).not.toHaveBeenCalled();
+  });
+
+  it('attaches a cloudwatch stream in production with full AWS credentials', async () => {
+    const result = await loadGetPinoHttp({
+      NODE_ENV: 'production',
+      RSSHCOOL_AWS_ACCESS_KEY_ID: 'key',
+      RSSHCOOL_AWS_SECRET_ACCESS_KEY: 'secret',
+      RSSHCOOL_AWS_REGION: 'eu-central-1',
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    const [options, stream] = result as [unknown, unknown];
+    expect(options).toEqual(BASE_OPTIONS);
+    expect(stream).toEqual({ __stream: true });
+
+    expect(cloudwatchStreamMock).toHaveBeenCalledTimes(1);
+    expect(cloudwatchStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interval: 2000,
+        aws_access_key_id: 'key',
+        aws_secret_access_key: 'secret',
+        aws_region: 'eu-central-1',
+        group: '/app/rsschool-api',
+        stream: expect.stringMatching(/^\d{4}-\d{2}-\d{2}-nestjs$/),
+      }),
+    );
+  });
+});

--- a/nestjs/src/core/subscribers/base-subscriber.spec.ts
+++ b/nestjs/src/core/subscribers/base-subscriber.spec.ts
@@ -1,0 +1,233 @@
+import { InsertEvent, RemoveEvent, UpdateEvent } from 'typeorm';
+import { History } from '@entities/history';
+import { BaseSubscriber } from './base-subscriber';
+
+type MockManager = {
+  save: ReturnType<typeof vi.fn>;
+  findOneBy: ReturnType<typeof vi.fn>;
+};
+
+const buildManager = (): MockManager => ({
+  save: vi.fn().mockResolvedValue(undefined),
+  findOneBy: vi.fn(),
+});
+
+const TARGET = class CourseEvent {};
+
+const buildMetadata = () => ({ tableName: 'course_event', target: TARGET });
+
+describe('BaseSubscriber', () => {
+  let subscriber: BaseSubscriber;
+  let manager: MockManager;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    subscriber = new BaseSubscriber();
+    manager = buildManager();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('afterInsert', () => {
+    it('saves an insert History record from the inserted entity', async () => {
+      const entity = { id: 7, name: 'Demo' };
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity,
+      } as unknown as InsertEvent<{ id: number }>;
+
+      await subscriber.afterInsert!(event);
+
+      expect(manager.save).toHaveBeenCalledTimes(1);
+      expect(manager.save).toHaveBeenCalledWith(
+        History,
+        {
+          event: 'course_event',
+          entityId: 7,
+          update: entity,
+          operation: 'insert',
+        },
+        { listeners: false },
+      );
+    });
+  });
+
+  describe('beforeUpdate', () => {
+    it('warns and returns when there is no entity', async () => {
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity: undefined,
+      } as unknown as UpdateEvent<{ id: number }>;
+
+      await subscriber.beforeUpdate!(event);
+
+      expect(warnSpy).toHaveBeenCalledWith('subscriber missing entity id');
+      expect(manager.findOneBy).not.toHaveBeenCalled();
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+
+    it('warns and returns when the entity has no id', async () => {
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity: { name: 'no id' },
+      } as unknown as UpdateEvent<{ id: number }>;
+
+      await subscriber.beforeUpdate!(event);
+
+      expect(warnSpy).toHaveBeenCalledWith('subscriber missing entity id');
+      expect(manager.findOneBy).not.toHaveBeenCalled();
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+
+    it('returns without saving when the previous record is not found', async () => {
+      manager.findOneBy.mockResolvedValue(null);
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity: { id: 3 },
+      } as unknown as UpdateEvent<{ id: number }>;
+
+      await subscriber.beforeUpdate!(event);
+
+      expect(manager.findOneBy).toHaveBeenCalledWith(TARGET, { id: 3 });
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+
+    it('saves an update History record with the previous and new state', async () => {
+      const old = { id: 3, name: 'old' };
+      const entity = { id: 3, name: 'new' };
+      manager.findOneBy.mockResolvedValue(old);
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity,
+      } as unknown as UpdateEvent<{ id: number }>;
+
+      await subscriber.beforeUpdate!(event);
+
+      expect(manager.save).toHaveBeenCalledWith(
+        History,
+        {
+          event: 'course_event',
+          update: entity,
+          entityId: 3,
+          previous: old,
+          operation: 'update',
+        },
+        { listeners: false },
+      );
+    });
+  });
+
+  describe('beforeRemove', () => {
+    it('returns silently when there is no entity', async () => {
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity: undefined,
+        entityId: 9,
+      } as unknown as RemoveEvent<{ id: number }>;
+
+      await subscriber.beforeRemove!(event);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(manager.findOneBy).not.toHaveBeenCalled();
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+
+    it('warns and returns when neither entity.id nor event.entityId is set', async () => {
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity: { name: 'no id' },
+        entityId: undefined,
+      } as unknown as RemoveEvent<{ id: number }>;
+
+      await subscriber.beforeRemove!(event);
+
+      expect(warnSpy).toHaveBeenCalledWith('subscriber missing entity id');
+      expect(manager.findOneBy).not.toHaveBeenCalled();
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+
+    it('uses entity.id and saves a remove History record', async () => {
+      const old = { id: 5, name: 'old' };
+      const entity = { id: 5, name: 'removed' };
+      manager.findOneBy.mockResolvedValue(old);
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity,
+        entityId: 99,
+      } as unknown as RemoveEvent<{ id: number }>;
+
+      await subscriber.beforeRemove!(event);
+
+      // entity.id takes precedence over event.entityId.
+      expect(manager.findOneBy).toHaveBeenCalledWith(TARGET, { id: 5 });
+      expect(manager.save).toHaveBeenCalledWith(
+        History,
+        {
+          event: 'course_event',
+          operation: 'remove',
+          entityId: 5,
+          update: entity,
+          previous: old,
+        },
+        { listeners: false },
+      );
+    });
+
+    it('falls back to event.entityId when entity.id is missing', async () => {
+      const old = { id: 12 };
+      manager.findOneBy.mockResolvedValue(old);
+      const entity = { name: 'removed' };
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity,
+        entityId: 12,
+      } as unknown as RemoveEvent<{ id: number }>;
+
+      await subscriber.beforeRemove!(event);
+
+      expect(manager.findOneBy).toHaveBeenCalledWith(TARGET, { id: 12 });
+      expect(manager.save).toHaveBeenCalledWith(
+        History,
+        expect.objectContaining({ entityId: 12, operation: 'remove' }),
+        { listeners: false },
+      );
+    });
+
+    it('saves with undefined entityId when the previous record is not found', async () => {
+      manager.findOneBy.mockResolvedValue(null);
+      const entity = { id: 8 };
+      const event = {
+        manager,
+        metadata: buildMetadata(),
+        entity,
+        entityId: 8,
+      } as unknown as RemoveEvent<{ id: number }>;
+
+      await subscriber.beforeRemove!(event);
+
+      expect(manager.save).toHaveBeenCalledWith(
+        History,
+        {
+          event: 'course_event',
+          operation: 'remove',
+          entityId: undefined,
+          update: entity,
+          previous: null,
+        },
+        { listeners: false },
+      );
+    });
+  });
+});

--- a/nestjs/src/core/subscribers/course-event.subscriber.spec.ts
+++ b/nestjs/src/core/subscribers/course-event.subscriber.spec.ts
@@ -1,0 +1,19 @@
+import { CourseEvent } from '@entities/courseEvent';
+import { BaseSubscriber } from './base-subscriber';
+import { CourseEventSubscriber } from './course-event.subscriber';
+
+describe('CourseEventSubscriber', () => {
+  const subscriber = new CourseEventSubscriber();
+
+  it('should be defined', () => {
+    expect(subscriber).toBeDefined();
+  });
+
+  it('extends BaseSubscriber', () => {
+    expect(subscriber).toBeInstanceOf(BaseSubscriber);
+  });
+
+  it('listens to the CourseEvent entity', () => {
+    expect(subscriber.listenTo()).toBe(CourseEvent);
+  });
+});

--- a/nestjs/src/core/subscribers/course-task.subscriber.spec.ts
+++ b/nestjs/src/core/subscribers/course-task.subscriber.spec.ts
@@ -1,0 +1,19 @@
+import { CourseTask } from '@entities/courseTask';
+import { BaseSubscriber } from './base-subscriber';
+import { CourseTaskSubscriber } from './course-task.subscriber';
+
+describe('CourseTaskSubscriber', () => {
+  const subscriber = new CourseTaskSubscriber();
+
+  it('should be defined', () => {
+    expect(subscriber).toBeDefined();
+  });
+
+  it('extends BaseSubscriber', () => {
+    expect(subscriber).toBeInstanceOf(BaseSubscriber);
+  });
+
+  it('listens to the CourseTask entity', () => {
+    expect(subscriber.listenTo()).toBe(CourseTask);
+  });
+});

--- a/nestjs/src/core/templates/index.spec.ts
+++ b/nestjs/src/core/templates/index.spec.ts
@@ -1,0 +1,127 @@
+import handlebars from 'handlebars';
+// Importing the module registers the custom helpers on the shared handlebars instance.
+import './index';
+
+type HelperFn = (...args: unknown[]) => unknown;
+
+const getHelper = (name: string): HelperFn => handlebars.helpers[name] as unknown as HelperFn;
+
+describe('handlebars template helpers', () => {
+  it('registers all expected helpers', () => {
+    expect(typeof getHelper('truncate')).toBe('function');
+    expect(typeof getHelper('capitalize')).toBe('function');
+    expect(typeof getHelper('ifEquals')).toBe('function');
+    expect(typeof getHelper('formatDateTime')).toBe('function');
+  });
+
+  describe('truncate', () => {
+    // The helper reads `options.maxLength` directly (see latent-bug note below),
+    // so tests pass the value at the top level of the options object.
+    const truncate = (str: string, maxLength?: number) => getHelper('truncate')(str, { maxLength } as never);
+
+    it('truncates and appends ellipsis when longer than maxLength', () => {
+      const result = truncate('abcdefghij', 3);
+
+      expect(result).toBe('abc...');
+    });
+
+    it('returns the string unchanged when shorter than maxLength', () => {
+      const result = truncate('abc', 10);
+
+      expect(result).toBe('abc');
+    });
+
+    it('returns the string unchanged when exactly at maxLength', () => {
+      const result = truncate('abcde', 5);
+
+      expect(result).toBe('abcde');
+    });
+
+    it('falls back to default maxLength of 50 when maxLength is undefined', () => {
+      const long = 'x'.repeat(60);
+
+      const result = truncate(long, undefined);
+
+      expect(result).toBe(`${'x'.repeat(50)}...`);
+    });
+
+    it('returns short strings unchanged under the default maxLength', () => {
+      const result = truncate('short', undefined);
+
+      expect(result).toBe('short');
+    });
+
+    it('handles a missing options object via the `options || {}` fallback', () => {
+      // Invoked without an options argument: options is undefined.
+      const result = (getHelper('truncate') as HelperFn)('x'.repeat(60));
+
+      expect(result).toBe(`${'x'.repeat(50)}...`);
+    });
+
+    it('LATENT BUG: ignores the handlebars hash arg and always defaults to 50', () => {
+      // In a real template `{{truncate str maxLength=3}}`, handlebars places named
+      // args under options.hash. The helper reads options.maxLength (not options.hash),
+      // so the configured length is silently ignored and the default 50 is used.
+      const result = getHelper('truncate')('y'.repeat(60), { hash: { maxLength: 3 } } as never);
+
+      expect(result).toBe(`${'y'.repeat(50)}...`);
+    });
+  });
+
+  describe('capitalize', () => {
+    const capitalize = (str: string) => getHelper('capitalize')(str);
+
+    it('uppercases the first character', () => {
+      expect(capitalize('hello')).toBe('Hello');
+    });
+
+    it('leaves an already-capitalized string with its first char uppercased', () => {
+      expect(capitalize('Hello')).toBe('Hello');
+    });
+
+    it('handles a single character', () => {
+      expect(capitalize('a')).toBe('A');
+    });
+
+    it('returns an empty string for empty input', () => {
+      expect(capitalize('')).toBe('');
+    });
+  });
+
+  describe('ifEquals', () => {
+    it('renders the truthy block when arguments are loosely equal', () => {
+      const template = handlebars.compile('{{#ifEquals a b}}YES{{else}}NO{{/ifEquals}}');
+
+      expect(template({ a: 1, b: 1 })).toBe('YES');
+    });
+
+    it('uses loose equality (== ) across types', () => {
+      const template = handlebars.compile('{{#ifEquals a b}}YES{{else}}NO{{/ifEquals}}');
+
+      // 1 == '1' is true under loose equality.
+      expect(template({ a: 1, b: '1' })).toBe('YES');
+    });
+
+    it('renders the inverse block when arguments are not equal', () => {
+      const template = handlebars.compile('{{#ifEquals a b}}YES{{else}}NO{{/ifEquals}}');
+
+      expect(template({ a: 1, b: 2 })).toBe('NO');
+    });
+  });
+
+  describe('formatDateTime', () => {
+    const formatDateTime = (value: string) => getHelper('formatDateTime')(value);
+
+    it('returns an empty string for falsy input', () => {
+      expect(formatDateTime('')).toBe('');
+    });
+
+    it('formats an ISO date-time string in UTC', () => {
+      expect(formatDateTime('2026-06-26T14:30:00Z')).toBe('2026-06-26 14:30');
+    });
+
+    it('formats a midnight UTC value', () => {
+      expect(formatDateTime('2026-01-01T00:00:00Z')).toBe('2026-01-01 00:00');
+    });
+  });
+});

--- a/nestjs/src/core/validation/validation.filter.spec.ts
+++ b/nestjs/src/core/validation/validation.filter.spec.ts
@@ -1,0 +1,87 @@
+import { ArgumentsHost, Logger } from '@nestjs/common';
+import { ValidationFilter } from './validation.filter';
+import { ValidationException } from './validation.exception';
+
+const mockResponse = {
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn(),
+};
+
+const mockHost = {
+  switchToHttp: () => ({
+    getResponse: () => mockResponse,
+    getRequest: () => ({}),
+  }),
+} as unknown as ArgumentsHost;
+
+describe('ValidationFilter', () => {
+  let filter: ValidationFilter;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    filter = new ValidationFilter();
+    mockResponse.status.mockClear().mockReturnThis();
+    mockResponse.json.mockClear();
+    warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined();
+  });
+
+  describe('catch', () => {
+    it('should respond with a 400 status code', () => {
+      const exception = new ValidationException(['name must be a string']);
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should respond with the validation errors in the JSON body', () => {
+      const errors = ['name must be a string', 'age must be a number'];
+      const exception = new ValidationException(errors);
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: 400,
+        errors,
+      });
+    });
+
+    it('should handle an empty validation errors array', () => {
+      const exception = new ValidationException([]);
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: 400,
+        errors: [],
+      });
+    });
+
+    it('should log the validation errors joined by newlines as a warning', () => {
+      const errors = ['name must be a string', 'age must be a number'];
+      const exception = new ValidationException(errors);
+
+      filter.catch(exception, mockHost);
+
+      expect(warnSpy).toHaveBeenCalledWith('name must be a string\nage must be a number');
+    });
+
+    it('should chain status().json() on the same response object', () => {
+      const exception = new ValidationException(['boom']);
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledTimes(1);
+      expect(mockResponse.json).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/nestjs/src/courses/course-access.service.spec.ts
+++ b/nestjs/src/courses/course-access.service.spec.ts
@@ -1,0 +1,413 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
+import { Between, In } from 'typeorm';
+import { Course, Student } from '@entities/index';
+import { AuthUser, CourseRole, Role } from '../auth';
+import { CourseAccessService } from './course-access.service';
+import { ExpelledStatsService } from './expelled-stats.service';
+import { LeaveCourseRequestDto } from './dto';
+
+// --- module-scope fixtures -------------------------------------------------
+
+const SELF_EXPELLED_MARK = 'Self expelled from the course';
+
+// Build a minimal AuthUser-shaped object. We bypass the real constructor and
+// just provide the fields the service reads (appRoles, courses, isAdmin).
+function makeUser(partial: Partial<AuthUser>): AuthUser {
+  return {
+    appRoles: [Role.User],
+    courses: {},
+    isAdmin: false,
+    ...partial,
+  } as Partial<AuthUser> as AuthUser;
+}
+
+const mockStudent = {
+  id: 101,
+  userId: 5005,
+  isExpelled: false,
+  expellingReason: null,
+} as Partial<Student> as Student;
+
+const mockCourse = {
+  id: 77,
+  completed: false,
+} as Partial<Course> as Course;
+
+const mockLeaveDto = {
+  reasonForLeaving: ['too hard'],
+  otherComment: 'bye',
+} as Partial<LeaveCourseRequestDto> as LeaveCourseRequestDto;
+
+describe('CourseAccessService', () => {
+  let service: CourseAccessService;
+  let studentRepository: {
+    findOneByOrFail: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  let courseRepository: {
+    find: ReturnType<typeof vi.fn>;
+    findOneByOrFail: ReturnType<typeof vi.fn>;
+  };
+  let expelledStatsService: { submitLeaveSurvey: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    studentRepository = {
+      findOneByOrFail: vi.fn(),
+      update: vi.fn(),
+    };
+    courseRepository = {
+      find: vi.fn(),
+      findOneByOrFail: vi.fn(),
+    };
+    expelledStatsService = {
+      submitLeaveSurvey: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CourseAccessService,
+        { provide: getRepositoryToken(Student), useValue: studentRepository },
+        { provide: getRepositoryToken(Course), useValue: courseRepository },
+        { provide: ExpelledStatsService, useValue: expelledStatsService },
+      ],
+    }).compile();
+
+    service = module.get<CourseAccessService>(CourseAccessService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ------------------------------------------------------------------------
+  describe('canAccessCourse', () => {
+    it('returns true for an admin regardless of course membership (admin bypass)', async () => {
+      const user = makeUser({ appRoles: [Role.Admin], courses: {} });
+
+      await expect(service.canAccessCourse(user, 77)).resolves.toBe(true);
+    });
+
+    it('returns true for a non-admin enrolled in the course', async () => {
+      const user = makeUser({ appRoles: [Role.User], courses: { 77: { roles: [CourseRole.Student] } } });
+
+      await expect(service.canAccessCourse(user, 77)).resolves.toBe(true);
+    });
+
+    it('returns false for a non-admin not enrolled in the course', async () => {
+      const user = makeUser({ appRoles: [Role.User], courses: { 77: { roles: [CourseRole.Student] } } });
+
+      await expect(service.canAccessCourse(user, 999)).resolves.toBe(false);
+    });
+
+    it('returns true when appRoles is undefined but the user is enrolled', async () => {
+      const user = makeUser({ appRoles: undefined, courses: { 77: { roles: [CourseRole.Student] } } });
+
+      await expect(service.canAccessCourse(user, 77)).resolves.toBe(true);
+    });
+
+    it('returns false when appRoles is undefined and the user is not enrolled', async () => {
+      const user = makeUser({ appRoles: undefined, courses: {} });
+
+      await expect(service.canAccessCourse(user, 77)).resolves.toBe(false);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  describe('getUserAllowedCourseIds', () => {
+    describe('without a year (intersection path)', () => {
+      it('returns the intersection of requested ids and the student courses', async () => {
+        const user = makeUser({
+          appRoles: [Role.User],
+          courses: { 1: { roles: [] }, 2: { roles: [] }, 3: { roles: [] } },
+        });
+
+        const result = await service.getUserAllowedCourseIds(user, [2, 3, 4], 0);
+
+        expect(result).toEqual([2, 3]);
+        expect(courseRepository.find).not.toHaveBeenCalled();
+      });
+
+      it('returns an empty array when there is no overlap', async () => {
+        const user = makeUser({ appRoles: [Role.User], courses: { 1: { roles: [] } } });
+
+        const result = await service.getUserAllowedCourseIds(user, [2, 3], 0);
+
+        expect(result).toEqual([]);
+      });
+
+      it('for an admin intersects the requested ids with themselves (admin path)', async () => {
+        const user = makeUser({ appRoles: [Role.Admin], courses: {} });
+
+        const result = await service.getUserAllowedCourseIds(user, [2, 3, 4], 0);
+
+        // admin userCourses == ids, so the intersection is the full list
+        expect(result).toEqual([2, 3, 4]);
+      });
+
+      it('defaults ids to an empty array when omitted, returning an empty intersection', async () => {
+        const user = makeUser({ appRoles: [Role.User], courses: { 1: { roles: [] } } });
+
+        const result = await service.getUserAllowedCourseIds(user, undefined, 0);
+
+        expect(result).toEqual([]);
+        expect(courseRepository.find).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with a year (repository path)', () => {
+      it('for a non-admin queries by date range AND restricts to the user enrolled courses', async () => {
+        const user = makeUser({
+          appRoles: [Role.User],
+          courses: { 10: { roles: [] }, 20: { roles: [] } },
+        });
+        courseRepository.find.mockResolvedValue([{ id: 10 }, { id: 20 }]);
+
+        const result = await service.getUserAllowedCourseIds(user, [], 2024);
+
+        expect(result).toEqual([10, 20]);
+        expect(courseRepository.find).toHaveBeenCalledWith({
+          where: {
+            startDate: Between(new Date('2024'), new Date('2025')),
+            id: In([10, 20]),
+          },
+          select: ['id'],
+        });
+      });
+
+      it('for an admin queries only by the date range without an id restriction', async () => {
+        const user = makeUser({ appRoles: [Role.Admin], courses: {} });
+        courseRepository.find.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+        const result = await service.getUserAllowedCourseIds(user, [], 2024);
+
+        expect(result).toEqual([1, 2, 3]);
+        // condition must NOT contain an `id` key for admins
+        expect(courseRepository.find).toHaveBeenCalledWith({
+          where: {
+            startDate: Between(new Date('2024'), new Date('2025')),
+          },
+          select: ['id'],
+        });
+        const [[arg]] = courseRepository.find.mock.calls;
+        expect(arg.where).not.toHaveProperty('id');
+      });
+
+      it('builds the date range from year (start) to year+1 (end)', async () => {
+        const user = makeUser({ appRoles: [Role.Admin], courses: {} });
+        courseRepository.find.mockResolvedValue([]);
+
+        await service.getUserAllowedCourseIds(user, [], 2030);
+
+        const [[arg]] = courseRepository.find.mock.calls;
+        // Between encodes the boundaries as _value: [start, end]
+        const range = arg.where.startDate as { _value: [Date, Date] };
+        expect(range._value[0]).toEqual(new Date('2030'));
+        expect(range._value[1]).toEqual(new Date('2031'));
+      });
+
+      it('returns an empty array when the repository finds no matching courses', async () => {
+        const user = makeUser({ appRoles: [Role.Admin], courses: {} });
+        courseRepository.find.mockResolvedValue([]);
+
+        const result = await service.getUserAllowedCourseIds(user, [], 2024);
+
+        expect(result).toEqual([]);
+      });
+
+      it('maps the result rows down to their ids', async () => {
+        const user = makeUser({ appRoles: [Role.Admin], courses: {} });
+        courseRepository.find.mockResolvedValue([{ id: 42, name: 'ignored' }]);
+
+        const result = await service.getUserAllowedCourseIds(user, [], 2024);
+
+        expect(result).toEqual([42]);
+      });
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  describe('canAccessCourseAsManager', () => {
+    it('returns true when the user has the Manager role for the course', () => {
+      const user = makeUser({
+        isAdmin: false,
+        courses: { 77: { roles: [CourseRole.Manager] } },
+      });
+
+      expect(service.canAccessCourseAsManager(user, 77)).toBe(true);
+    });
+
+    it('returns true for an admin even without the Manager role', () => {
+      const user = makeUser({
+        isAdmin: true,
+        courses: { 77: { roles: [CourseRole.Student] } },
+      });
+
+      expect(service.canAccessCourseAsManager(user, 77)).toBe(true);
+    });
+
+    it('returns false when the user is enrolled but is neither a manager nor an admin', () => {
+      const user = makeUser({
+        isAdmin: false,
+        courses: { 77: { roles: [CourseRole.Student] } },
+      });
+
+      expect(service.canAccessCourseAsManager(user, 77)).toBe(false);
+    });
+
+    it('returns false (undefined coalesces to isAdmin) when the user is not enrolled and not admin', () => {
+      const user = makeUser({ isAdmin: false, courses: {} });
+
+      // courses[courseId]?.roles -> undefined, `undefined || false` -> false
+      expect(service.canAccessCourseAsManager(user, 77)).toBe(false);
+    });
+
+    it('returns true when the user is not enrolled but is an admin', () => {
+      const user = makeUser({ isAdmin: true, courses: {} });
+
+      expect(service.canAccessCourseAsManager(user, 77)).toBe(true);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  describe('leaveAsStudent', () => {
+    it('expels the student, records the self-expel reason and submits the leave survey', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...mockStudent });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await service.leaveAsStudent(77, 101, mockLeaveDto);
+
+      expect(studentRepository.findOneByOrFail).toHaveBeenCalledWith({ id: 101 });
+      expect(courseRepository.findOneByOrFail).toHaveBeenCalledWith({ id: 77 });
+      expect(studentRepository.update).toHaveBeenCalledWith(
+        101,
+        expect.objectContaining({
+          mentorId: null,
+          isExpelled: true,
+          expellingReason: `${SELF_EXPELLED_MARK}. bye`,
+          endDate: expect.any(Date),
+        }),
+      );
+      expect(expelledStatsService.submitLeaveSurvey).toHaveBeenCalledWith(5005, 77, ['too hard'], 'bye');
+    });
+
+    it('falls back to an empty comment in the reason when otherComment is missing', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...mockStudent });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await service.leaveAsStudent(77, 101, { reasonForLeaving: ['x'] } as LeaveCourseRequestDto);
+
+      expect(studentRepository.update).toHaveBeenCalledWith(
+        101,
+        expect.objectContaining({ expellingReason: `${SELF_EXPELLED_MARK}. ` }),
+      );
+    });
+
+    it('throws BadRequestException when the course is already completed', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...mockStudent });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse, completed: true });
+
+      await expect(service.leaveAsStudent(77, 101, mockLeaveDto)).rejects.toThrow(
+        new BadRequestException('Course is already completed'),
+      );
+      expect(studentRepository.update).not.toHaveBeenCalled();
+      expect(expelledStatsService.submitLeaveSurvey).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the student is already expelled', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...mockStudent, isExpelled: true });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await expect(service.leaveAsStudent(77, 101, mockLeaveDto)).rejects.toThrow(
+        new BadRequestException('Student is not active'),
+      );
+      expect(studentRepository.update).not.toHaveBeenCalled();
+      expect(expelledStatsService.submitLeaveSurvey).not.toHaveBeenCalled();
+    });
+
+    it('propagates the rejection when the student is not found', async () => {
+      const err = new Error('student not found');
+      studentRepository.findOneByOrFail.mockRejectedValue(err);
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await expect(service.leaveAsStudent(77, 101, mockLeaveDto)).rejects.toThrow(err);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  describe('rejoinAsStudent', () => {
+    const selfExpelledStudent = {
+      ...mockStudent,
+      isExpelled: true,
+      expellingReason: `${SELF_EXPELLED_MARK}. changed my mind`,
+    } as Partial<Student> as Student;
+
+    it('re-joins a self-expelled student and resets the expel fields', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...selfExpelledStudent });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await service.rejoinAsStudent(77, 101);
+
+      expect(studentRepository.findOneByOrFail).toHaveBeenCalledWith({ id: 101 });
+      expect(courseRepository.findOneByOrFail).toHaveBeenCalledWith({ id: 77 });
+      expect(studentRepository.update).toHaveBeenCalledWith(101, {
+        isExpelled: false,
+        expellingReason: 'Re-joined course',
+        endDate: null,
+      });
+    });
+
+    it('throws BadRequestException when the course is already completed', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...selfExpelledStudent });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse, completed: true });
+
+      await expect(service.rejoinAsStudent(77, 101)).rejects.toThrow(
+        new BadRequestException('Course is already completed'),
+      );
+      expect(studentRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the student is still active (not expelled)', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...selfExpelledStudent, isExpelled: false });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await expect(service.rejoinAsStudent(77, 101)).rejects.toThrow(new BadRequestException('Student is active'));
+      expect(studentRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the student was expelled by someone else (not self)', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({
+        ...selfExpelledStudent,
+        expellingReason: 'Expelled by mentor for inactivity',
+      });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await expect(service.rejoinAsStudent(77, 101)).rejects.toThrow(
+        new BadRequestException('Student is not expelled by self'),
+      );
+      expect(studentRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the expelling reason is null', async () => {
+      studentRepository.findOneByOrFail.mockResolvedValue({
+        ...selfExpelledStudent,
+        expellingReason: null,
+      });
+      courseRepository.findOneByOrFail.mockResolvedValue({ ...mockCourse });
+
+      await expect(service.rejoinAsStudent(77, 101)).rejects.toThrow(
+        new BadRequestException('Student is not expelled by self'),
+      );
+      expect(studentRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('propagates the rejection when the course is not found', async () => {
+      const err = new Error('course not found');
+      studentRepository.findOneByOrFail.mockResolvedValue({ ...selfExpelledStudent });
+      courseRepository.findOneByOrFail.mockRejectedValue(err);
+
+      await expect(service.rejoinAsStudent(77, 101)).rejects.toThrow(err);
+    });
+  });
+});

--- a/nestjs/src/courses/cross-checks/cross-check-feedback.guard.spec.ts
+++ b/nestjs/src/courses/cross-checks/cross-check-feedback.guard.spec.ts
@@ -1,0 +1,160 @@
+import { ExecutionContext, BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Mocked } from 'vitest';
+import { FeedbackGuard } from './cross-check-feedback.guard';
+import { CourseCrossCheckService } from './course-cross-checks.service';
+import { CourseTasksService } from '../course-tasks';
+import { CourseRole } from '@entities/session';
+
+type GuardUser = {
+  isAdmin?: boolean;
+  courses: Record<number, { studentId?: number; roles: CourseRole[] }>;
+};
+
+const createContext = (user: Partial<GuardUser>, params: Record<string, unknown> = {}): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ user, params }),
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('FeedbackGuard', () => {
+  let guard: FeedbackGuard;
+  let courseCrossCheckService: Mocked<CourseCrossCheckService>;
+  let courseTasksService: Mocked<CourseTasksService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeedbackGuard,
+        {
+          provide: CourseCrossCheckService,
+          useValue: {
+            isCrossCheckTask: vi.fn(),
+          },
+        },
+        {
+          provide: CourseTasksService,
+          useValue: {
+            getById: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<FeedbackGuard>(FeedbackGuard);
+    courseCrossCheckService = module.get(CourseCrossCheckService);
+    courseTasksService = module.get(CourseTasksService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('student vs manager authorization', () => {
+    // The authorization check runs synchronously before the async validateTask call,
+    // so the guard throws synchronously here rather than returning a rejected promise.
+    it('throws UnauthorizedException when the user is neither a student nor a manager', () => {
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Mentor] } } },
+        { courseId: '5', courseTaskId: '10' },
+      );
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow('Not a valid student for this course');
+      expect(courseTasksService.getById).not.toHaveBeenCalled();
+    });
+
+    it('throws UnauthorizedException when the course entry is missing entirely (optional chaining yields undefined)', () => {
+      const context = createContext({ isAdmin: false, courses: {} }, { courseId: '5', courseTaskId: '10' });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    });
+
+    it('proceeds when the user has a studentId for the course (student branch)', async () => {
+      courseTasksService.getById.mockResolvedValue({ checker: 'crossCheck' } as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(true);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { studentId: 42, roles: [CourseRole.Student] } } },
+        { courseId: '5', courseTaskId: '10' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(courseTasksService.getById).toHaveBeenCalledWith('10');
+    });
+
+    it('proceeds when the user is an admin even without a studentId (isAdmin branch)', async () => {
+      courseTasksService.getById.mockResolvedValue({ checker: 'crossCheck' } as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(true);
+
+      const context = createContext(
+        { isAdmin: true, courses: { 5: { roles: [] } } },
+        { courseId: '5', courseTaskId: '10' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    });
+
+    it('proceeds when the user has the Manager role for the course (manager branch)', async () => {
+      courseTasksService.getById.mockResolvedValue({ checker: 'crossCheck' } as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(true);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Manager] } } },
+        { courseId: '5', courseTaskId: '10' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    });
+
+    it('proceeds when the user has both a studentId and is a manager', async () => {
+      courseTasksService.getById.mockResolvedValue({ checker: 'crossCheck' } as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(true);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { studentId: 7, roles: [CourseRole.Manager] } } },
+        { courseId: '5', courseTaskId: '10' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    });
+  });
+
+  describe('validateTask', () => {
+    const allowedContext = createContext({ isAdmin: true, courses: {} }, { courseId: '5', courseTaskId: '10' });
+
+    it('throws BadRequestException when the course task is not found (null)', async () => {
+      courseTasksService.getById.mockResolvedValue(null as never);
+
+      await expect(guard.canActivate(allowedContext)).rejects.toBeInstanceOf(BadRequestException);
+      await expect(guard.canActivate(allowedContext)).rejects.toThrow('not valid student or course task');
+      expect(courseCrossCheckService.isCrossCheckTask).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException with the not-supported message when the task is not a cross-check task', async () => {
+      courseTasksService.getById.mockResolvedValue({ checker: 'auto-test' } as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(false);
+
+      await expect(guard.canActivate(allowedContext)).rejects.toBeInstanceOf(BadRequestException);
+      await expect(guard.canActivate(allowedContext)).rejects.toThrow('not supported task');
+    });
+
+    it('returns true when the task is found and is a cross-check task', async () => {
+      const courseTask = { checker: 'crossCheck' };
+      courseTasksService.getById.mockResolvedValue(courseTask as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(true);
+
+      await expect(guard.canActivate(allowedContext)).resolves.toBe(true);
+      expect(courseCrossCheckService.isCrossCheckTask).toHaveBeenCalledWith(courseTask);
+    });
+
+    it('is callable directly and resolves to true for a valid cross-check task', async () => {
+      courseTasksService.getById.mockResolvedValue({ checker: 'crossCheck' } as never);
+      courseCrossCheckService.isCrossCheckTask.mockReturnValue(true);
+
+      await expect(guard.validateTask(10)).resolves.toBe(true);
+      expect(courseTasksService.getById).toHaveBeenCalledWith(10);
+    });
+  });
+});

--- a/nestjs/src/courses/team-distribution/registered-student-guard.spec.ts
+++ b/nestjs/src/courses/team-distribution/registered-student-guard.spec.ts
@@ -1,0 +1,159 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Mocked } from 'vitest';
+import { RegisteredStudentOrPowerUserGuard } from './registered-student-guard';
+import { TeamDistributionStudentService } from './team-distribution-student.service';
+import { CourseRole } from '@entities/session';
+
+type GuardUser = {
+  isAdmin?: boolean;
+  courses: Record<number, { studentId?: number; roles: CourseRole[] }>;
+};
+
+const createContext = (user: Partial<GuardUser>, params: Record<string, unknown> = {}): ExecutionContext =>
+  ({
+    getArgs: () => [{ user, params }],
+  }) as unknown as ExecutionContext;
+
+describe('RegisteredStudentOrPowerUserGuard', () => {
+  let guard: RegisteredStudentOrPowerUserGuard;
+  let teamDistributionStudentService: Mocked<TeamDistributionStudentService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegisteredStudentOrPowerUserGuard,
+        {
+          provide: TeamDistributionStudentService,
+          useValue: {
+            getTeamDistributionStudent: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<RegisteredStudentOrPowerUserGuard>(RegisteredStudentOrPowerUserGuard);
+    teamDistributionStudentService = module.get(TeamDistributionStudentService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('power-user bypass', () => {
+    it('returns true for an admin without a registration lookup (isAdmin short-circuit)', async () => {
+      const context = createContext({ isAdmin: true, courses: {} }, { courseId: '5', id: '3' });
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(teamDistributionStudentService.getTeamDistributionStudent).not.toHaveBeenCalled();
+    });
+
+    it('returns true for a course Manager (second clause of the || chain)', async () => {
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Manager] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(teamDistributionStudentService.getTeamDistributionStudent).not.toHaveBeenCalled();
+    });
+
+    it('returns true for a course Dementor (third clause of the || chain)', async () => {
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Dementor] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(teamDistributionStudentService.getTeamDistributionStudent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('courseId / studentId validation', () => {
+    it('throws UnauthorizedException when courseId is missing (NaN -> falsy)', async () => {
+      const context = createContext({ isAdmin: false, courses: {} }, { id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(teamDistributionStudentService.getTeamDistributionStudent).not.toHaveBeenCalled();
+    });
+
+    it('throws UnauthorizedException when courseId resolves to 0 (falsy)', async () => {
+      const context = createContext({ isAdmin: false, courses: {} }, { courseId: '0', id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when the user has a course entry but no studentId', async () => {
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Student] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(teamDistributionStudentService.getTeamDistributionStudent).not.toHaveBeenCalled();
+    });
+
+    it('throws UnauthorizedException when the course entry is missing so studentId is undefined', async () => {
+      const context = createContext({ isAdmin: false, courses: {} }, { courseId: '5', id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe('registration status', () => {
+    const studentContext = createContext(
+      { isAdmin: false, courses: { 5: { studentId: 42, roles: [CourseRole.Student] } } },
+      { courseId: '5', id: '3' },
+    );
+
+    it('returns true when the registration is active (active && not distributed)', async () => {
+      teamDistributionStudentService.getTeamDistributionStudent.mockResolvedValue({
+        active: true,
+        distributed: false,
+      } as never);
+
+      await expect(guard.canActivate(studentContext)).resolves.toBe(true);
+      expect(teamDistributionStudentService.getTeamDistributionStudent).toHaveBeenCalledWith(42, 3);
+    });
+
+    it('returns true when the registration is distributed but not active', async () => {
+      teamDistributionStudentService.getTeamDistributionStudent.mockResolvedValue({
+        active: false,
+        distributed: true,
+      } as never);
+
+      await expect(guard.canActivate(studentContext)).resolves.toBe(true);
+    });
+
+    it('returns true when the registration is both active and distributed', async () => {
+      teamDistributionStudentService.getTeamDistributionStudent.mockResolvedValue({
+        active: true,
+        distributed: true,
+      } as never);
+
+      await expect(guard.canActivate(studentContext)).resolves.toBe(true);
+    });
+
+    it('throws UnauthorizedException when the registration is neither active nor distributed', async () => {
+      teamDistributionStudentService.getTeamDistributionStudent.mockResolvedValue({
+        active: false,
+        distributed: false,
+      } as never);
+
+      await expect(guard.canActivate(studentContext)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when the registration is nullish (optional chaining yields undefined)', async () => {
+      teamDistributionStudentService.getTeamDistributionStudent.mockResolvedValue(null as never);
+
+      await expect(guard.canActivate(studentContext)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('propagates the rejection when the registration lookup fails', async () => {
+      const lookupError = new Error('not found');
+      teamDistributionStudentService.getTeamDistributionStudent.mockRejectedValue(lookupError);
+
+      await expect(guard.canActivate(studentContext)).rejects.toBe(lookupError);
+    });
+  });
+});

--- a/nestjs/src/courses/team-distribution/team-lead-or-manager.guard.spec.ts
+++ b/nestjs/src/courses/team-distribution/team-lead-or-manager.guard.spec.ts
@@ -1,0 +1,144 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Mocked } from 'vitest';
+import { TeamLeadOrCourseManagerGuard } from './team-lead-or-manager.guard';
+import { TeamService } from './team.service';
+import { CourseRole } from '@entities/session';
+
+type GuardUser = {
+  isAdmin?: boolean;
+  courses: Record<number, { studentId?: number; roles: CourseRole[] }>;
+};
+
+const createContext = (user: Partial<GuardUser>, params: Record<string, unknown> = {}): ExecutionContext =>
+  ({
+    getArgs: () => [{ user, params }],
+  }) as unknown as ExecutionContext;
+
+describe('TeamLeadOrCourseManagerGuard', () => {
+  let guard: TeamLeadOrCourseManagerGuard;
+  let teamService: Mocked<TeamService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TeamLeadOrCourseManagerGuard,
+        {
+          provide: TeamService,
+          useValue: {
+            findById: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<TeamLeadOrCourseManagerGuard>(TeamLeadOrCourseManagerGuard);
+    teamService = module.get(TeamService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('courseId validation', () => {
+    it('throws UnauthorizedException when courseId is missing (NaN -> falsy)', async () => {
+      const context = createContext({ isAdmin: true, courses: {} }, { id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(teamService.findById).not.toHaveBeenCalled();
+    });
+
+    it('throws UnauthorizedException when courseId resolves to 0 (falsy)', async () => {
+      const context = createContext({ isAdmin: true, courses: {} }, { courseId: '0', id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when courseId is non-numeric (NaN)', async () => {
+      const context = createContext({ isAdmin: true, courses: {} }, { courseId: 'abc', id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe('manager bypass', () => {
+    it('returns true for an admin (isAdmin short-circuit) without a team lookup', async () => {
+      const context = createContext({ isAdmin: true, courses: {} }, { courseId: '5', id: '3' });
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(teamService.findById).not.toHaveBeenCalled();
+    });
+
+    it('returns true for a course Manager without a team lookup', async () => {
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Manager] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(teamService.findById).not.toHaveBeenCalled();
+    });
+
+    it('returns true when the course entry is present but isAdmin handles the missing-roles short-circuit', async () => {
+      const context = createContext({ isAdmin: true, courses: {} }, { courseId: '5', id: '3' });
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    });
+  });
+
+  describe('team lead path', () => {
+    it('returns true when the user is the team lead (teamLeadId === studentId)', async () => {
+      teamService.findById.mockResolvedValue({ teamLeadId: 42 } as never);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { studentId: 42, roles: [CourseRole.Student] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(teamService.findById).toHaveBeenCalledWith(3);
+    });
+
+    it('throws UnauthorizedException when the user is not the team lead', async () => {
+      teamService.findById.mockResolvedValue({ teamLeadId: 99 } as never);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { studentId: 42, roles: [CourseRole.Student] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when the user has no studentId for the course (undefined !== teamLeadId)', async () => {
+      teamService.findById.mockResolvedValue({ teamLeadId: 42 } as never);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { roles: [CourseRole.Student] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when the course entry is missing so studentId is undefined', async () => {
+      teamService.findById.mockResolvedValue({ teamLeadId: 42 } as never);
+
+      const context = createContext({ isAdmin: false, courses: {} }, { courseId: '5', id: '3' });
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('propagates the rejection when findById fails (team not found)', async () => {
+      const notFound = new Error('team not found');
+      teamService.findById.mockRejectedValue(notFound);
+
+      const context = createContext(
+        { isAdmin: false, courses: { 5: { studentId: 42, roles: [CourseRole.Student] } } },
+        { courseId: '5', id: '3' },
+      );
+
+      await expect(guard.canActivate(context)).rejects.toBe(notFound);
+    });
+  });
+});

--- a/nestjs/src/profile/profile-info/permissions.spec.ts
+++ b/nestjs/src/profile/profile-info/permissions.spec.ts
@@ -1,6 +1,6 @@
 import { CourseRole, IUserSession } from '@entities/session';
 // Mirrored from server/src/routes/profile/__test__/permissions.test.ts to prove business-logic equivalence
-import { getPermissions, defineRole, getProfilePermissionsSettings } from './permissions';
+import { getPermissions, defineRole, getProfilePermissionsSettings, getFullName } from './permissions';
 
 const mockSession = {
   id: 1,
@@ -233,6 +233,38 @@ describe('getPermissions', () => {
           isExpellingReasonVisible: true,
         });
       });
+      it('"role" is "coursesupervisor" makes profile and contacts visible (no "permissions" passed)', () => {
+        // Covers the `role === 'coursesupervisor' && permission === 'isProfileVisible'` branch
+        // in getPermissions plus the coursesupervisor branch of accessToContacts.
+        expect(
+          getPermissions({
+            isProfileOwner: false,
+            isAdmin: false,
+            role: 'coursesupervisor',
+          }),
+        ).toEqual({
+          isProfileVisible: true,
+          isAboutVisible: false,
+          isEducationVisible: false,
+          isEnglishVisible: true,
+          isEmailVisible: true,
+          isTelegramVisible: true,
+          isWhatsAppVisible: true,
+          isSkypeVisible: true,
+          isPhoneVisible: true,
+          // NOTE: stays false because accessToContacts checks the typo'd key
+          // 'isContactsNodesVisible' (should be 'isContactsNotesVisible').
+          isContactsNotesVisible: false,
+          isLinkedInVisible: false,
+          isPublicFeedbackVisible: false,
+          isMentorStatsVisible: false,
+          isStudentStatsVisible: false,
+          isStageInterviewFeedbackVisible: false,
+          isCoreJsFeedbackVisible: false,
+          isConsentsVisible: false,
+          isExpellingReasonVisible: false,
+        });
+      });
     });
     describe('if "isProfileOwner" is "true"', () => {
       it('"role" is "all" and all "permissions" set with "all" = "false"', () => {
@@ -397,6 +429,64 @@ describe('defineRole', () => {
         }),
       ).toBe('coursemanager');
     });
+    it('"coursesupervisor", if user is a supervisor on a registry course', () => {
+      expect(
+        defineRole({
+          relationsRoles: null,
+          registryCourses: [{ courseId: 1 }],
+          studentCourses: null,
+          session: {
+            courses: { 1: { roles: [CourseRole.Supervisor] } },
+          } as unknown as IUserSession,
+          userGithubId: 'denis',
+        }),
+      ).toBe('coursesupervisor');
+    });
+    it('"coursemanager", if user is a manager on a student course', () => {
+      expect(
+        defineRole({
+          relationsRoles: null,
+          registryCourses: null,
+          studentCourses: [{ courseId: 1 }],
+          session: {
+            courses: { 1: { roles: [CourseRole.Manager] } },
+          } as unknown as IUserSession,
+          userGithubId: 'denis',
+        }),
+      ).toBe('coursemanager');
+    });
+    it('"coursemanager", if user is a supervisor on a student course', () => {
+      // NOTE: the supervisor-on-student-course branch returns 'coursemanager', not 'coursesupervisor'.
+      expect(
+        defineRole({
+          relationsRoles: null,
+          registryCourses: null,
+          studentCourses: [{ courseId: 1 }],
+          session: {
+            courses: { 1: { roles: [CourseRole.Supervisor] } },
+          } as unknown as IUserSession,
+          userGithubId: 'denis',
+        }),
+      ).toBe('coursemanager');
+    });
+    it('"all", if user has relations but is neither the student nor any kind of mentor', () => {
+      // Covers the false branch of the mentor-set membership check in defineRole.
+      expect(
+        defineRole({
+          relationsRoles: {
+            student: 'dima',
+            mentors: ['andrey', 'dasha'],
+            interviewers: ['sasha', 'max'],
+            stageInterviewers: ['alex'],
+            checkers: ['masha', 'ivan'],
+          },
+          registryCourses: null,
+          studentCourses: null,
+          session: mockSession,
+          userGithubId: 'stranger',
+        }),
+      ).toBe('all');
+    });
     it('"all", if user is not a mentor at the same course where requested user is a student', () => {
       expect(
         defineRole({
@@ -460,5 +550,28 @@ describe('getProfilePermissionsSettings', () => {
       isMentorStatsVisible: { all: false, mentor: false, student: false },
       isStudentStatsVisible: { all: false, student: false },
     });
+  });
+});
+
+describe('getFullName', () => {
+  it('Should be an instance of Function', () => {
+    expect(getFullName).toBeInstanceOf(Function);
+  });
+
+  it('joins first and last name with a space', () => {
+    expect(getFullName('John', 'Doe', 'githubId')).toBe('John Doe');
+  });
+
+  it('omits an empty last name', () => {
+    expect(getFullName('John', '', 'githubId')).toBe('John');
+  });
+
+  it('omits an empty first name', () => {
+    expect(getFullName('', 'Doe', 'githubId')).toBe('Doe');
+  });
+
+  it('falls back to githubId when both names are empty', () => {
+    // Covers the `|| githubId` fallback branch.
+    expect(getFullName('', '', 'githubId')).toBe('githubId');
   });
 });

--- a/nestjs/vitest.config.mts
+++ b/nestjs/vitest.config.mts
@@ -48,10 +48,10 @@ export default mergeConfig(
         // baseline so this config-only change passes, then bumps up as each
         // unit-test tier lands so coverage can only move up, never regress.
         thresholds: {
-          statements: 34,
-          branches: 32,
-          functions: 27,
-          lines: 34,
+          statements: 37,
+          branches: 35,
+          functions: 29,
+          lines: 37,
         },
       },
       deps: {


### PR DESCRIPTION
## What & why

**Phase 2 of 4** of the nestjs coverage initiative. This tier covers the highest-risk, mostly-pure surface first — authorization, authentication and core infrastructure — where a regression is most dangerous and the code is cheapest to test exhaustively.

> Stacked on #3070 (base branch `alreadybored/nestjs-coverage-config`). Review/merge that first; GitHub will retarget this to `master` once it lands.

## Changes
New/extended co-located specs (no source changes — behavior asserted as-is):
- **Auth**: `RoleGuard` & `CourseGuard` (every app/course-role + `requireCourseMatch` combination), JWT/GitHub/Basic/Dev passport strategies, `AuthService` (full surface incl. login-state, cookies, `getAuthDetails`), the `AuthUser` model role aggregation, and the auth controller.
- **Core**: `JwtService`, `paginate`, exception filters (`entity-not-found`, `sentry`), `validation` filter, logger/no-cache middlewares, TypeORM subscribers, the `student-id` decorator, pino config, and handlebars templates.
- **Permissions/authorization**: the profile permission matrix (`permissions.ts` → ~100%), `CourseAccessService`, the cross-check feedback guard, and the team-distribution guards.

Conventions: `Test.createTestingModule().compile()`, `vi.fn()` mocks, `getRepositoryToken`, `Mocked<T>`, AAA, module-scope fixtures.

## Verification
- ✅ `npm run test:cov` (nestjs) green; coverage rises to ~38.6% stmts / 37% branch / 31% funcs / 39% lines.
- ✅ Floor ratcheted to 37/35/29/37.
- ✅ eslint + oxfmt clean. The targeted files are at ~100%.

## Result
The auth/permissions/core layer is comprehensively covered. Tier 2 (business services) follows.

Phase 2 of 4 — nestjs unit-test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)