### PR TITLE
test(nestjs): unit tests for remaining modules + 90% coverage floor (tier 3)

### DIFF
--- a/nestjs/src/activity/activity.controller.spec.ts
+++ b/nestjs/src/activity/activity.controller.spec.ts
@@ -1,0 +1,157 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as crypto from 'crypto';
+import type { Request } from 'express';
+import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { User } from '@entities/user';
+import { CurrentRequest } from 'src/auth';
+import { UsersService } from 'src/users/users.service';
+import { ConfigService } from 'src/config';
+import { ActivityController } from './activity.controller';
+import { CreateActivityDto } from './dto/create-activity.dto';
+import { CreateActivityWebhookDto } from './dto/create-activity-webhook.dto';
+
+const WEBHOOK_SECRET = 'activity-webhook';
+
+const mockUser = {
+  id: 42,
+  githubId: 'john-doe',
+  lastActivityTime: 1700000000000,
+  isActive: true,
+} as Partial<User> as User;
+
+const sign = (body: unknown) => {
+  const selfSignature = crypto.createHmac('sha1', WEBHOOK_SECRET).update(JSON.stringify(body)).digest('hex');
+  return `sha1=${selfSignature}`;
+};
+
+describe('ActivityController', () => {
+  let controller: ActivityController;
+  let userService: Mocked<UsersService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ActivityController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: {
+            getUserByUserId: vi.fn(),
+            getByGithubId: vi.fn(),
+            updateUser: vi.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            auth: { github: { activityWebhookSecret: WEBHOOK_SECRET } },
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ActivityController>(ActivityController);
+    userService = module.get(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getActivity', () => {
+    it('returns the activity flags of the current user', async () => {
+      userService.getUserByUserId.mockResolvedValue(mockUser);
+      const req = { user: { id: 42 } } as CurrentRequest;
+
+      const result = await controller.getActivity(req);
+
+      expect(userService.getUserByUserId).toHaveBeenCalledWith(42);
+      expect(result).toEqual({ isActive: true, lastActivityTime: 1700000000000 });
+    });
+  });
+
+  describe('createActivity', () => {
+    it('updates the user activity and returns the new state', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1234567890);
+      userService.getUserByUserId.mockResolvedValue(mockUser);
+      userService.updateUser.mockResolvedValue();
+      const req = { user: { id: 42 } } as CurrentRequest;
+      const body: CreateActivityDto = { isActive: false };
+
+      const result = await controller.createActivity(body, req);
+
+      expect(userService.getUserByUserId).toHaveBeenCalledWith(42);
+      expect(userService.updateUser).toHaveBeenCalledWith(42, {
+        lastActivityTime: 1234567890,
+        isActive: false,
+      });
+      expect(result).toEqual({ isActive: false, lastActivityTime: 1234567890 });
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe('createActivityWebhook', () => {
+    const buildReq = (signature?: string) =>
+      ({ headers: signature ? { 'x-hub-signature': signature } : {} }) as unknown as Request;
+
+    it('throws Unauthorized when the signature header is missing', async () => {
+      const body = { sender: { login: { githubId: 'john-doe' } } } as CreateActivityWebhookDto;
+
+      await expect(controller.createActivityWebhook(body, buildReq())).rejects.toThrow(UnauthorizedException);
+      await expect(controller.createActivityWebhook(body, buildReq())).rejects.toThrow('x-hub-signature is missing');
+    });
+
+    it('throws Unauthorized when the signature does not match', async () => {
+      const body = { sender: { login: { githubId: 'john-doe' } } } as CreateActivityWebhookDto;
+      const wrongSignature = sign({ sender: { login: { githubId: 'someone-else' } } });
+
+      await expect(controller.createActivityWebhook(body, buildReq(wrongSignature))).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(controller.createActivityWebhook(body, buildReq(wrongSignature))).rejects.toThrow(
+        "Signatures didn't match",
+      );
+    });
+
+    it('throws BadRequest when sender is missing', async () => {
+      const body = {} as CreateActivityWebhookDto;
+
+      await expect(controller.createActivityWebhook(body, buildReq(sign(body)))).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequest when sender.login is missing', async () => {
+      const body = { sender: {} } as CreateActivityWebhookDto;
+
+      await expect(controller.createActivityWebhook(body, buildReq(sign(body)))).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFound when the user does not exist', async () => {
+      const body = { sender: { login: { githubId: 'ghost' } } } as CreateActivityWebhookDto;
+      userService.getByGithubId.mockResolvedValue(null);
+
+      await expect(controller.createActivityWebhook(body, buildReq(sign(body)))).rejects.toThrow(NotFoundException);
+      await expect(controller.createActivityWebhook(body, buildReq(sign(body)))).rejects.toThrow(
+        'User with GitHub id ghost not found',
+      );
+    });
+
+    it('updates activity and returns the new state for a valid signed payload', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1234567890);
+      const body = { sender: { login: { githubId: 'john-doe' } } } as CreateActivityWebhookDto;
+      userService.getByGithubId.mockResolvedValue(mockUser);
+      userService.updateUser.mockResolvedValue();
+
+      const result = await controller.createActivityWebhook(body, buildReq(sign(body)));
+
+      expect(userService.getByGithubId).toHaveBeenCalledWith('john-doe');
+      expect(userService.updateUser).toHaveBeenCalledWith(42, {
+        lastActivityTime: 1234567890,
+        isActive: true,
+      });
+      expect(result).toEqual({ isActive: true, lastActivityTime: 1234567890 });
+
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/nestjs/src/alerts/alerts.controller.spec.ts
+++ b/nestjs/src/alerts/alerts.controller.spec.ts
@@ -1,0 +1,112 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Alert } from '@entities/alert';
+import { AlertsController } from './alerts.controller';
+import { AlertsService } from './alerts.service';
+import { AlertDto, CreateAlertDto, UpdateAlertDto } from './dto';
+
+const mockAlert = {
+  id: 1,
+  type: 'warning',
+  text: 'Maintenance window tonight',
+  enabled: true,
+  courseId: 5,
+  createdDate: '2026-01-01T00:00:00.000Z',
+  updatedDate: '2026-01-02T00:00:00.000Z',
+} as Partial<Alert> as Alert;
+
+describe('AlertsController', () => {
+  let controller: AlertsController;
+  let service: Mocked<AlertsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AlertsController],
+      providers: [
+        {
+          provide: AlertsService,
+          useValue: {
+            create: vi.fn(),
+            findAll: vi.fn(),
+            update: vi.fn(),
+            remove: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AlertsController>(AlertsController);
+    service = module.get(AlertsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('delegates to the service and wraps the result in an AlertDto', async () => {
+      const dto: CreateAlertDto = { type: 'warning', text: 'Maintenance window tonight', enabled: true, courseId: 5 };
+      service.create.mockResolvedValue(mockAlert);
+
+      const result = await controller.create(dto);
+
+      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(result).toBeInstanceOf(AlertDto);
+      expect(result).toEqual({
+        id: 1,
+        type: 'warning',
+        text: 'Maintenance window tonight',
+        enabled: true,
+        courseId: 5,
+        createdDate: '2026-01-01T00:00:00.000Z',
+        updatedDate: '2026-01-02T00:00:00.000Z',
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    it('requests alerts for the given enabled flag and maps them to DTOs', async () => {
+      service.findAll.mockResolvedValue([mockAlert]);
+
+      const result = await controller.getAll(true);
+
+      expect(service.findAll).toHaveBeenCalledWith({ enabled: true });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(AlertDto);
+      expect(result[0].id).toBe(1);
+    });
+
+    it('forwards a false enabled flag and returns an empty list', async () => {
+      service.findAll.mockResolvedValue([]);
+
+      const result = await controller.getAll(false);
+
+      expect(service.findAll).toHaveBeenCalledWith({ enabled: false });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates removal to the service', async () => {
+      service.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove(1);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('delegates the update and wraps the result in an AlertDto', async () => {
+      const dto: UpdateAlertDto = { text: 'Updated' };
+      service.update.mockResolvedValue(mockAlert);
+
+      const result = await controller.update(1, dto);
+
+      expect(service.update).toHaveBeenCalledWith(1, dto);
+      expect(result).toBeInstanceOf(AlertDto);
+      expect(result.id).toBe(1);
+    });
+  });
+});

--- a/nestjs/src/alerts/alerts.service.spec.ts
+++ b/nestjs/src/alerts/alerts.service.spec.ts
@@ -1,0 +1,172 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Alert } from '@entities/alert';
+import { AlertsService } from './alerts.service';
+import { CreateAlertDto } from './dto/create-alert.dto';
+import { UpdateAlertDto } from './dto/update-alert.dto';
+
+const mockAlert = {
+  id: 1,
+  text: 'Maintenance window tonight',
+  type: 'warning',
+  courseId: 5,
+  enabled: true,
+} as Partial<Alert> as Alert;
+
+describe('AlertsService', () => {
+  let service: AlertsService;
+  let repository: Mocked<Repository<Alert>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AlertsService,
+        {
+          provide: getRepositoryToken(Alert),
+          useValue: {
+            save: vi.fn(),
+            find: vi.fn(),
+            findOneByOrFail: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AlertsService>(AlertsService);
+    repository = module.get(getRepositoryToken(Alert));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('saves the alert and returns the freshly loaded entity', async () => {
+      const dto: CreateAlertDto = { text: 'Hi', type: 'info', courseId: 5, enabled: true };
+      repository.save.mockResolvedValue({ id: 1 } as Alert);
+      repository.findOneByOrFail.mockResolvedValue(mockAlert);
+
+      const result = await service.create(dto);
+
+      expect(repository.save).toHaveBeenCalledWith({
+        text: 'Hi',
+        type: 'info',
+        courseId: 5,
+        enabled: true,
+      });
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: 1 });
+      expect(result).toBe(mockAlert);
+    });
+
+    it('defaults enabled to false when omitted', async () => {
+      const dto: CreateAlertDto = { text: 'Hi', type: 'info', courseId: 5 };
+      repository.save.mockResolvedValue({ id: 2 } as Alert);
+      repository.findOneByOrFail.mockResolvedValue(mockAlert);
+
+      await service.create(dto);
+
+      expect(repository.save).toHaveBeenCalledWith({
+        text: 'Hi',
+        type: 'info',
+        courseId: 5,
+        enabled: false,
+      });
+    });
+
+    it('passes through an undefined courseId', async () => {
+      const dto: CreateAlertDto = { text: 'Global', type: 'info' };
+      repository.save.mockResolvedValue({ id: 3 } as Alert);
+      repository.findOneByOrFail.mockResolvedValue(mockAlert);
+
+      await service.create(dto);
+
+      expect(repository.save).toHaveBeenCalledWith({
+        text: 'Global',
+        type: 'info',
+        courseId: undefined,
+        enabled: false,
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('loads enabled alerts with the selected fields and cache window', async () => {
+      const items = [mockAlert];
+      repository.find.mockResolvedValue(items);
+
+      const result = await service.findAll({ enabled: true });
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { enabled: true },
+        select: ['id', 'text', 'type', 'courseId', 'enabled'],
+        cache: 5 * 60 * 1000,
+      });
+      expect(result).toBe(items);
+    });
+
+    it('loads disabled alerts when enabled is false', async () => {
+      repository.find.mockResolvedValue([]);
+
+      const result = await service.findAll({ enabled: false });
+
+      expect(repository.find).toHaveBeenCalledWith(expect.objectContaining({ where: { enabled: false } }));
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('strips undefined fields before updating and returns the reloaded entity', async () => {
+      const dto: UpdateAlertDto = { text: 'New text', enabled: false };
+      repository.update.mockResolvedValue({} as never);
+      repository.findOneByOrFail.mockResolvedValue(mockAlert);
+
+      const result = await service.update(1, dto);
+
+      expect(repository.update).toHaveBeenCalledWith(1, {
+        text: 'New text',
+        enabled: false,
+      });
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: 1 });
+      expect(result).toBe(mockAlert);
+    });
+
+    it('keeps all provided fields including falsy enabled', async () => {
+      const dto: UpdateAlertDto = { text: 'T', type: 'info', courseId: 0, enabled: false };
+      repository.update.mockResolvedValue({} as never);
+      repository.findOneByOrFail.mockResolvedValue(mockAlert);
+
+      await service.update(2, dto);
+
+      expect(repository.update).toHaveBeenCalledWith(2, {
+        text: 'T',
+        type: 'info',
+        courseId: 0,
+        enabled: false,
+      });
+    });
+
+    it('passes an empty object when no fields are provided', async () => {
+      repository.update.mockResolvedValue({} as never);
+      repository.findOneByOrFail.mockResolvedValue(mockAlert);
+
+      await service.update(3, {});
+
+      expect(repository.update).toHaveBeenCalledWith(3, {});
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes the alert by id and resolves to undefined', async () => {
+      repository.delete.mockResolvedValue({} as never);
+
+      const result = await service.remove(7);
+
+      expect(repository.delete).toHaveBeenCalledWith(7);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/auto-test/auto-test.controller.spec.ts
+++ b/nestjs/src/auto-test/auto-test.controller.spec.ts
@@ -1,0 +1,106 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { Task } from '@entities/task';
+import { AutoTestController } from './auto-test.controller';
+import { AutoTestService } from './auto-test.service';
+import { AutoTestTaskDto } from './dto/auto-test-task.dto';
+import { BasicAutoTestTaskDto } from './dto/basic-auto-test-task.dto';
+
+const mockBasicTask = {
+  id: 1,
+  name: 'Self education task',
+  attributes: {
+    public: {
+      maxAttemptsNumber: 3,
+      numberOfQuestions: 10,
+      strictAttemptsMode: true,
+      tresholdPercentage: 70,
+    },
+  },
+} as Partial<Task> as Task;
+
+const mockDetailedTask = {
+  id: 2,
+  name: 'Detailed task',
+  type: 'selfeducation',
+  descriptionUrl: 'http://desc',
+  description: 'desc',
+  githubRepoName: 'repo',
+  sourceGithubRepoUrl: 'http://repo',
+  discipline: null,
+  courseTasks: [],
+  githubPrRequired: false,
+  tags: [],
+  skills: [],
+  attributes: {},
+  createdDate: '2024-01-01',
+  updatedDate: '2024-01-02',
+} as unknown as Task;
+
+describe('AutoTestController', () => {
+  let controller: AutoTestController;
+  let service: Mocked<AutoTestService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AutoTestController],
+      providers: [
+        {
+          provide: AutoTestService,
+          useValue: {
+            getAll: vi.fn(),
+            findById: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AutoTestController);
+    service = module.get(AutoTestService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getBasicAutoTests', () => {
+    it('maps service results to BasicAutoTestTaskDto instances', async () => {
+      service.getAll.mockResolvedValue([mockBasicTask]);
+
+      const result = await controller.getBasicAutoTests();
+
+      expect(service.getAll).toHaveBeenCalledWith();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(BasicAutoTestTaskDto);
+      expect(result[0]).toMatchObject({ id: 1, name: 'Self education task', maxAttemptsNumber: 3 });
+    });
+
+    it('returns an empty array when service has no tasks', async () => {
+      service.getAll.mockResolvedValue([]);
+
+      const result = await controller.getBasicAutoTests();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAutoTestTask', () => {
+    it('returns an AutoTestTaskDto when the task exists', async () => {
+      service.findById.mockResolvedValue(mockDetailedTask);
+
+      const result = await controller.getAutoTestTask(2);
+
+      expect(service.findById).toHaveBeenCalledWith(2);
+      expect(result).toBeInstanceOf(AutoTestTaskDto);
+      expect(result.id).toBe(2);
+    });
+
+    it('throws NotFoundException with the id in the message when not found', async () => {
+      service.findById.mockResolvedValue(null);
+
+      await expect(controller.getAutoTestTask(7)).rejects.toThrow(NotFoundException);
+      await expect(controller.getAutoTestTask(7)).rejects.toThrow("Couldn't find task with id = 7");
+    });
+  });
+});

--- a/nestjs/src/auto-test/auto-test.service.spec.ts
+++ b/nestjs/src/auto-test/auto-test.service.spec.ts
@@ -1,0 +1,90 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Task, TaskType } from '@entities/task';
+import { AutoTestService } from './auto-test.service';
+
+const mockTask = { id: 1, name: 'Self education task' } as Partial<Task> as Task;
+
+describe('AutoTestService', () => {
+  let service: AutoTestService;
+  let repository: Mocked<Repository<Task>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AutoTestService,
+        {
+          provide: getRepositoryToken(Task),
+          useValue: {
+            find: vi.fn(),
+            findOne: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(AutoTestService);
+    repository = module.get(getRepositoryToken(Task));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getAll', () => {
+    it('queries self-education tasks with discipline + courses relations ordered by updatedDate DESC', async () => {
+      const tasks = [mockTask];
+      repository.find.mockResolvedValue(tasks);
+
+      const result = await service.getAll();
+
+      expect(repository.find).toHaveBeenCalledWith({
+        select: ['id', 'name', 'attributes'],
+        where: {
+          type: TaskType.SelfEducation,
+        },
+        relations: {
+          discipline: true,
+          courseTasks: { course: true },
+        },
+        order: {
+          updatedDate: 'DESC',
+        },
+      });
+      expect(result).toBe(tasks);
+    });
+  });
+
+  describe('findById', () => {
+    it('queries a single self-education task by id with relations', async () => {
+      repository.findOne.mockResolvedValue(mockTask);
+
+      const result = await service.findById(42);
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: {
+          type: TaskType.SelfEducation,
+          id: 42,
+        },
+        relations: {
+          discipline: true,
+          courseTasks: { course: true },
+        },
+        order: {
+          updatedDate: 'DESC',
+        },
+      });
+      expect(result).toBe(mockTask);
+    });
+
+    it('returns null when the task is not found', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      const result = await service.findById(999);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/nestjs/src/certificates/certificates.controller.spec.ts
+++ b/nestjs/src/certificates/certificates.controller.spec.ts
@@ -1,0 +1,150 @@
+import type { Mocked } from 'vitest';
+import { Readable } from 'stream';
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Response } from 'express';
+import { CertificatesController } from './certificates.controller';
+import { CertificationsService } from './certificates.service';
+import { StudentsService } from '../courses/students';
+import { UserNotificationsService } from 'src/users-notifications/users.notifications.service';
+import { CERTIFICATE_TEMPLATES } from './templates/catalog';
+
+describe('CertificatesController', () => {
+  let controller: CertificatesController;
+  let certificatesService: Mocked<CertificationsService>;
+  let notificationService: Mocked<UserNotificationsService>;
+  let studentsService: Mocked<StudentsService>;
+
+  const makeRes = () =>
+    ({
+      json: vi.fn(),
+      set: vi.fn(),
+    }) as unknown as Response;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CertificatesController],
+      providers: [
+        {
+          provide: CertificationsService,
+          useValue: {
+            getByPublicId: vi.fn(),
+            getCertificateMetadata: vi.fn(),
+            getFileStream: vi.fn(),
+            buildNotificationData: vi.fn(),
+            saveCertificate: vi.fn(),
+            removeCertificate: vi.fn(),
+          },
+        },
+        { provide: UserNotificationsService, useValue: { sendEventNotification: vi.fn() } },
+        { provide: StudentsService, useValue: { getById: vi.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get(CertificatesController);
+    certificatesService = module.get(CertificationsService);
+    notificationService = module.get(UserNotificationsService);
+    studentsService = module.get(StudentsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getTemplates', () => {
+    it('returns the static certificate templates catalog', () => {
+      expect(controller.getTemplates()).toBe(CERTIFICATE_TEMPLATES);
+    });
+  });
+
+  describe('getCertificate', () => {
+    it('throws NotFoundException when no certificate matches the public id', async () => {
+      certificatesService.getByPublicId.mockResolvedValue(null);
+      const res = makeRes();
+
+      await expect(controller.getCertificate('abc', res)).rejects.toThrow(NotFoundException);
+      expect(certificatesService.getByPublicId).toHaveBeenCalledWith('abc');
+    });
+
+    it('returns metadata as json for a .json public id', async () => {
+      const certificate = { s3Bucket: 'b', s3Key: 'k' } as never;
+      const metadata = { id: 'abc', name: 'John Doe' } as never;
+      certificatesService.getByPublicId.mockResolvedValue(certificate);
+      certificatesService.getCertificateMetadata.mockResolvedValue(metadata);
+      const res = makeRes();
+
+      await controller.getCertificate('abc.json', res);
+
+      // .json suffix is stripped before lookup
+      expect(certificatesService.getByPublicId).toHaveBeenCalledWith('abc');
+      expect(certificatesService.getCertificateMetadata).toHaveBeenCalledWith(certificate);
+      expect(res.json).toHaveBeenCalledWith(metadata);
+    });
+
+    it('streams the pdf for a non-json public id', async () => {
+      const certificate = { s3Bucket: 'bucket', s3Key: 'key.pdf' } as never;
+      certificatesService.getByPublicId.mockResolvedValue(certificate);
+      const stream = { pipe: vi.fn() } as unknown as Readable;
+      certificatesService.getFileStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await controller.getCertificate('abc', res);
+
+      expect(certificatesService.getFileStream).toHaveBeenCalledWith('bucket', 'key.pdf');
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+      expect(stream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it('throws NotFoundException when fetching the artifact fails', async () => {
+      const certificate = { s3Bucket: 'bucket', s3Key: 'key.pdf' } as never;
+      certificatesService.getByPublicId.mockResolvedValue(certificate);
+      certificatesService.getFileStream.mockRejectedValue(new Error('S3 down'));
+      const res = makeRes();
+
+      await expect(controller.getCertificate('abc', res)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when building json metadata fails', async () => {
+      const certificate = { s3Bucket: 'b', s3Key: 'k' } as never;
+      certificatesService.getByPublicId.mockResolvedValue(certificate);
+      certificatesService.getCertificateMetadata.mockRejectedValue(new Error('no course'));
+      const res = makeRes();
+
+      await expect(controller.getCertificate('abc.json', res)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('saveCertificate', () => {
+    it('saves the certificate, builds notification data and dispatches the event', async () => {
+      const dto = { studentId: 42, publicId: 'abc' } as never;
+      const student = { id: 42, userId: 7, courseId: 3 } as never;
+      const notificationData = { userId: 7, notification: { course: { id: 3 }, publicId: 'abc' } } as never;
+
+      studentsService.getById.mockResolvedValue(student);
+      certificatesService.buildNotificationData.mockResolvedValue(notificationData);
+      certificatesService.saveCertificate.mockResolvedValue(undefined);
+      notificationService.sendEventNotification.mockResolvedValue(undefined as never);
+
+      await controller.saveCertificate(dto);
+
+      expect(studentsService.getById).toHaveBeenCalledWith(42);
+      expect(certificatesService.buildNotificationData).toHaveBeenCalledWith(student, dto);
+      expect(certificatesService.saveCertificate).toHaveBeenCalledWith(42, dto);
+      expect(notificationService.sendEventNotification).toHaveBeenCalledWith({
+        data: { course: { id: 3 }, publicId: 'abc' },
+        notificationId: 'courseCertificate',
+        userId: 7,
+      });
+    });
+  });
+
+  describe('removeCertificate', () => {
+    it('delegates removal to the service', async () => {
+      certificatesService.removeCertificate.mockResolvedValue(undefined);
+
+      await controller.removeCertificate(99);
+
+      expect(certificatesService.removeCertificate).toHaveBeenCalledWith(99);
+    });
+  });
+});

--- a/nestjs/src/certificates/certificates.service.spec.ts
+++ b/nestjs/src/certificates/certificates.service.spec.ts
@@ -1,0 +1,461 @@
+import { Readable } from 'stream';
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { Certificate } from '@entities/certificate';
+import { Student } from '@entities/student';
+import { Course } from '@entities/course';
+import { User } from '@entities/user';
+import { ConfigService } from 'src/config';
+import { CertificationsService } from './certificates.service';
+import { CertificateMetadataDto } from './dto/certificate-metadata.dto';
+
+// Mock the AWS SDK so the S3 client constructed in the service ctor is inert
+// and we control GetObjectCommand input + the send() result.
+const mockS3Send = vi.fn();
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3: class {
+    send = mockS3Send;
+  },
+  GetObjectCommand: class {
+    input: unknown;
+    __command = 'GetObject';
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  },
+}));
+
+describe('CertificationsService', () => {
+  let service: CertificationsService;
+
+  const certificateRepository = {
+    findOne: vi.fn(),
+    findOneOrFail: vi.fn(),
+    update: vi.fn(),
+    save: vi.fn(),
+    remove: vi.fn(),
+  };
+  const courseRepository = { findOne: vi.fn(), findOneByOrFail: vi.fn() };
+  const userRepository = { findOneByOrFail: vi.fn() };
+  const studentRepository = { findOne: vi.fn(), createQueryBuilder: vi.fn() };
+  const mockPost = vi.fn();
+  const mockDelete = vi.fn();
+
+  const configValue = {
+    awsServices: { restApiUrl: 'https://aws.example.com', restApiKey: 'secret-key' },
+    awsClient: { region: 'eu-central-1', credentials: { accessKeyId: 'x', secretAccessKey: 'y' } },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockPost.mockReturnValue(of({ data: {} }));
+    mockDelete.mockReturnValue(of({ data: {} }));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CertificationsService,
+        { provide: getRepositoryToken(Certificate), useValue: certificateRepository },
+        { provide: getRepositoryToken(Course), useValue: courseRepository },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: getRepositoryToken(Student), useValue: studentRepository },
+        { provide: ConfigService, useValue: configValue },
+        { provide: HttpService, useValue: { post: mockPost, delete: mockDelete } },
+      ],
+    }).compile();
+
+    service = module.get(CertificationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getByPublicId', () => {
+    it('finds a certificate by publicId with the student relation', async () => {
+      const cert = { id: 1, publicId: 'abc' };
+      certificateRepository.findOne.mockResolvedValue(cert);
+
+      const result = await service.getByPublicId('abc');
+
+      expect(certificateRepository.findOne).toHaveBeenCalledWith({
+        where: { publicId: 'abc' },
+        relations: ['student'],
+      });
+      expect(result).toBe(cert);
+    });
+  });
+
+  describe('getCertificateMetadata', () => {
+    const certificate = {
+      publicId: 'abc',
+      issueDate: new Date('2026-01-15T00:00:00.000Z'),
+      student: { userId: 7, courseId: 3 },
+    } as unknown as Certificate;
+
+    it('builds metadata from the user and course', async () => {
+      userRepository.findOneByOrFail.mockResolvedValue({ firstName: 'John', lastName: 'Doe' });
+      courseRepository.findOne.mockResolvedValue({
+        fullName: 'JS Course',
+        certificateIssuer: 'RS School',
+        discipline: { name: 'JavaScript' },
+      });
+
+      const result = await service.getCertificateMetadata(certificate);
+
+      expect(userRepository.findOneByOrFail).toHaveBeenCalledWith({ id: 7 });
+      expect(courseRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 3 },
+        relations: ['discipline'],
+      });
+      expect(result).toBeInstanceOf(CertificateMetadataDto);
+      expect(result.name).toBe('John Doe');
+      expect(result.issueDate).toBe('2026-01-15');
+    });
+
+    it('throws NotFoundException when the course does not exist', async () => {
+      userRepository.findOneByOrFail.mockResolvedValue({ firstName: 'John', lastName: 'Doe' });
+      courseRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getCertificateMetadata(certificate)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getFileStream', () => {
+    it('sends a GetObjectCommand and returns the response body', async () => {
+      const body = Readable.from('pdf-bytes');
+      mockS3Send.mockResolvedValue({ Body: body });
+
+      const result = await service.getFileStream('my-bucket', 'my-key');
+
+      expect(mockS3Send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          __command: 'GetObject',
+          input: { Bucket: 'my-bucket', Key: 'my-key' },
+        }),
+      );
+      expect(result).toBe(body);
+    });
+  });
+
+  describe('saveCertificate', () => {
+    const data = { publicId: 'abc', studentId: 42, s3Bucket: 'b', s3Key: 'k', issueDate: '2026-01-01' };
+
+    it('updates the existing certificate found by publicId', async () => {
+      certificateRepository.findOne.mockResolvedValueOnce({ id: 1 });
+
+      await service.saveCertificate(42, data);
+
+      expect(certificateRepository.update).toHaveBeenCalledWith(1, data);
+      expect(certificateRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('updates the certificate found by studentId when none matches publicId', async () => {
+      certificateRepository.findOne.mockResolvedValueOnce(null); // by publicId
+      certificateRepository.findOne.mockResolvedValueOnce({ id: 2 }); // by studentId
+
+      await service.saveCertificate(42, data);
+
+      expect(certificateRepository.findOne).toHaveBeenNthCalledWith(2, { where: { studentId: 42 } });
+      expect(certificateRepository.update).toHaveBeenCalledWith(2, data);
+      expect(certificateRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('saves a new certificate when no existing one is found', async () => {
+      certificateRepository.findOne.mockResolvedValueOnce(null); // by publicId
+      certificateRepository.findOne.mockResolvedValueOnce(null); // by studentId
+
+      await service.saveCertificate(42, data);
+
+      expect(certificateRepository.update).not.toHaveBeenCalled();
+      expect(certificateRepository.save).toHaveBeenCalledWith(data);
+    });
+  });
+
+  describe('buildNotificationData', () => {
+    it('assembles userId and notification payload from the student course', async () => {
+      const course = { id: 3, name: 'JS' };
+      courseRepository.findOneByOrFail.mockResolvedValue(course);
+      const student = { userId: 7, courseId: 3 } as Student;
+      const data = { publicId: 'abc' } as never;
+
+      const result = await service.buildNotificationData(student, data);
+
+      expect(courseRepository.findOneByOrFail).toHaveBeenCalledWith({ id: 3 });
+      expect(result).toEqual({
+        userId: 7,
+        notification: { course, publicId: 'abc' },
+      });
+    });
+  });
+
+  describe('removeCertificate', () => {
+    it('deletes the remote artifact and removes the entity in parallel', async () => {
+      const certificate = { id: 1, s3Key: 'folder/file.pdf' };
+      certificateRepository.findOneOrFail.mockResolvedValue(certificate);
+
+      await service.removeCertificate(99);
+
+      expect(certificateRepository.findOneOrFail).toHaveBeenCalledWith({ where: { studentId: 99 } });
+      expect(mockDelete).toHaveBeenCalledWith('https://aws.example.com/certificate/folder/file.pdf');
+      expect(certificateRepository.remove).toHaveBeenCalledWith(certificate);
+    });
+  });
+
+  describe('resolveTemplateId', () => {
+    it('keeps an allowed template id', () => {
+      expect(service.resolveTemplateId('bootcamp_13_weeks')).toBe('bootcamp_13_weeks');
+      expect(service.resolveTemplateId('default')).toBe('default');
+    });
+
+    it('falls back to the default for unknown or non-string inputs', () => {
+      expect(service.resolveTemplateId('unknown')).toBe('default');
+      expect(service.resolveTemplateId(undefined)).toBe('default');
+      expect(service.resolveTemplateId(123)).toBe('default');
+      expect(service.resolveTemplateId(null)).toBe('default');
+    });
+  });
+
+  describe('buildStudentCertificateRequest', () => {
+    const student = {
+      id: 42,
+      user: { firstName: 'John', lastName: 'Doe', githubId: 'john' },
+      course: {
+        name: 'JS 2026',
+        primarySkillName: 'JavaScript',
+        certificateIssuer: 'RS School',
+        discipline: { name: 'JS / FE' },
+      },
+    };
+
+    it('returns null when no matching student is found', async () => {
+      studentRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.buildStudentCertificateRequest(5, 'john');
+
+      expect(result).toBeNull();
+    });
+
+    it('uses the discipline name as the primary skill when present', async () => {
+      studentRepository.findOne.mockResolvedValue(student);
+
+      const result = await service.buildStudentCertificateRequest(5, 'john', 'bootcamp_13_weeks');
+
+      expect(result).toMatchObject({
+        courseId: 5,
+        courseName: 'JS 2026',
+        coursePrimarySkill: 'JS / FE',
+        certificateIssuer: 'RS School',
+        studentId: 42,
+        studentName: 'John Doe',
+        templateId: 'bootcamp_13_weeks',
+      });
+      expect(typeof result?.timestamp).toBe('number');
+    });
+
+    it('falls back to primarySkillName when discipline is missing', async () => {
+      const noDiscipline = { ...student, course: { ...student.course, discipline: undefined } };
+      studentRepository.findOne.mockResolvedValue(noDiscipline);
+
+      const result = await service.buildStudentCertificateRequest(5, 'john', 'hacked');
+
+      expect(result?.coursePrimarySkill).toBe('JavaScript');
+      // unknown template id falls back to default
+      expect(result?.templateId).toBe('default');
+    });
+  });
+
+  describe('buildCourseCertificateRequests', () => {
+    const student = {
+      id: 42,
+      user: { firstName: 'John', lastName: 'Doe', githubId: 'john' },
+      course: {
+        name: 'JS 2026',
+        primarySkillName: 'JavaScript',
+        certificateIssuer: 'RS School',
+        discipline: { name: 'JS / FE' },
+      },
+    };
+
+    const makeQb = (students: unknown[]) => {
+      const qb = {
+        innerJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        leftJoinAndSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        getMany: vi.fn().mockResolvedValue(students),
+      };
+      return qb;
+    };
+
+    it('short-circuits when criteria are non-empty but match no students', async () => {
+      vi.spyOn(service as never, 'findStudentIdsByCriteria' as never).mockResolvedValue([] as never);
+
+      const result = await service.buildCourseCertificateRequests(5, { criteria: { minTotalScore: 100 } });
+
+      expect(result).toEqual({ requests: [], shortCircuit: true });
+    });
+
+    it('builds requests for the matched student ids', async () => {
+      vi.spyOn(service as never, 'findStudentIdsByCriteria' as never).mockResolvedValue([42] as never);
+      const qb = makeQb([student]);
+      studentRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.buildCourseCertificateRequests(5, { criteria: { minTotalScore: 100 } });
+
+      expect(qb.where).toHaveBeenCalledWith('student."id" IN (:...ids)', { ids: [42] });
+      expect(result.shortCircuit).toBe(false);
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0]).toMatchObject({
+        studentId: 42,
+        templateId: 'default',
+        coursePrimarySkill: 'JS / FE',
+        studentName: 'John Doe',
+      });
+    });
+
+    it('falls back to primarySkillName when the matched student course has no discipline', async () => {
+      vi.spyOn(service as never, 'findStudentIdsByCriteria' as never).mockResolvedValue([42] as never);
+      const noDiscipline = { ...student, course: { ...student.course, discipline: undefined } };
+      const qb = makeQb([noDiscipline]);
+      studentRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.buildCourseCertificateRequests(5, { criteria: {} });
+
+      expect(result.requests[0].coursePrimarySkill).toBe('JavaScript');
+    });
+
+    it('targets students without certificates when criteria are empty', async () => {
+      vi.spyOn(service as never, 'findStudentIdsByCriteria' as never).mockResolvedValue([] as never);
+      const qb = makeQb([]);
+      studentRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.buildCourseCertificateRequests(5, { criteria: {} });
+
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('student.certificate', 'certificate');
+      expect(qb.where).toHaveBeenCalledWith(
+        'certificate.id IS NULL AND student."courseId" = :courseId AND student."isExpelled" = false AND student."isFailed" = false',
+        { courseId: 5 },
+      );
+      expect(result).toEqual({ requests: [], shortCircuit: false });
+    });
+
+    it('handles a fully empty data object (no criteria, no templateId)', async () => {
+      vi.spyOn(service as never, 'findStudentIdsByCriteria' as never).mockResolvedValue([] as never);
+      const qb = makeQb([]);
+      studentRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.buildCourseCertificateRequests(5, {});
+
+      expect(result).toEqual({ requests: [], shortCircuit: false });
+    });
+  });
+
+  describe('requestCertificates', () => {
+    it('posts the payload to the AWS gateway with the api key header', async () => {
+      const payload = { studentId: 42 };
+
+      await service.requestCertificates(payload);
+
+      expect(mockPost).toHaveBeenCalledWith('https://aws.example.com/certificate', payload, {
+        headers: { 'x-api-key': 'secret-key' },
+      });
+    });
+  });
+
+  describe('findStudentIdsByCriteria (via buildCourseCertificateRequests with courseTaskIds)', () => {
+    it('returns student ids whose task + interview matches cover all required tasks', async () => {
+      // Drive the real private method by NOT spying on it; mock the raw query builder.
+      const selectionQb = {
+        select: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        andWhere: vi.fn().mockReturnThis(),
+        groupBy: vi.fn().mockReturnThis(),
+        getRawMany: vi.fn().mockResolvedValue([
+          { student_id: 1, tasks: [10], interviews: [20] }, // 2 of 2 => kept
+          { student_id: 2, tasks: [10], interviews: [] }, // 1 of 2 => dropped
+        ]),
+      };
+      // second builder used to materialize the selected students
+      const materializeQb = {
+        innerJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        leftJoinAndSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        getMany: vi.fn().mockResolvedValue([]),
+      };
+      studentRepository.createQueryBuilder.mockReturnValueOnce(selectionQb).mockReturnValueOnce(materializeQb);
+
+      const result = await service.buildCourseCertificateRequests(5, {
+        criteria: { courseTaskIds: [10, 20], minScore: 50, minTotalScore: 80 },
+      });
+
+      // Only student 1 satisfies all required tasks => non-empty studentIds => IN query path
+      expect(materializeQb.where).toHaveBeenCalledWith('student."id" IN (:...ids)', { ids: [1] });
+      expect(result.shortCircuit).toBe(false);
+    });
+
+    it('returns all rows when no courseTaskIds are required (tasksCount === 0)', async () => {
+      const selectionQb = {
+        select: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        andWhere: vi.fn().mockReturnThis(),
+        groupBy: vi.fn().mockReturnThis(),
+        getRawMany: vi.fn().mockResolvedValue([{ student_id: 1 }, { student_id: 2 }]),
+      };
+      const materializeQb = {
+        innerJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        leftJoinAndSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        getMany: vi.fn().mockResolvedValue([]),
+      };
+      studentRepository.createQueryBuilder.mockReturnValueOnce(selectionQb).mockReturnValueOnce(materializeQb);
+
+      const result = await service.buildCourseCertificateRequests(5, {
+        criteria: { minTotalScore: 80 },
+      });
+
+      expect(materializeQb.where).toHaveBeenCalledWith('student."id" IN (:...ids)', { ids: [1, 2] });
+      expect(result.shortCircuit).toBe(false);
+    });
+
+    it('uses the default minScore (1) when courseTaskIds are present without an explicit minScore', async () => {
+      const selectionQb = {
+        select: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        andWhere: vi.fn().mockReturnThis(),
+        groupBy: vi.fn().mockReturnThis(),
+        getRawMany: vi.fn().mockResolvedValue([{ student_id: 1, tasks: [10], interviews: [] }]),
+      };
+      const materializeQb = {
+        innerJoin: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        leftJoinAndSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        getMany: vi.fn().mockResolvedValue([]),
+      };
+      studentRepository.createQueryBuilder.mockReturnValueOnce(selectionQb).mockReturnValueOnce(materializeQb);
+
+      // No minScore and no minTotalScore => task/interview join uses the `: 1` fallback
+      // and the minTotalScore andWhere clause is skipped.
+      const result = await service.buildCourseCertificateRequests(5, {
+        criteria: { courseTaskIds: [10] },
+      });
+
+      const taskJoin = selectionQb.leftJoin.mock.calls.find(call => call[1] === 'tr');
+      expect(taskJoin?.[3]).toMatchObject({ minScore: 1 });
+      // minTotalScore was not provided => no totalScore andWhere clause
+      expect(selectionQb.andWhere).not.toHaveBeenCalledWith('student.totalScore >= :minTotalScore', expect.anything());
+      expect(result.shortCircuit).toBe(false);
+    });
+  });
+});

--- a/nestjs/src/certificates/templates/catalog.spec.ts
+++ b/nestjs/src/certificates/templates/catalog.spec.ts
@@ -1,0 +1,50 @@
+import {
+  CERTIFICATE_TEMPLATES,
+  CERTIFICATE_TEMPLATE_IDS,
+  DEFAULT_CERTIFICATE_TEMPLATE_ID,
+  resolveCertificateTemplateId,
+} from './catalog';
+
+describe('certificate templates catalog', () => {
+  describe('CERTIFICATE_TEMPLATE_IDS', () => {
+    it('contains exactly the ids declared in CERTIFICATE_TEMPLATES', () => {
+      expect([...CERTIFICATE_TEMPLATE_IDS].sort()).toEqual(CERTIFICATE_TEMPLATES.map(t => t.id).sort());
+    });
+
+    it('includes the default template id', () => {
+      expect(CERTIFICATE_TEMPLATE_IDS.has(DEFAULT_CERTIFICATE_TEMPLATE_ID)).toBe(true);
+    });
+  });
+
+  describe('DEFAULT_CERTIFICATE_TEMPLATE_ID', () => {
+    it('is "default"', () => {
+      expect(DEFAULT_CERTIFICATE_TEMPLATE_ID).toBe('default');
+    });
+  });
+
+  describe('resolveCertificateTemplateId', () => {
+    it('returns the input when it is a known template id', () => {
+      expect(resolveCertificateTemplateId('default')).toBe('default');
+      expect(resolveCertificateTemplateId('bootcamp_13_weeks')).toBe('bootcamp_13_weeks');
+    });
+
+    it('falls back to the default for an unknown string id', () => {
+      expect(resolveCertificateTemplateId('not-a-template')).toBe(DEFAULT_CERTIFICATE_TEMPLATE_ID);
+    });
+
+    it('falls back to the default for an empty string', () => {
+      expect(resolveCertificateTemplateId('')).toBe(DEFAULT_CERTIFICATE_TEMPLATE_ID);
+    });
+
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['number', 42],
+      ['boolean', true],
+      ['object', { id: 'default' }],
+      ['array', ['default']],
+    ])('falls back to the default for a non-string input (%s)', (_label, input) => {
+      expect(resolveCertificateTemplateId(input)).toBe(DEFAULT_CERTIFICATE_TEMPLATE_ID);
+    });
+  });
+});

--- a/nestjs/src/cloud-api/cloud-api.service.spec.ts
+++ b/nestjs/src/cloud-api/cloud-api.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { ConfigService } from 'src/config';
+import { CloudApiService } from './cloud-api.service';
+
+describe('CloudApiService', () => {
+  let service: CloudApiService;
+  const mockPost = vi.fn();
+
+  const baseUrl = 'https://aws.example.com';
+  const apiKey = 'secret-key';
+  const headers = { headers: { 'x-api-key': apiKey } };
+
+  beforeEach(async () => {
+    mockPost.mockReset().mockReturnValue(of({ data: { ok: true } }));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CloudApiService,
+        { provide: HttpService, useValue: { post: mockPost } },
+        {
+          provide: ConfigService,
+          useValue: { awsServices: { restApiUrl: baseUrl, restApiKey: apiKey } },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CloudApiService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('logErrors', () => {
+    it('posts errors to the /errors endpoint with the api key header', async () => {
+      const errors = [{ message: 'boom' }];
+      const response = { data: { logged: true } };
+      mockPost.mockReturnValueOnce(of(response));
+
+      const result = await service.logErrors(errors);
+
+      expect(mockPost).toHaveBeenCalledWith(`${baseUrl}/errors`, errors, headers);
+      expect(result).toBe(response);
+    });
+  });
+
+  describe('submitTask', () => {
+    it('posts task data to the /task endpoint with the api key header', async () => {
+      const data = [{ id: 1 }];
+      const response = { data: { submitted: true } };
+      mockPost.mockReturnValueOnce(of(response));
+
+      const result = await service.submitTask(data);
+
+      expect(mockPost).toHaveBeenCalledWith(`${baseUrl}/task`, data, headers);
+      expect(result).toBe(response);
+    });
+  });
+
+  describe('uploadFile', () => {
+    it('posts to the upload endpoint with key/githubId query params and returns response data', async () => {
+      const payload = { content: 'binary' };
+      mockPost.mockReturnValueOnce(of({ data: { url: 'https://cdn/file' } }));
+
+      const result = await service.uploadFile('john', 'avatar.png', payload);
+
+      expect(mockPost).toHaveBeenCalledWith(`${baseUrl}/upload?key=avatar.png&githubId=john`, payload, headers);
+      expect(result).toEqual({ url: 'https://cdn/file' });
+    });
+  });
+});

--- a/nestjs/src/config/config.service.spec.ts
+++ b/nestjs/src/config/config.service.spec.ts
@@ -1,0 +1,174 @@
+import { ConfigService as NestConfigService } from '@nestjs/config';
+import { ConfigService } from './config.service';
+
+/**
+ * Builds a minimal NestConfigService stand-in whose `get(key, fallback?)`
+ * resolves from `values`, mirroring @nestjs/config semantics: when the key is
+ * absent and a default is provided, the default is returned; otherwise undefined.
+ */
+function makeNestConfig(values: Record<string, unknown>): NestConfigService {
+  return {
+    get: vi.fn((key: string, defaultValue?: unknown) => {
+      if (key in values) return values[key];
+      return defaultValue;
+    }),
+  } as unknown as NestConfigService;
+}
+
+describe('ConfigService', () => {
+  describe('when every env value is provided', () => {
+    let service: ConfigService;
+
+    beforeEach(() => {
+      service = new ConfigService(
+        makeNestConfig({
+          RSSHCOOL_AUTH_GITHUB_CLIENT_ID: 'client-id',
+          RSSHCOOL_AUTH_GITHUB_CLIENT_SECRET: 'client-secret',
+          RSSHCOOL_AUTH_GITHUB_CALLBACK: 'https://callback',
+          RSSHCOOL_AUTH_GITHUB_WEBHOOK_ACTIVITY_SECRET: 'webhook-secret',
+          RSSHCOOL_AUTH_GITHUB_INTEGRATION_SITE_TOKEN: 'site-token',
+          RSSCHOOL_AUTH_DEV_USERNAME: 'dev-user',
+          RSSCHOOL_AUTH_DEV_ADMIN: 'TRUE',
+          RSSHCOOL_AUTH_JWT_SECRET_KEY: 'jwt-secret',
+          RSSHCOOL_OPENAI_API_KEY: 'openai-key',
+          RSSHCOOL_AWS_REGION: 'us-east-1',
+          RSSHCOOL_AWS_ACCESS_KEY_ID: 'access-key',
+          RSSHCOOL_AWS_SECRET_ACCESS_KEY: 'secret-access',
+          RSSHCOOL_AWS_REST_API_URL: 'https://api',
+          RSSHCOOL_AWS_REST_API_KEY: 'rest-key',
+          RSSHCOOL_USERS_CLOUD_USERNAME: 'root',
+          RSSHCOOL_USERS_CLOUD_PASSWORD: 'root-pass',
+          RSSHCOOL_USERS_HIRERS: 'h1,h2',
+          RSSHCOOL_USERS_ADMINS: 'a1,a2,a3',
+          RSSHCOOL_SECURE_ENCRYPT_KEY: 'encrypt-key',
+          RSSHCOOL_HOST: 'https://host',
+          RS_ENV: 'staging',
+        }),
+      );
+    });
+
+    it('maps github auth config', () => {
+      expect(service.auth.github).toEqual({
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        callbackUrl: 'https://callback',
+        scope: ['user:email'],
+        activityWebhookSecret: 'webhook-secret',
+        integrationSiteToken: 'site-token',
+      });
+    });
+
+    it('parses the dev admin flag case-insensitively', () => {
+      expect(service.auth.dev).toEqual({ username: 'dev-user', admin: true });
+    });
+
+    it('maps jwt, openai, aws client and aws services config', () => {
+      expect(service.auth.jwt.secretKey).toBe('jwt-secret');
+      expect(service.openai).toEqual({ apiKey: 'openai-key' });
+      expect(service.awsClient).toEqual({
+        region: 'us-east-1',
+        credentials: { accessKeyId: 'access-key', secretAccessKey: 'secret-access' },
+      });
+      expect(service.awsServices).toEqual({ restApiUrl: 'https://api', restApiKey: 'rest-key' });
+    });
+
+    it('splits comma-separated hirers and admins into arrays', () => {
+      expect(service.users).toEqual({
+        root: { username: 'root', password: 'root-pass' },
+        hirers: ['h1', 'h2'],
+        admins: ['a1', 'a2', 'a3'],
+      });
+    });
+
+    it('maps secure, host and static buckets', () => {
+      expect(service.secure).toEqual({ encryptKey: 'encrypt-key' });
+      expect(service.host).toBe('https://host');
+      expect(service.buckets).toEqual({ cdn: 'cdn.rs.school' });
+    });
+
+    it('resolves env to staging when RS_ENV is staging', () => {
+      expect(service.env).toBe('staging');
+    });
+  });
+
+  describe('when env values are missing', () => {
+    let service: ConfigService;
+
+    beforeEach(() => {
+      service = new ConfigService(makeNestConfig({}));
+    });
+
+    it('falls back to empty strings for missing auth values', () => {
+      expect(service.auth.github.clientId).toBe('');
+      expect(service.auth.github.clientSecret).toBe('');
+      expect(service.auth.github.callbackUrl).toBe('');
+    });
+
+    it('uses provided defaults for webhook secret and integration token', () => {
+      expect(service.auth.github.activityWebhookSecret).toBe('activity-webhook');
+      expect(service.auth.github.integrationSiteToken).toBe('');
+    });
+
+    it('defaults dev admin to false when flag is absent', () => {
+      expect(service.auth.dev.admin).toBe(false);
+      expect(service.auth.dev.username).toBe('');
+    });
+
+    it('defaults jwt secret and encrypt key to "secret"', () => {
+      expect(service.auth.jwt.secretKey).toBe('secret');
+      expect(service.secure.encryptKey).toBe('secret');
+    });
+
+    it('defaults aws region and empty credentials/services', () => {
+      expect(service.awsClient.region).toBe('eu-central-1');
+      expect(service.awsClient.credentials).toEqual({ accessKeyId: '', secretAccessKey: '' });
+      expect(service.awsServices).toEqual({ restApiUrl: '', restApiKey: '' });
+    });
+
+    it('defaults openai key and host to empty strings', () => {
+      expect(service.openai.apiKey).toBe('');
+      expect(service.host).toBe('');
+    });
+
+    it('defaults hirers and admins to empty arrays', () => {
+      expect(service.users.hirers).toEqual([]);
+      expect(service.users.admins).toEqual([]);
+    });
+  });
+
+  describe('dev admin flag parsing', () => {
+    it('treats a non-"true" string as false', () => {
+      const service = new ConfigService(makeNestConfig({ RSSCHOOL_AUTH_DEV_ADMIN: 'yes' }));
+      expect(service.auth.dev.admin).toBe(false);
+    });
+  });
+
+  describe('env resolution', () => {
+    it('resolves to "local" in dev when RS_ENV is not staging', () => {
+      // In the test runtime NODE_ENV is not "production", so isDev is true.
+      const service = new ConfigService(makeNestConfig({ RS_ENV: 'production' }));
+      expect(service.env).toBe(service.isDev ? 'local' : 'prod');
+    });
+  });
+
+  describe('authWithDevUser', () => {
+    it('does nothing when dev tools toggle is off', () => {
+      const service = new ConfigService(makeNestConfig({ RSSCHOOL_AUTH_DEV_USERNAME: 'original' }));
+      // devToolsToggle reads RSSCHOOL_DEV_TOOLS at field init; default test env keeps it off.
+      Object.defineProperty(service, 'devToolsToggle', { value: false });
+
+      service.authWithDevUser('hacker');
+
+      expect(service.auth.dev.username).toBe('original');
+    });
+
+    it('overrides the dev username when the toggle is on', () => {
+      const service = new ConfigService(makeNestConfig({ RSSCHOOL_AUTH_DEV_USERNAME: 'original' }));
+      Object.defineProperty(service, 'devToolsToggle', { value: true });
+
+      service.authWithDevUser('impersonated');
+
+      expect(service.auth.dev.username).toBe('impersonated');
+    });
+  });
+});

--- a/nestjs/src/contributors/contributors.controller.spec.ts
+++ b/nestjs/src/contributors/contributors.controller.spec.ts
@@ -1,0 +1,120 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Contributor } from '@entities/contributor';
+import { ContributorsController } from './contributors.controller';
+import { ContributorsService } from './contributors.service';
+import { ContributorDto, CreateContributorDto, UpdateContributorDto } from './dto';
+
+const mockContributor = {
+  id: 1,
+  description: 'Core maintainer',
+  createdDate: '2026-01-01T00:00:00.000Z',
+  updatedDate: '2026-01-02T00:00:00.000Z',
+  user: { id: 11, githubId: 'john-doe', firstName: 'John', lastName: 'Doe' },
+} as Partial<Contributor> as Contributor;
+
+describe('ContributorsController', () => {
+  let controller: ContributorsController;
+  let service: Mocked<ContributorsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ContributorsController],
+      providers: [
+        {
+          provide: ContributorsService,
+          useValue: {
+            create: vi.fn(),
+            getAll: vi.fn(),
+            getById: vi.fn(),
+            delete: vi.fn(),
+            update: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ContributorsController>(ContributorsController);
+    service = module.get(ContributorsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('delegates to the service and wraps the result in a ContributorDto', async () => {
+      const dto: CreateContributorDto = { description: 'Core maintainer', userId: 11 };
+      service.create.mockResolvedValue(mockContributor);
+
+      const result = await controller.create(dto);
+
+      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(result).toBeInstanceOf(ContributorDto);
+      expect(result).toEqual({
+        id: 1,
+        description: 'Core maintainer',
+        createdDate: '2026-01-01T00:00:00.000Z',
+        updatedDate: '2026-01-02T00:00:00.000Z',
+        user: { id: 11, githubId: 'john-doe', firstName: 'John', lastName: 'Doe' },
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    it('maps every contributor to a ContributorDto', async () => {
+      service.getAll.mockResolvedValue([mockContributor]);
+
+      const result = await controller.getAll();
+
+      expect(service.getAll).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(ContributorDto);
+      expect(result[0].id).toBe(1);
+    });
+
+    it('returns an empty list when there are no contributors', async () => {
+      service.getAll.mockResolvedValue([]);
+
+      const result = await controller.getAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getContributor', () => {
+    it('fetches a contributor by id and wraps it in a ContributorDto', async () => {
+      service.getById.mockResolvedValue(mockContributor);
+
+      const result = await controller.getContributor(1);
+
+      expect(service.getById).toHaveBeenCalledWith(1);
+      expect(result).toBeInstanceOf(ContributorDto);
+      expect(result.id).toBe(1);
+    });
+  });
+
+  describe('delete', () => {
+    it('delegates deletion to the service', async () => {
+      service.delete.mockResolvedValue(undefined);
+
+      const result = await controller.delete(1);
+
+      expect(service.delete).toHaveBeenCalledWith(1);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('delegates the update and wraps the result in a ContributorDto', async () => {
+      const dto: UpdateContributorDto = { description: 'Updated' };
+      service.update.mockResolvedValue(mockContributor);
+
+      const result = await controller.update(1, dto);
+
+      expect(service.update).toHaveBeenCalledWith(1, dto);
+      expect(result).toBeInstanceOf(ContributorDto);
+      expect(result.id).toBe(1);
+    });
+  });
+});

--- a/nestjs/src/contributors/contributors.service.spec.ts
+++ b/nestjs/src/contributors/contributors.service.spec.ts
@@ -1,0 +1,114 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Contributor } from '@entities/contributor';
+import { ContributorsService } from './contributors.service';
+import { CreateContributorDto, UpdateContributorDto } from './dto';
+
+const mockContributor = {
+  id: 1,
+  description: 'Core maintainer',
+  user: { id: 11, githubId: 'john-doe', firstName: 'John', lastName: 'Doe' },
+} as Partial<Contributor> as Contributor;
+
+describe('ContributorsService', () => {
+  let service: ContributorsService;
+  let repository: Mocked<Repository<Contributor>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContributorsService,
+        {
+          provide: getRepositoryToken(Contributor),
+          useValue: {
+            find: vi.fn(),
+            findOneOrFail: vi.fn(),
+            save: vi.fn(),
+            update: vi.fn(),
+            softDelete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ContributorsService>(ContributorsService);
+    repository = module.get(getRepositoryToken(Contributor));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getAll', () => {
+    it('loads all contributors with the user relation', async () => {
+      const items = [mockContributor];
+      repository.find.mockResolvedValue(items);
+
+      const result = await service.getAll();
+
+      expect(repository.find).toHaveBeenCalledWith({ relations: ['user'] });
+      expect(result).toBe(items);
+    });
+  });
+
+  describe('getById', () => {
+    it('loads a single contributor with the user relation', async () => {
+      repository.findOneOrFail.mockResolvedValue(mockContributor);
+
+      const result = await service.getById(1);
+
+      expect(repository.findOneOrFail).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['user'],
+      });
+      expect(result).toBe(mockContributor);
+    });
+  });
+
+  describe('create', () => {
+    it('saves the dto and returns the reloaded contributor', async () => {
+      const dto: CreateContributorDto = { description: 'Core maintainer', userId: 11 };
+      repository.save.mockResolvedValue({ id: 1 } as Contributor);
+      repository.findOneOrFail.mockResolvedValue(mockContributor);
+
+      const result = await service.create(dto);
+
+      expect(repository.save).toHaveBeenCalledWith(dto);
+      expect(repository.findOneOrFail).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['user'],
+      });
+      expect(result).toBe(mockContributor);
+    });
+  });
+
+  describe('update', () => {
+    it('updates the contributor and returns the reloaded entity', async () => {
+      const dto: UpdateContributorDto = { description: 'Updated' };
+      repository.update.mockResolvedValue({} as never);
+      repository.findOneOrFail.mockResolvedValue(mockContributor);
+
+      const result = await service.update(1, dto);
+
+      expect(repository.update).toHaveBeenCalledWith(1, dto);
+      expect(repository.findOneOrFail).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['user'],
+      });
+      expect(result).toBe(mockContributor);
+    });
+  });
+
+  describe('delete', () => {
+    it('soft-deletes the contributor by id and resolves to undefined', async () => {
+      repository.softDelete.mockResolvedValue({} as never);
+
+      const result = await service.delete(1);
+
+      expect(repository.softDelete).toHaveBeenCalledWith(1);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/devtools/devtools.controller.spec.ts
+++ b/nestjs/src/devtools/devtools.controller.spec.ts
@@ -1,0 +1,54 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DevtoolsController } from './devtools.controller';
+import { DevtoolsService } from './devtools.service';
+
+describe('DevtoolsController', () => {
+  let controller: DevtoolsController;
+  let service: Mocked<DevtoolsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DevtoolsController],
+      providers: [
+        {
+          provide: DevtoolsService,
+          useValue: {
+            getUsers: vi.fn(),
+            getDevUserLogin: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DevtoolsController>(DevtoolsController);
+    service = module.get(DevtoolsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getDevUsers', () => {
+    it('returns the users produced by the service', async () => {
+      const users = [{ id: 1, githubId: 'john-doe', mentor: [], student: [], students: [] }];
+      service.getUsers.mockResolvedValue(users);
+
+      const result = await controller.getDevUsers();
+
+      expect(service.getUsers).toHaveBeenCalledTimes(1);
+      expect(result).toBe(users);
+    });
+  });
+
+  describe('getDevUserLogin', () => {
+    it('delegates to the service with the githubId from the route param', async () => {
+      service.getDevUserLogin.mockResolvedValue(undefined);
+
+      const result = await controller.getDevUserLogin('john-doe');
+
+      expect(service.getDevUserLogin).toHaveBeenCalledWith({ githubId: 'john-doe' });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/devtools/devtools.service.spec.ts
+++ b/nestjs/src/devtools/devtools.service.spec.ts
@@ -1,0 +1,131 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '@entities/user';
+import { DevtoolsService } from './devtools.service';
+import { ConfigService } from '../config';
+
+describe('DevtoolsService', () => {
+  let service: DevtoolsService;
+  let userRepository: Mocked<Repository<User>>;
+  let configService: Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DevtoolsService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            find: vi.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            authWithDevUser: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DevtoolsService>(DevtoolsService);
+    userRepository = module.get(getRepositoryToken(User));
+    configService = module.get(ConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getUsers', () => {
+    it('queries users with their student/mentor course relations', async () => {
+      userRepository.find.mockResolvedValue([]);
+
+      await service.getUsers();
+
+      expect(userRepository.find).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          githubId: true,
+          students: {
+            courseId: true,
+            course: { alias: true },
+          },
+          mentors: {
+            courseId: true,
+            course: { alias: true },
+          },
+        },
+        relations: ['students.course', 'mentors.course'],
+      });
+    });
+
+    it('maps mentor and student course aliases and passes through raw students', async () => {
+      const students = [{ course: { alias: 'js-2026' } }, { course: { alias: 'react-2026' } }];
+      const mentors = [{ course: { alias: 'node-2026' } }];
+      userRepository.find.mockResolvedValue([{ id: 1, githubId: 'john-doe', students, mentors }] as unknown as User[]);
+
+      const result = await service.getUsers();
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          githubId: 'john-doe',
+          mentor: ['node-2026'],
+          student: ['js-2026', 'react-2026'],
+          students,
+        },
+      ]);
+    });
+
+    it('falls back to empty arrays when mentors and students are missing', async () => {
+      userRepository.find.mockResolvedValue([
+        { id: 2, githubId: 'jane-doe', students: undefined, mentors: undefined },
+      ] as unknown as User[]);
+
+      const result = await service.getUsers();
+
+      expect(result).toEqual([
+        {
+          id: 2,
+          githubId: 'jane-doe',
+          mentor: [],
+          student: [],
+          students: undefined,
+        },
+      ]);
+    });
+
+    it('maps an undefined course alias when course relation is absent', async () => {
+      userRepository.find.mockResolvedValue([
+        {
+          id: 3,
+          githubId: 'no-course',
+          students: [{ course: undefined }],
+          mentors: [{ course: undefined }],
+        },
+      ] as unknown as User[]);
+
+      const result = await service.getUsers();
+
+      expect(result[0].mentor).toEqual([undefined]);
+      expect(result[0].student).toEqual([undefined]);
+    });
+  });
+
+  describe('getDevUserLogin', () => {
+    it('delegates to ConfigService.authWithDevUser with the githubId', async () => {
+      await service.getDevUserLogin({ githubId: 'john-doe' });
+
+      expect(configService.authWithDevUser).toHaveBeenCalledWith('john-doe');
+    });
+
+    it('resolves to undefined', async () => {
+      const result = await service.getDevUserLogin({ githubId: 'john-doe' });
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/disciplines/disciplines.controller.test.ts
+++ b/nestjs/src/disciplines/disciplines.controller.test.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DisciplinesController } from './disciplines.controller';
 import { DisciplinesService } from './disciplines.service';
-import { CreateDisciplineDto, DisciplineDto, UpdateDisciplineDto } from './dto';
+import { CreateDisciplineDto, DisciplineDto, DisciplineIdsDto, UpdateDisciplineDto } from './dto';
 
 const mockId = 1;
 
@@ -15,12 +15,14 @@ const mockDiscipline = {
 
 const mockCreate = vi.fn(() => Promise.resolve(mockDiscipline));
 const mockGetAll = vi.fn(() => Promise.resolve([mockDiscipline, mockDiscipline]));
+const mockGetByIds = vi.fn(() => Promise.resolve([mockDiscipline, mockDiscipline]));
 const mockDelete = vi.fn(() => Promise.resolve());
 const mockUpdate = vi.fn(() => Promise.resolve(mockDiscipline));
 
 const mockDisciplinesServiceFactory = vi.fn(() => ({
   create: mockCreate,
   getAll: mockGetAll,
+  getByIds: mockGetByIds,
   delete: mockDelete,
   update: mockUpdate,
 }));
@@ -54,6 +56,18 @@ describe('DisciplinesController', () => {
 
       expect(result).toEqual([new DisciplineDto(mockDiscipline), new DisciplineDto(mockDiscipline)]);
       expect(mockGetAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('getByIds', () => {
+    it('should get disciplines by ids', async () => {
+      const mockDisciplineIdsDto = new DisciplineIdsDto();
+      mockDisciplineIdsDto.ids = [1, 2];
+
+      const result = await controller.getByIds(mockDisciplineIdsDto);
+
+      expect(result).toEqual([new DisciplineDto(mockDiscipline), new DisciplineDto(mockDiscipline)]);
+      expect(mockGetByIds).toHaveBeenCalledWith(mockDisciplineIdsDto.ids);
     });
   });
 

--- a/nestjs/src/discord-servers/discord-servers.controller.spec.ts
+++ b/nestjs/src/discord-servers/discord-servers.controller.spec.ts
@@ -1,0 +1,152 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscordServer } from '@entities/discordServer';
+import { IdNameDto } from 'src/core/dto';
+import { DiscordServersController } from './discord-servers.controller';
+import { DiscordServersService } from './discord-servers.service';
+import { DiscordServerDto, CreateDiscordServerDto, UpdateDiscordServerDto } from './dto';
+
+const mockDiscordServer = {
+  id: 1,
+  name: 'RS School',
+  gratitudeUrl: 'https://discord.gg/gratitude',
+  mentorsChatUrl: 'https://discord.gg/mentors',
+  createdDate: 1700000000000,
+  updatedDate: 1700000001000,
+} as Partial<DiscordServer> as DiscordServer;
+
+describe('DiscordServersController', () => {
+  let controller: DiscordServersController;
+  let service: Mocked<DiscordServersService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DiscordServersController],
+      providers: [
+        {
+          provide: DiscordServersService,
+          useValue: {
+            create: vi.fn(),
+            getAll: vi.fn(),
+            getById: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DiscordServersController>(DiscordServersController);
+    service = module.get(DiscordServersService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('delegates to the service and wraps the result in a DiscordServerDto', async () => {
+      const dto: CreateDiscordServerDto = {
+        name: 'RS School',
+        gratitudeUrl: 'https://discord.gg/gratitude',
+        mentorsChatUrl: 'https://discord.gg/mentors',
+      };
+      service.create.mockResolvedValue(mockDiscordServer);
+
+      const result = await controller.create(dto);
+
+      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(result).toBeInstanceOf(DiscordServerDto);
+      expect(result).toEqual({
+        id: 1,
+        name: 'RS School',
+        gratitudeUrl: 'https://discord.gg/gratitude',
+        mentorsChatUrl: 'https://discord.gg/mentors',
+        createdDate: 1700000000000,
+        updatedDate: 1700000001000,
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    it('maps every server to a DiscordServerDto', async () => {
+      service.getAll.mockResolvedValue([mockDiscordServer]);
+
+      const result = await controller.getAll();
+
+      expect(service.getAll).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(DiscordServerDto);
+      expect(result[0].id).toBe(1);
+    });
+
+    it('returns an empty list when there are no servers', async () => {
+      service.getAll.mockResolvedValue([]);
+
+      const result = await controller.getAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getReducedAll', () => {
+    it('maps every server to an IdNameDto with only id and name', async () => {
+      service.getAll.mockResolvedValue([mockDiscordServer]);
+
+      const result = await controller.getReducedAll();
+
+      expect(service.getAll).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(IdNameDto);
+      expect(result[0]).toEqual({ id: 1, name: 'RS School' });
+    });
+  });
+
+  describe('getInviteLinkById', () => {
+    it('returns the mentorsChatUrl of the requested server', async () => {
+      service.getById.mockResolvedValue(mockDiscordServer);
+
+      const result = await controller.getInviteLinkById(7, 1);
+
+      expect(service.getById).toHaveBeenCalledWith(1);
+      expect(result).toBe('https://discord.gg/mentors');
+    });
+
+    it('returns undefined when the server is not found', async () => {
+      service.getById.mockResolvedValue(null);
+
+      const result = await controller.getInviteLinkById(7, 99);
+
+      expect(service.getById).toHaveBeenCalledWith(99);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('delegates the update and wraps the result in a DiscordServerDto', async () => {
+      const dto: UpdateDiscordServerDto = {
+        name: 'RS School Updated',
+        gratitudeUrl: 'https://discord.gg/gratitude',
+        mentorsChatUrl: 'https://discord.gg/mentors',
+      };
+      service.update.mockResolvedValue(mockDiscordServer);
+
+      const result = await controller.update(1, dto);
+
+      expect(service.update).toHaveBeenCalledWith(1, dto);
+      expect(result).toBeInstanceOf(DiscordServerDto);
+      expect(result.id).toBe(1);
+    });
+  });
+
+  describe('delete', () => {
+    it('delegates deletion to the service', async () => {
+      service.delete.mockResolvedValue(undefined);
+
+      const result = await controller.delete(1);
+
+      expect(service.delete).toHaveBeenCalledWith(1);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/discord-servers/discord-servers.service.spec.ts
+++ b/nestjs/src/discord-servers/discord-servers.service.spec.ts
@@ -1,0 +1,117 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DiscordServer } from '@entities/discordServer';
+import { DiscordServersService } from './discord-servers.service';
+import { CreateDiscordServerDto, UpdateDiscordServerDto } from './dto';
+
+const mockDiscordServer = {
+  id: 1,
+  name: 'RS School',
+  gratitudeUrl: 'https://discord.gg/gratitude',
+  mentorsChatUrl: 'https://discord.gg/mentors',
+} as Partial<DiscordServer> as DiscordServer;
+
+describe('DiscordServersService', () => {
+  let service: DiscordServersService;
+  let repository: Mocked<Repository<DiscordServer>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DiscordServersService,
+        {
+          provide: getRepositoryToken(DiscordServer),
+          useValue: {
+            find: vi.fn(),
+            findOneBy: vi.fn(),
+            save: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DiscordServersService>(DiscordServersService);
+    repository = module.get(getRepositoryToken(DiscordServer));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getAll', () => {
+    it('returns all discord servers from the repository', () => {
+      const items = [mockDiscordServer];
+      repository.find.mockReturnValue(items as never);
+
+      const result = service.getAll();
+
+      expect(repository.find).toHaveBeenCalledWith();
+      expect(result).toBe(items as never);
+    });
+  });
+
+  describe('getById', () => {
+    it('looks up a discord server by id', async () => {
+      repository.findOneBy.mockResolvedValue(mockDiscordServer);
+
+      const result = await service.getById(1);
+
+      expect(repository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+      expect(result).toBe(mockDiscordServer);
+    });
+
+    it('returns null when no server matches', async () => {
+      repository.findOneBy.mockResolvedValue(null);
+
+      const result = await service.getById(99);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('saves the provided dto', () => {
+      const dto: CreateDiscordServerDto = {
+        name: 'RS School',
+        gratitudeUrl: 'https://discord.gg/gratitude',
+        mentorsChatUrl: 'https://discord.gg/mentors',
+      };
+      repository.save.mockReturnValue(mockDiscordServer as never);
+
+      const result = service.create(dto);
+
+      expect(repository.save).toHaveBeenCalledWith(dto);
+      expect(result).toBe(mockDiscordServer as never);
+    });
+  });
+
+  describe('update', () => {
+    it('saves the dto merged with the id', () => {
+      const dto: UpdateDiscordServerDto = {
+        name: 'RS School Updated',
+        gratitudeUrl: 'https://discord.gg/gratitude',
+        mentorsChatUrl: 'https://discord.gg/mentors',
+      };
+      repository.save.mockReturnValue(mockDiscordServer as never);
+
+      const result = service.update(5, dto);
+
+      expect(repository.save).toHaveBeenCalledWith({ id: 5, ...dto });
+      expect(result).toBe(mockDiscordServer as never);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the server by id and resolves to undefined', async () => {
+      repository.delete.mockResolvedValue({} as never);
+
+      const result = await service.delete(1);
+
+      expect(repository.delete).toHaveBeenCalledWith(1);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/events/events.controller.spec.ts
+++ b/nestjs/src/events/events.controller.spec.ts
@@ -1,0 +1,80 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Event } from '@entities/event';
+import { EventsController } from './events.controller';
+import { EventsService } from './events.service';
+import { CreateEventDto, EventDto, UpdateEventDto } from './dto';
+
+const mockId = 1;
+
+const mockEvent = {
+  id: mockId,
+  name: 'Event 1',
+  descriptionUrl: 'http://example.com',
+  description: 'desc',
+  type: 'lecture',
+  discipline: null,
+} as Partial<Event> as Event;
+
+const mockFindAll = vi.fn(() => Promise.resolve([mockEvent, mockEvent]));
+const mockCreate = vi.fn(() => Promise.resolve(mockEvent));
+const mockUpdate = vi.fn(() => Promise.resolve(mockEvent));
+const mockRemove = vi.fn(() => Promise.resolve());
+
+const mockEventsServiceFactory = vi.fn(() => ({
+  findAll: mockFindAll,
+  create: mockCreate,
+  update: mockUpdate,
+  remove: mockRemove,
+}));
+
+describe('EventsController', () => {
+  let controller: EventsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventsController],
+      providers: [{ provide: EventsService, useFactory: mockEventsServiceFactory }],
+    }).compile();
+
+    controller = module.get<EventsController>(EventsController);
+  });
+
+  describe('findAll', () => {
+    it('should get all events mapped to EventDto', async () => {
+      const result = await controller.findAll();
+
+      expect(mockFindAll).toHaveBeenCalled();
+      expect(result).toEqual([new EventDto(mockEvent), new EventDto(mockEvent)]);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new event and wrap it in an EventDto', async () => {
+      const mockCreateEventDto = new CreateEventDto();
+
+      const result = await controller.create(mockCreateEventDto);
+
+      expect(mockCreate).toHaveBeenCalledWith(mockCreateEventDto);
+      expect(result).toEqual(new EventDto(mockEvent));
+    });
+  });
+
+  describe('update', () => {
+    it('should update an event and wrap it in an EventDto', async () => {
+      const mockUpdateEventDto = new UpdateEventDto();
+
+      const result = await controller.update(mockId, mockUpdateEventDto);
+
+      expect(mockUpdate).toHaveBeenCalledWith(mockId, mockUpdateEventDto);
+      expect(result).toEqual(new EventDto(mockEvent));
+    });
+  });
+
+  describe('delete', () => {
+    it('should remove an event by id', async () => {
+      await controller.delete(mockId);
+
+      expect(mockRemove).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/events/events.service.spec.ts
+++ b/nestjs/src/events/events.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Mocked } from 'vitest';
+import { Event } from '@entities/event';
+import { EventsService } from './events.service';
+import { CreateEventDto, UpdateEventDto } from './dto';
+
+const mockId = 1;
+const mockEvent = { id: mockId, name: 'Event 1' } as Partial<Event> as Event;
+const mockFindResponse = [mockEvent, mockEvent];
+
+describe('EventsService', () => {
+  let service: EventsService;
+  let repository: Mocked<Repository<Event>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventsService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: {
+            find: vi.fn(),
+            findOneByOrFail: vi.fn(),
+            save: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<EventsService>(EventsService);
+    repository = module.get(getRepositoryToken(Event));
+  });
+
+  describe('findAll', () => {
+    it('should return all events ordered by updatedDate DESC with discipline relation', async () => {
+      repository.find.mockResolvedValue(mockFindResponse);
+
+      const result = await service.findAll();
+
+      expect(repository.find).toHaveBeenCalledWith({
+        order: { updatedDate: 'DESC' },
+        relations: ['discipline'],
+      });
+      expect(result).toEqual(mockFindResponse);
+    });
+
+    it('should return an empty array when there are no events', async () => {
+      repository.find.mockResolvedValue([]);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('create', () => {
+    it('should save and return the event', async () => {
+      const mockData = { name: 'Event 1' } as CreateEventDto;
+      repository.save.mockResolvedValue(mockEvent);
+
+      const result = await service.create(mockData);
+
+      expect(repository.save).toHaveBeenCalledWith(mockData);
+      expect(result).toEqual(mockEvent);
+    });
+  });
+
+  describe('update', () => {
+    it('should update the event and return the freshly fetched entity', async () => {
+      const mockData = { name: 'Updated' } as UpdateEventDto;
+      repository.findOneByOrFail.mockResolvedValue(mockEvent);
+
+      const result = await service.update(mockId, mockData);
+
+      expect(repository.update).toHaveBeenCalledWith(mockId, mockData);
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: mockId });
+      expect(result).toEqual(mockEvent);
+    });
+  });
+
+  describe('remove', () => {
+    it('should hard-delete the event by id', async () => {
+      await service.remove(mockId);
+
+      expect(repository.delete).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/listeners/course.listener.spec.ts
+++ b/nestjs/src/listeners/course.listener.spec.ts
@@ -1,0 +1,187 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { Course } from '@entities/course';
+import { MoreThanOrEqual, Not } from 'typeorm';
+import { ExportCourseDto } from 'src/courses/dto';
+import { ConfigService } from '../config';
+import { CourseListener } from './course.listener';
+
+// Mock the AWS SDK so the S3 client constructed in the listener ctor is inert
+// and we control getObject/putObject.
+const mockGetObject = vi.fn();
+const mockPutObject = vi.fn();
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3: class {
+    getObject = mockGetObject;
+    putObject = mockPutObject;
+  },
+}));
+
+const buildCourse = (overrides: Partial<Course> = {}): Course =>
+  ({
+    id: 1,
+    name: 'RS 2024',
+    fullName: 'Rolling Scopes 2024',
+    alias: 'rs2024',
+    description: 'desc',
+    descriptionUrl: 'http://x',
+    startDate: new Date('2024-01-01'),
+    endDate: new Date('2024-06-01'),
+    registrationEndDate: new Date('2024-02-01'),
+    personalMentoringStartDate: null,
+    personalMentoringEndDate: null,
+    wearecommunityUrl: null,
+    discipline: { id: 2, name: 'JS' },
+    ...overrides,
+  }) as Partial<Course> as Course;
+
+describe('CourseListener', () => {
+  let listener: CourseListener;
+  const repository = { find: vi.fn() };
+  const httpService = { post: vi.fn() };
+  let config: {
+    awsClient: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } };
+    buckets: { cdn: string };
+    env: 'prod' | 'staging' | 'local';
+    auth: { github: { integrationSiteToken: string } };
+  };
+
+  const buildListener = async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CourseListener,
+        { provide: getRepositoryToken(Course), useValue: repository },
+        { provide: HttpService, useValue: httpService },
+        { provide: ConfigService, useValue: config },
+      ],
+    }).compile();
+    return module.get(CourseListener);
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    config = {
+      awsClient: { region: 'eu-central-1', credentials: { accessKeyId: 'x', secretAccessKey: 'y' } },
+      buckets: { cdn: 'cdn.rs.school' },
+      env: 'prod',
+      auth: { github: { integrationSiteToken: 'token-123' } },
+    };
+    listener = await buildListener();
+  });
+
+  describe('findExportCourses (via handleCoursesChange)', () => {
+    it('queries only open, registration-open, non-test, non-invite-only courses with discipline', async () => {
+      repository.find.mockResolvedValue([]);
+      // env is prod but stored===serialized → no S3 write, no trigger
+      mockGetObject.mockResolvedValue({ Body: { transformToString: () => Promise.resolve('[]') } });
+
+      await listener.handleCoursesChange();
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: {
+          completed: false,
+          registrationEndDate: MoreThanOrEqual(expect.any(Date)),
+          alias: Not('test-course'),
+          inviteOnly: Not(true),
+        },
+        relations: ['discipline'],
+      });
+    });
+  });
+
+  describe('exportCoursesToS3Conditionally', () => {
+    it('does not export or trigger when env is not prod', async () => {
+      config.env = 'staging';
+      listener = await buildListener();
+      repository.find.mockResolvedValue([buildCourse()]);
+
+      await listener.handleCoursesChange();
+
+      expect(mockGetObject).not.toHaveBeenCalled();
+      expect(mockPutObject).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('writes to S3 and triggers a site update when the serialized data changed', async () => {
+      const course = buildCourse();
+      repository.find.mockResolvedValue([course]);
+      mockGetObject.mockResolvedValue({ Body: { transformToString: () => Promise.resolve('stale') } });
+      mockPutObject.mockResolvedValue({});
+      httpService.post.mockReturnValue(of({ data: {} }));
+
+      await listener.handleCoursesChange();
+
+      expect(mockPutObject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Bucket: 'cdn.rs.school',
+          Key: 'app/courses.json',
+          ContentType: 'application/json',
+          CacheControl: 'max-age=30',
+        }),
+      );
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://api.github.com/repos/rolling-scopes/site/dispatches',
+        { event_type: 'course.updated' },
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer token-123' }),
+        }),
+      );
+    });
+
+    it('does not write or trigger when the stored data is identical', async () => {
+      const course = buildCourse();
+      repository.find.mockResolvedValue([course]);
+      // Stored value is exactly what the listener will serialize from ExportCourseDto(course)
+      const serialized = JSON.stringify([new ExportCourseDto(course)]);
+      mockGetObject.mockResolvedValue({ Body: { transformToString: () => Promise.resolve(serialized) } });
+
+      await listener.handleCoursesChange();
+
+      expect(mockPutObject).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('treats a getObject failure as no stored data and writes + triggers', async () => {
+      repository.find.mockResolvedValue([buildCourse()]);
+      mockGetObject.mockRejectedValue(new Error('NoSuchKey'));
+      mockPutObject.mockResolvedValue({});
+      httpService.post.mockReturnValue(of({ data: {} }));
+
+      await listener.handleCoursesChange();
+
+      // stored is undefined !== serialized → writes
+      expect(mockPutObject).toHaveBeenCalled();
+      expect(httpService.post).toHaveBeenCalled();
+    });
+  });
+
+  describe('triggerSiteUpdate', () => {
+    it('warns and does not POST when there is no integration site token', async () => {
+      config.auth.github.integrationSiteToken = '';
+      listener = await buildListener();
+      const warnSpy = vi.spyOn((listener as unknown as { logger: { warn: () => void } }).logger, 'warn');
+      repository.find.mockResolvedValue([buildCourse()]);
+      mockGetObject.mockResolvedValue({ Body: { transformToString: () => Promise.resolve('stale') } });
+      mockPutObject.mockResolvedValue({});
+
+      await listener.handleCoursesChange();
+
+      expect(warnSpy).toHaveBeenCalledWith('No integration site token');
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('logs an error when the dispatch request fails', async () => {
+      repository.find.mockResolvedValue([buildCourse()]);
+      mockGetObject.mockResolvedValue({ Body: { transformToString: () => Promise.resolve('stale') } });
+      mockPutObject.mockResolvedValue({});
+      httpService.post.mockReturnValue(throwError(() => new Error('dispatch failed')));
+      const errorSpy = vi.spyOn((listener as unknown as { logger: { error: () => void } }).logger, 'error');
+
+      await listener.handleCoursesChange();
+
+      expect(errorSpy).toHaveBeenCalledWith('Error dispatching course event to the site repository', 'dispatch failed');
+    });
+  });
+});

--- a/nestjs/src/notifications/notifications.controller.spec.ts
+++ b/nestjs/src/notifications/notifications.controller.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Notification } from '@entities/notification';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { UpdateNotificationDto } from './dto/update-notification.dto';
+
+const mockNotification = {
+  id: 'taskGrade',
+  name: 'Task grade',
+  enabled: true,
+  type: 'event',
+  channels: [{ channelId: 'email', template: { subject: 's', body: 'b' } }],
+  parent: { id: 'messages' },
+} as Partial<Notification> as Notification;
+
+const mockDto = {
+  id: 'taskGrade',
+  name: 'Task grade',
+  enabled: true,
+  type: 'event',
+  channels: [],
+} as Partial<UpdateNotificationDto> as UpdateNotificationDto;
+
+describe('NotificationsController', () => {
+  let controller: NotificationsController;
+  const service = {
+    getNotifications: vi.fn(),
+    saveNotification: vi.fn(),
+    createNotification: vi.fn(),
+    deleteNotification: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    Object.values(service).forEach(fn => fn.mockReset());
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [{ provide: NotificationsService, useValue: service }],
+    }).compile();
+
+    controller = module.get(NotificationsController);
+  });
+
+  describe('getNotifications', () => {
+    it('maps service results to NotificationDto instances', async () => {
+      service.getNotifications.mockResolvedValue([mockNotification]);
+
+      const result = await controller.getNotifications();
+
+      expect(service.getNotifications).toHaveBeenCalledWith();
+      expect(result).toEqual([
+        {
+          id: 'taskGrade',
+          name: 'Task grade',
+          enabled: true,
+          type: 'event',
+          channels: [{ channelId: 'email', template: { subject: 's', body: 'b' } }],
+          parentId: 'messages',
+        },
+      ]);
+    });
+
+    it('returns an empty array when there are no notifications', async () => {
+      service.getNotifications.mockResolvedValue([]);
+
+      const result = await controller.getNotifications();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('updateNotification', () => {
+    it('saves and wraps the result in a NotificationDto', async () => {
+      service.saveNotification.mockResolvedValue(mockNotification);
+
+      const result = await controller.updateNotification(mockDto);
+
+      expect(service.saveNotification).toHaveBeenCalledWith(mockDto);
+      expect(result).toMatchObject({ id: 'taskGrade', parentId: 'messages' });
+    });
+  });
+
+  describe('createNotification', () => {
+    it('creates and wraps the result in a NotificationDto', async () => {
+      service.createNotification.mockResolvedValue(mockNotification);
+
+      const result = await controller.createNotification(mockDto);
+
+      expect(service.createNotification).toHaveBeenCalledWith(mockDto);
+      expect(result).toMatchObject({ id: 'taskGrade' });
+    });
+  });
+
+  describe('deleteNotification', () => {
+    it('delegates to the service and returns nothing', async () => {
+      service.deleteNotification.mockResolvedValue(undefined);
+
+      const result = await controller.deleteNotification('taskGrade');
+
+      expect(service.deleteNotification).toHaveBeenCalledWith('taskGrade');
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/notifications/notifications.service.spec.ts
+++ b/nestjs/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,319 @@
+import type { Mocked } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { of } from 'rxjs';
+import { HttpService } from '@nestjs/axios';
+import { Notification } from '@entities/notification';
+import { NotificationChannelSettings } from '@entities/notificationChannelSettings';
+import { ConfigService } from '../config';
+import { NotificationsService } from './notifications.service';
+
+const mockNotification = {
+  id: 'taskGrade',
+  name: 'Task grade',
+  enabled: true,
+} as Partial<Notification> as Notification;
+
+const emailChannelSettings = {
+  channelId: 'email',
+  notificationId: 'taskGrade',
+  template: { subject: 'Subject {{name}}', body: 'Hello {{name}}' },
+} as Partial<NotificationChannelSettings> as NotificationChannelSettings;
+
+const telegramChannelSettings = {
+  channelId: 'telegram',
+  notificationId: 'taskGrade',
+  template: { body: 'Hello {{name}}' },
+} as Partial<NotificationChannelSettings> as NotificationChannelSettings;
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+  let notificationsRepository: Mocked<{
+    findOneBy: ReturnType<typeof vi.fn>;
+    find: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  }>;
+  let channelSettingsRepository: Mocked<{ findOne: ReturnType<typeof vi.fn> }>;
+  let httpService: Mocked<{ post: ReturnType<typeof vi.fn> }>;
+  let configService: { isDev: boolean; awsServices: { restApiUrl: string; restApiKey: string } };
+
+  beforeEach(async () => {
+    const notificationsRepoValue = {
+      findOneBy: vi.fn(),
+      find: vi.fn(),
+      findOne: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn(),
+    };
+    const channelSettingsRepoValue = { findOne: vi.fn() };
+    const httpServiceValue = { post: vi.fn() };
+    configService = {
+      isDev: false,
+      awsServices: { restApiUrl: 'https://api.example.com', restApiKey: 'secret-key' },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        { provide: getRepositoryToken(Notification), useValue: notificationsRepoValue },
+        { provide: getRepositoryToken(NotificationChannelSettings), useValue: channelSettingsRepoValue },
+        { provide: ConfigService, useValue: configService },
+        { provide: HttpService, useValue: httpServiceValue },
+      ],
+    }).compile();
+
+    service = module.get(NotificationsService);
+    notificationsRepository = module.get(getRepositoryToken(Notification));
+    channelSettingsRepository = module.get(getRepositoryToken(NotificationChannelSettings));
+    httpService = module.get(HttpService);
+  });
+
+  describe('getNotification', () => {
+    it('finds a notification by id', async () => {
+      notificationsRepository.findOneBy.mockResolvedValue(mockNotification);
+
+      const result = await service.getNotification('taskGrade');
+
+      expect(notificationsRepository.findOneBy).toHaveBeenCalledWith({ id: 'taskGrade' });
+      expect(result).toBe(mockNotification);
+    });
+  });
+
+  describe('getNotifications', () => {
+    it('lists notifications with relations ordered by name', async () => {
+      notificationsRepository.find.mockResolvedValue([mockNotification]);
+
+      const result = await service.getNotifications();
+
+      expect(notificationsRepository.find).toHaveBeenCalledWith({
+        relations: ['channels', 'parent'],
+        order: { name: 'ASC' },
+      });
+      expect(result).toEqual([mockNotification]);
+    });
+  });
+
+  describe('saveNotification', () => {
+    it('maps a parentId to a parent relation object', async () => {
+      notificationsRepository.save.mockResolvedValue(mockNotification);
+
+      await service.saveNotification({
+        id: 'taskGrade',
+        name: 'Task grade',
+        enabled: true,
+        channels: [],
+        type: 'event' as never,
+        parentId: 'messages' as never,
+      });
+
+      expect(notificationsRepository.save).toHaveBeenCalledWith({
+        id: 'taskGrade',
+        name: 'Task grade',
+        enabled: true,
+        channels: [],
+        type: 'event',
+        parent: { id: 'messages' },
+      });
+    });
+
+    it('sets parent to null when there is no parentId', async () => {
+      notificationsRepository.save.mockResolvedValue(mockNotification);
+
+      await service.saveNotification({
+        id: 'taskGrade',
+        name: 'Task grade',
+        enabled: true,
+        channels: [],
+        type: 'event' as never,
+      });
+
+      expect(notificationsRepository.save).toHaveBeenCalledWith({
+        id: 'taskGrade',
+        name: 'Task grade',
+        enabled: true,
+        channels: [],
+        type: 'event',
+        parent: null,
+      });
+    });
+  });
+
+  describe('createNotification', () => {
+    it('saves the notification when it does not already exist', async () => {
+      notificationsRepository.findOne.mockResolvedValue(null);
+      notificationsRepository.save.mockResolvedValue(mockNotification);
+
+      const dto = {
+        id: 'taskGrade',
+        name: 'Task grade',
+        enabled: true,
+        channels: [],
+        type: 'event' as never,
+      };
+      const result = await service.createNotification(dto);
+
+      expect(notificationsRepository.findOne).toHaveBeenCalledWith({ where: { id: 'taskGrade' } });
+      expect(notificationsRepository.save).toHaveBeenCalledWith(dto);
+      expect(result).toBe(mockNotification);
+    });
+
+    it('throws a BadRequestException when the notification already exists', async () => {
+      notificationsRepository.findOne.mockResolvedValue(mockNotification);
+
+      await expect(
+        service.createNotification({
+          id: 'taskGrade',
+          name: 'Task grade',
+          enabled: true,
+          channels: [],
+          type: 'event' as never,
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(notificationsRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteNotification', () => {
+    it('deletes by id', async () => {
+      notificationsRepository.delete.mockResolvedValue({} as never);
+
+      await service.deleteNotification('taskGrade');
+
+      expect(notificationsRepository.delete).toHaveBeenCalledWith({ id: 'taskGrade' });
+    });
+  });
+
+  describe('buildChannelMessage', () => {
+    it('returns undefined when externalId is missing', () => {
+      const result = service.buildChannelMessage({ ...emailChannelSettings, externalId: undefined }, { name: 'John' });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the template is missing', () => {
+      const result = service.buildChannelMessage(
+        { ...emailChannelSettings, template: undefined as never, externalId: 'john@x.com' },
+        { name: 'John' },
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('compiles a non-email channel body via Handlebars without wrapping in the email template', () => {
+      const result = service.buildChannelMessage({ ...telegramChannelSettings, externalId: '12345' }, { name: 'John' });
+
+      expect(result).toEqual({
+        channelId: 'telegram',
+        to: '12345',
+        template: { body: 'Hello John' },
+      });
+    });
+
+    it('wraps email bodies in the email template and copies the subject', () => {
+      const result = service.buildChannelMessage(
+        { ...emailChannelSettings, externalId: 'john@x.com' },
+        { name: 'John' },
+      );
+
+      expect(result?.channelId).toBe('email');
+      expect(result?.to).toBe('john@x.com');
+      // The compiled email body is wrapped in the HTML email template
+      expect(result?.template.body).toContain('Hello John');
+      expect(result?.template.body).toContain('<!DOCTYPE html>');
+      // Subject is copied verbatim from the EmailTemplate and is NOT run through Handlebars
+      expect((result?.template as { subject: string }).subject).toBe('Subject {{name}}');
+    });
+
+    it('escapes HTML by default and preserves it when noEscape is set', () => {
+      const escaped = service.buildChannelMessage(
+        { ...telegramChannelSettings, externalId: '1', noEscape: false },
+        { name: '<b>' },
+      );
+      const raw = service.buildChannelMessage(
+        { ...telegramChannelSettings, externalId: '1', noEscape: true },
+        { name: '<b>' },
+      );
+
+      expect(escaped?.template.body).toBe('Hello &lt;b&gt;');
+      expect(raw?.template.body).toBe('Hello <b>');
+    });
+  });
+
+  describe('publishNotification', () => {
+    const payload = {
+      notificationId: 'taskGrade' as const,
+      channelId: ['email' as const],
+      userId: 1,
+      data: {},
+    };
+
+    it('is a no-op in dev mode', async () => {
+      configService.isDev = true;
+
+      await service.publishNotification(payload);
+
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('posts to the AWS notification endpoint with the api key header', async () => {
+      configService.isDev = false;
+      httpService.post.mockReturnValue(of({ data: {} }));
+
+      await service.publishNotification(payload);
+
+      expect(httpService.post).toHaveBeenCalledWith('https://api.example.com/v2/notification', payload, {
+        headers: { 'x-api-key': 'secret-key' },
+      });
+    });
+  });
+
+  describe('sendMessage', () => {
+    const baseMessage = {
+      notificationId: 'taskGrade' as const,
+      userId: 1,
+      data: { name: 'John' },
+      channelId: 'email' as const,
+      channelValue: 'john@x.com',
+    };
+
+    it('builds and publishes a message when channel settings exist', async () => {
+      channelSettingsRepository.findOne.mockResolvedValue(emailChannelSettings);
+      const publishSpy = vi.spyOn(service, 'publishNotification').mockResolvedValue(undefined);
+
+      await service.sendMessage(baseMessage);
+
+      expect(channelSettingsRepository.findOne).toHaveBeenCalledWith({
+        where: { notificationId: 'taskGrade', channelId: 'email' },
+      });
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notificationId: 'taskGrade',
+          channelId: ['email'],
+          userId: 1,
+          data: expect.objectContaining({
+            email: expect.objectContaining({ to: 'john@x.com' }),
+          }),
+        }),
+      );
+    });
+
+    it('logs an error and does not publish when there are no channel settings', async () => {
+      channelSettingsRepository.findOne.mockResolvedValue(null);
+      const publishSpy = vi.spyOn(service, 'publishNotification');
+
+      await service.sendMessage(baseMessage);
+
+      expect(publishSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not publish when the message cannot be built (no channelValue)', async () => {
+      channelSettingsRepository.findOne.mockResolvedValue(emailChannelSettings);
+      const publishSpy = vi.spyOn(service, 'publishNotification');
+
+      await service.sendMessage({ ...baseMessage, channelValue: '' });
+
+      expect(publishSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/nestjs/src/opportunities/opportunities.controller.spec.ts
+++ b/nestjs/src/opportunities/opportunities.controller.spec.ts
@@ -1,0 +1,246 @@
+import type { Mocked } from 'vitest';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Resume } from '@entities/resume';
+import { Student } from '@entities/student';
+import { Feedback } from '@entities/feedback';
+import { StudentFeedback } from '@entities/student-feedback';
+import { CurrentRequest } from 'src/auth';
+import { OpportunitiesController } from './opportunities.controller';
+import { OpportunitiesService } from './opportunities.service';
+import { ConsentDto } from './dto/consent.dto';
+import { GiveConsentDto } from './dto/give-consent-dto';
+import { StatusDto } from './dto/status.dto';
+import { VisibilityDto } from './dto/visibility.dto';
+import { ResumeDto } from './dto/resume.dto';
+import { ApplicantResumeDto } from './dto/applicant-resume.dto';
+
+const mockResume = {
+  uuid: 'uuid-1',
+  userId: 7,
+  visibleCourses: [],
+  avatarLink: null,
+  desiredPosition: 'FE',
+  email: null,
+  englishLevel: null,
+  expires: 123,
+  fullTime: true,
+  githubUsername: 'john',
+  linkedin: null,
+  locations: null,
+  militaryService: null,
+  name: 'John',
+  notes: null,
+  phone: null,
+  selfIntroLink: null,
+  skype: null,
+  startFrom: null,
+  telegram: null,
+  website: null,
+} as Partial<Resume> as Resume;
+
+const resumeData = {
+  resume: mockResume,
+  students: [] as Student[],
+  gratitudes: [] as Feedback[],
+  feedbacks: [] as StudentFeedback[],
+};
+
+const makeReq = (githubId: string) => ({ user: { githubId } }) as CurrentRequest;
+
+describe('OpportunitiesController', () => {
+  let controller: OpportunitiesController;
+  let service: Mocked<OpportunitiesService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OpportunitiesController],
+      providers: [
+        {
+          provide: OpportunitiesService,
+          useValue: {
+            getResumeByGithubId: vi.fn(),
+            getResumeByUuid: vi.fn(),
+            saveResume: vi.fn(),
+            getConsent: vi.fn(),
+            createConsent: vi.fn(),
+            deleteConsent: vi.fn(),
+            prolong: vi.fn(),
+            setVisibility: vi.fn(),
+            getApplicantResumes: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(OpportunitiesController);
+    service = module.get(OpportunitiesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getResume', () => {
+    it('throws ForbiddenException when accessing another user resume', async () => {
+      await expect(controller.getResume(makeReq('owner'), 'someone-else')).rejects.toThrow(ForbiddenException);
+      expect(service.getResumeByGithubId).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when service returns null', async () => {
+      service.getResumeByGithubId.mockResolvedValue(null);
+
+      await expect(controller.getResume(makeReq('john'), 'john')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns a ResumeDto built from service data', async () => {
+      service.getResumeByGithubId.mockResolvedValue(resumeData);
+
+      const result = await controller.getResume(makeReq('john'), 'john');
+
+      expect(service.getResumeByGithubId).toHaveBeenCalledWith('john');
+      expect(result).toBeInstanceOf(ResumeDto);
+      expect(result.uuid).toBe('uuid-1');
+    });
+  });
+
+  describe('saveResume', () => {
+    it('throws ForbiddenException for a foreign githubId', async () => {
+      await expect(controller.saveResume(makeReq('owner'), 'other', {} as never)).rejects.toThrow(ForbiddenException);
+      expect(service.saveResume).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when service returns null', async () => {
+      service.saveResume.mockResolvedValue(null);
+
+      await expect(controller.saveResume(makeReq('john'), 'john', {} as never)).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns the saved resume', async () => {
+      const dto = { name: 'Updated' } as never;
+      service.saveResume.mockResolvedValue(mockResume);
+
+      const result = await controller.saveResume(makeReq('john'), 'john', dto);
+
+      expect(service.saveResume).toHaveBeenCalledWith('john', dto);
+      expect(result).toBe(mockResume);
+    });
+  });
+
+  describe('getConsent', () => {
+    it('returns a ConsentDto wrapping the service value', async () => {
+      service.getConsent.mockResolvedValue(true);
+
+      const result = await controller.getConsent(makeReq('john'));
+
+      expect(service.getConsent).toHaveBeenCalledWith('john');
+      expect(result).toBeInstanceOf(ConsentDto);
+      expect(result.consent).toBe(true);
+    });
+
+    it('returns ConsentDto(false) when consent is false', async () => {
+      service.getConsent.mockResolvedValue(false);
+
+      const result = await controller.getConsent(makeReq('john'));
+
+      expect(result.consent).toBe(false);
+    });
+  });
+
+  describe('createConsent', () => {
+    it('returns a GiveConsentDto with consent and expires', async () => {
+      service.createConsent.mockResolvedValue({ consent: true, expires: 999 });
+
+      const result = await controller.createConsent(makeReq('john'));
+
+      expect(service.createConsent).toHaveBeenCalledWith('john');
+      expect(result).toBeInstanceOf(GiveConsentDto);
+      expect(result).toEqual({ consent: true, expires: 999 });
+    });
+  });
+
+  describe('deleteConsent', () => {
+    it('returns a ConsentDto with the deletion result', async () => {
+      service.deleteConsent.mockResolvedValue(false);
+
+      const result = await controller.deleteConsent(makeReq('john'));
+
+      expect(service.deleteConsent).toHaveBeenCalledWith('john');
+      expect(result).toBeInstanceOf(ConsentDto);
+      expect(result.consent).toBe(false);
+    });
+  });
+
+  describe('prolong', () => {
+    it('returns a StatusDto with new expiration', async () => {
+      service.prolong.mockResolvedValue(555);
+
+      const result = await controller.prolong(makeReq('john'));
+
+      expect(service.prolong).toHaveBeenCalledWith('john');
+      expect(result).toBeInstanceOf(StatusDto);
+      expect(result.expires).toBe(555);
+    });
+  });
+
+  describe('setVisibility', () => {
+    it('inverts isHidden before calling the service and wraps the result', async () => {
+      service.setVisibility.mockResolvedValue(true);
+
+      const result = await controller.setVisibility(makeReq('john'), false);
+
+      // controller passes !isHidden as the "isVisible" flag
+      expect(service.setVisibility).toHaveBeenCalledWith('john', true);
+      expect(result).toBeInstanceOf(VisibilityDto);
+      expect(result.isHidden).toBe(true);
+    });
+
+    it('passes isVisible=false when isHidden=true', async () => {
+      service.setVisibility.mockResolvedValue(false);
+
+      const result = await controller.setVisibility(makeReq('john'), true);
+
+      expect(service.setVisibility).toHaveBeenCalledWith('john', false);
+      expect(result.isHidden).toBe(false);
+    });
+  });
+
+  describe('getPublicResume', () => {
+    it('throws NotFoundException when service returns null', async () => {
+      service.getResumeByUuid.mockResolvedValue(null);
+
+      await expect(controller.getPublicResume('uuid-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns a ResumeDto for the public resume', async () => {
+      service.getResumeByUuid.mockResolvedValue(resumeData);
+
+      const result = await controller.getPublicResume('uuid-1');
+
+      expect(service.getResumeByUuid).toHaveBeenCalledWith('uuid-1');
+      expect(result).toBeInstanceOf(ResumeDto);
+    });
+  });
+
+  describe('getApplicants', () => {
+    it('maps each applicant resume into an ApplicantResumeDto', async () => {
+      const applicant = { ...mockResume, user: { githubId: 'john' } } as Partial<Resume> as Resume;
+      service.getApplicantResumes.mockResolvedValue([applicant]);
+
+      const result = await controller.getApplicants();
+
+      expect(service.getApplicantResumes).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(ApplicantResumeDto);
+      expect(result[0].githubId).toBe('john');
+    });
+
+    it('returns an empty array when there are no applicants', async () => {
+      service.getApplicantResumes.mockResolvedValue([]);
+
+      const result = await controller.getApplicants();
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/nestjs/src/opportunities/opportunities.service.test.ts
+++ b/nestjs/src/opportunities/opportunities.service.test.ts
@@ -1,29 +1,42 @@
 import { Feedback } from '@entities/feedback';
 import { Resume } from '@entities/resume';
 import { Student } from '@entities/student';
-import { StudentFeedback } from '@entities/student-feedback';
+import { Recommendation, StudentFeedback } from '@entities/student-feedback';
 import { User } from '@entities/user';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { In } from 'typeorm';
 import { OpportunitiesService } from './opportunities.service';
 
 describe('OpportunitiesService', () => {
   let service: OpportunitiesService;
 
   const resumeRepository = {
+    findOne: vi.fn(),
     findOneBy: vi.fn(),
+    findOneOrFail: vi.fn(),
     save: vi.fn(),
+    delete: vi.fn(),
+    createQueryBuilder: vi.fn(),
   };
 
-  const feedbackRepository = {};
-  const studentFeedbackRepository = {};
+  const feedbackRepository = {
+    find: vi.fn(),
+  };
+
+  const studentFeedbackRepository = {
+    find: vi.fn(),
+  };
 
   const userRepository = {
+    findOne: vi.fn(),
     findOneOrFail: vi.fn(),
     update: vi.fn(),
   };
 
-  const studentRepository = {};
+  const studentRepository = {
+    find: vi.fn(),
+  };
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -46,50 +59,305 @@ describe('OpportunitiesService', () => {
     vi.useRealTimers();
   });
 
-  it('should prolong resume expiration by 30 days', async () => {
-    const fixedNow = new Date('2026-01-01T10:00:00.000Z');
-    const expectedExpires = fixedNow.getTime() + 30 * 24 * 60 * 60 * 1000;
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
 
-    vi.useFakeTimers();
-    vi.setSystemTime(fixedNow);
+  describe('getResumeByUuid', () => {
+    it('loads resume by uuid then assembles full resume with visible courses filter', async () => {
+      const resume = { userId: 3, visibleCourses: [10, 20] } as Partial<Resume> as Resume;
+      const students = [{ id: 1 }, { id: 2 }] as Partial<Student>[] as Student[];
+      const gratitudes = [{ id: 9 }] as Partial<Feedback>[] as Feedback[];
+      const feedbacks = [{ id: 7 }] as Partial<StudentFeedback>[] as StudentFeedback[];
 
-    resumeRepository.findOneBy.mockResolvedValueOnce({ id: 5, githubId: 'john' });
-    resumeRepository.save.mockImplementationOnce(async (data: { expires: number }) => ({
-      id: 5,
-      githubId: 'john',
-      expires: data.expires,
-    }));
+      resumeRepository.findOneOrFail.mockResolvedValueOnce(resume);
+      studentRepository.find.mockResolvedValueOnce(students);
+      feedbackRepository.find.mockResolvedValueOnce(gratitudes);
+      studentFeedbackRepository.find.mockResolvedValueOnce(feedbacks);
 
-    const expires = await service.prolong('john');
+      const result = await service.getResumeByUuid('abc-uuid');
 
-    expect(expires).toBe(expectedExpires);
-    expect(resumeRepository.save).toHaveBeenCalledWith({
-      id: 5,
-      githubId: 'john',
-      expires: expectedExpires,
+      expect(resumeRepository.findOneOrFail).toHaveBeenCalledWith({ where: { uuid: 'abc-uuid' } });
+      // visibleCourseOnly defaults to true and visibleCourses is non-empty => filter by courseId
+      expect(studentRepository.find).toHaveBeenCalledWith({
+        relations: ['course', 'certificate', 'mentor', 'mentor.user'],
+        where: { userId: 3, courseId: In([10, 20]) },
+      });
+      expect(feedbackRepository.find).toHaveBeenCalledWith({
+        where: { toUserId: 3 },
+        order: { createdDate: 'DESC' },
+      });
+      expect(studentFeedbackRepository.find).toHaveBeenCalledWith({
+        relations: ['student', 'student.course', 'mentor', 'mentor.user'],
+        where: { studentId: In([1, 2]), recommendation: Recommendation.Hire },
+      });
+      expect(result).toEqual({ resume, students, gratitudes, feedbacks });
+    });
+
+    it('does not apply course filter when visibleCourses is empty', async () => {
+      const resume = { userId: 3, visibleCourses: [] } as Partial<Resume> as Resume;
+      resumeRepository.findOneOrFail.mockResolvedValueOnce(resume);
+      studentRepository.find.mockResolvedValueOnce([]);
+      feedbackRepository.find.mockResolvedValueOnce([]);
+      studentFeedbackRepository.find.mockResolvedValueOnce([]);
+
+      await service.getResumeByUuid('abc-uuid');
+
+      expect(studentRepository.find).toHaveBeenCalledWith({
+        relations: ['course', 'certificate', 'mentor', 'mentor.user'],
+        where: { userId: 3 },
+      });
+    });
+
+    it('returns empty students and gratitudes when resume has no userId', async () => {
+      const resume = { userId: null, visibleCourses: [] } as Partial<Resume> as Resume;
+      resumeRepository.findOneOrFail.mockResolvedValueOnce(resume);
+      studentFeedbackRepository.find.mockResolvedValueOnce([]);
+
+      const result = await service.getResumeByUuid('abc-uuid');
+
+      expect(studentRepository.find).not.toHaveBeenCalled();
+      expect(feedbackRepository.find).not.toHaveBeenCalled();
+      expect(studentFeedbackRepository.find).toHaveBeenCalledWith({
+        relations: ['student', 'student.course', 'mentor', 'mentor.user'],
+        where: { studentId: In([]), recommendation: Recommendation.Hire },
+      });
+      expect(result).toEqual({ resume, students: [], gratitudes: [], feedbacks: [] });
     });
   });
 
-  it('should create consent and set expiration in 30 days', async () => {
-    const fixedNow = new Date('2026-01-01T10:00:00.000Z');
-    const expectedExpires = fixedNow.getTime() + 30 * 24 * 60 * 60 * 1000;
+  describe('getResumeByGithubId', () => {
+    it('returns null when no resume exists for the user', async () => {
+      userRepository.findOneOrFail.mockResolvedValueOnce({ id: 42 });
+      resumeRepository.findOne.mockResolvedValueOnce(null);
 
-    vi.useFakeTimers();
-    vi.setSystemTime(fixedNow);
+      const result = await service.getResumeByGithubId('john');
 
-    userRepository.findOneOrFail.mockResolvedValueOnce({ id: 11 });
-    userRepository.update.mockResolvedValueOnce(undefined);
-    resumeRepository.findOneBy.mockResolvedValueOnce({ id: 7, githubId: 'john' });
-    resumeRepository.save.mockImplementationOnce(async (data: { expires: number }) => ({
-      expires: data.expires,
-    }));
-
-    const result = await service.createConsent('john');
-
-    expect(result).toEqual({
-      consent: true,
-      expires: expectedExpires,
+      expect(userRepository.findOneOrFail).toHaveBeenCalledWith({ where: { githubId: 'john' } });
+      expect(resumeRepository.findOne).toHaveBeenCalledWith({ where: { userId: 42 } });
+      expect(result).toBeNull();
     });
-    expect(userRepository.update).toHaveBeenCalledWith(11, { opportunitiesConsent: true });
+
+    it('assembles full resume without visible course filter (visibleCourseOnly=false)', async () => {
+      const resume = { userId: 42, visibleCourses: [10, 20] } as Partial<Resume> as Resume;
+      userRepository.findOneOrFail.mockResolvedValueOnce({ id: 42 });
+      resumeRepository.findOne.mockResolvedValueOnce(resume);
+      studentRepository.find.mockResolvedValueOnce([{ id: 5 }] as Partial<Student>[] as Student[]);
+      feedbackRepository.find.mockResolvedValueOnce([]);
+      studentFeedbackRepository.find.mockResolvedValueOnce([]);
+
+      await service.getResumeByGithubId('john');
+
+      // visibleCourseOnly=false => no courseId filter even though visibleCourses is set
+      expect(studentRepository.find).toHaveBeenCalledWith({
+        relations: ['course', 'certificate', 'mentor', 'mentor.user'],
+        where: { userId: 42 },
+      });
+    });
+  });
+
+  describe('saveResume', () => {
+    it('returns null when no resume exists for githubId', async () => {
+      resumeRepository.findOneBy.mockResolvedValueOnce(null);
+
+      const result = await service.saveResume('john', { name: 'New' } as never);
+
+      expect(resumeRepository.findOneBy).toHaveBeenCalledWith({ githubId: 'john' });
+      expect(resumeRepository.save).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('merges dto onto existing resume and saves', async () => {
+      const existing = { id: 1, githubId: 'john', name: 'Old', email: 'a@b.c' } as Partial<Resume> as Resume;
+      resumeRepository.findOneBy.mockResolvedValueOnce(existing);
+      resumeRepository.save.mockImplementationOnce(async (data: unknown) => data);
+
+      const result = await service.saveResume('john', { name: 'New' } as never);
+
+      expect(resumeRepository.save).toHaveBeenCalledWith({
+        id: 1,
+        githubId: 'john',
+        name: 'New',
+        email: 'a@b.c',
+      });
+      expect(result).toEqual({ id: 1, githubId: 'john', name: 'New', email: 'a@b.c' });
+    });
+  });
+
+  describe('getApplicantResumes', () => {
+    it('queries consented applicants with a non-null name', async () => {
+      const expected = [{ id: 1 }] as Partial<Resume>[] as Resume[];
+      const qb = {
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        andWhere: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        getMany: vi.fn().mockResolvedValue(expected),
+      };
+      resumeRepository.createQueryBuilder.mockReturnValueOnce(qb);
+
+      const result = await service.getApplicantResumes();
+
+      expect(resumeRepository.createQueryBuilder).toHaveBeenCalledWith('r');
+      expect(qb.innerJoin).toHaveBeenCalledWith('r.user', 'u');
+      expect(qb.where).toHaveBeenCalledWith('u."opportunitiesConsent" = true');
+      expect(qb.andWhere).toHaveBeenCalledWith('r.name IS NOT NULL');
+      expect(qb.addSelect).toHaveBeenCalledWith(['u.id', 'u.githubId']);
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('prolong', () => {
+    it('prolongs resume expiration by 30 days', async () => {
+      const fixedNow = new Date('2026-01-01T10:00:00.000Z');
+      const expectedExpires = fixedNow.getTime() + 30 * 24 * 60 * 60 * 1000;
+
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+
+      resumeRepository.findOneBy.mockResolvedValueOnce({ id: 5, githubId: 'john' });
+      resumeRepository.save.mockImplementationOnce(async (data: { expires: number }) => ({
+        id: 5,
+        githubId: 'john',
+        expires: data.expires,
+      }));
+
+      const expires = await service.prolong('john');
+
+      expect(expires).toBe(expectedExpires);
+      expect(resumeRepository.save).toHaveBeenCalledWith({
+        id: 5,
+        githubId: 'john',
+        expires: expectedExpires,
+      });
+    });
+
+    it('saves with undefined id when no resume exists', async () => {
+      const fixedNow = new Date('2026-01-01T10:00:00.000Z');
+      const expectedExpires = fixedNow.getTime() + 30 * 24 * 60 * 60 * 1000;
+
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+
+      resumeRepository.findOneBy.mockResolvedValueOnce(null);
+      resumeRepository.save.mockImplementationOnce(async (data: { expires: number }) => ({ expires: data.expires }));
+
+      await service.prolong('john');
+
+      expect(resumeRepository.save).toHaveBeenCalledWith({
+        id: undefined,
+        githubId: 'john',
+        expires: expectedExpires,
+      });
+    });
+  });
+
+  describe('setVisibility', () => {
+    it('persists isHidden=false when visible and returns saved value', async () => {
+      resumeRepository.findOneBy.mockResolvedValueOnce({ id: 3, githubId: 'john' });
+      resumeRepository.save.mockImplementationOnce(async (data: { isHidden: boolean }) => ({
+        isHidden: data.isHidden,
+      }));
+
+      const result = await service.setVisibility('john', true);
+
+      expect(resumeRepository.save).toHaveBeenCalledWith({ id: 3, githubId: 'john', isHidden: false });
+      expect(result).toBe(false);
+    });
+
+    it('persists isHidden=true when not visible', async () => {
+      resumeRepository.findOneBy.mockResolvedValueOnce(null);
+      resumeRepository.save.mockImplementationOnce(async (data: { isHidden: boolean }) => ({
+        isHidden: data.isHidden,
+      }));
+
+      const result = await service.setVisibility('john', false);
+
+      expect(resumeRepository.save).toHaveBeenCalledWith({ id: undefined, githubId: 'john', isHidden: true });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getConsent', () => {
+    it('returns false when user is not found', async () => {
+      userRepository.findOne.mockResolvedValueOnce(null);
+
+      const result = await service.getConsent('john');
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { githubId: 'john' } });
+      expect(result).toBe(false);
+    });
+
+    it('returns boolean consent value when user exists', async () => {
+      userRepository.findOne.mockResolvedValueOnce({ opportunitiesConsent: true });
+
+      const result = await service.getConsent('john');
+
+      expect(result).toBe(true);
+    });
+
+    it('coerces a nullish consent into false', async () => {
+      userRepository.findOne.mockResolvedValueOnce({ opportunitiesConsent: null });
+
+      const result = await service.getConsent('john');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createConsent', () => {
+    it('creates consent and sets expiration in 30 days', async () => {
+      const fixedNow = new Date('2026-01-01T10:00:00.000Z');
+      const expectedExpires = fixedNow.getTime() + 30 * 24 * 60 * 60 * 1000;
+
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+
+      userRepository.findOneOrFail.mockResolvedValueOnce({ id: 11 });
+      userRepository.update.mockResolvedValueOnce(undefined);
+      resumeRepository.findOneBy.mockResolvedValueOnce({ id: 7, githubId: 'john' });
+      resumeRepository.save.mockImplementationOnce(async (data: { expires: number }) => ({ expires: data.expires }));
+
+      const result = await service.createConsent('john');
+
+      expect(result).toEqual({ consent: true, expires: expectedExpires });
+      expect(userRepository.update).toHaveBeenCalledWith(11, { opportunitiesConsent: true });
+      expect(resumeRepository.save).toHaveBeenCalledWith({
+        id: 7,
+        githubId: 'john',
+        userId: 11,
+        expires: expectedExpires,
+      });
+    });
+
+    it('creates resume with undefined id when none exists yet', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T10:00:00.000Z'));
+
+      userRepository.findOneOrFail.mockResolvedValueOnce({ id: 11 });
+      userRepository.update.mockResolvedValueOnce(undefined);
+      resumeRepository.findOneBy.mockResolvedValueOnce(null);
+      resumeRepository.save.mockImplementationOnce(async (data: { expires: number }) => ({ expires: data.expires }));
+
+      await service.createConsent('john');
+
+      expect(resumeRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: undefined, githubId: 'john', userId: 11 }),
+      );
+    });
+  });
+
+  describe('deleteConsent', () => {
+    it('clears consent flag, deletes the resume and returns false', async () => {
+      userRepository.findOneOrFail.mockResolvedValueOnce({ id: 11 });
+      userRepository.update.mockResolvedValueOnce(undefined);
+      resumeRepository.delete.mockResolvedValueOnce(undefined);
+
+      const result = await service.deleteConsent('john');
+
+      expect(userRepository.update).toHaveBeenCalledWith(11, { opportunitiesConsent: false });
+      expect(resumeRepository.delete).toHaveBeenCalledWith({ githubId: 'john' });
+      expect(result).toBe(false);
+    });
   });
 });

--- a/nestjs/src/prompts/prompts.controller.spec.ts
+++ b/nestjs/src/prompts/prompts.controller.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prompt } from '@entities/prompt';
+import { PromptsController } from './prompts.controller';
+import { PromptsService } from './prompts.service';
+import { CreatePromptDto, PromptDto, UpdatePromptDto } from './dto';
+
+const mockId = 1;
+
+const mockPrompt = { id: mockId, type: 'system', text: 'Hello', temperature: 0.5 } as Partial<Prompt> as Prompt;
+
+const mockCreate = vi.fn(() => Promise.resolve(mockPrompt));
+const mockFindAll = vi.fn(() => Promise.resolve([mockPrompt, mockPrompt]));
+const mockRemove = vi.fn(() => Promise.resolve());
+const mockUpdate = vi.fn(() => Promise.resolve(mockPrompt));
+
+const mockPromptsServiceFactory = vi.fn(() => ({
+  create: mockCreate,
+  findAll: mockFindAll,
+  remove: mockRemove,
+  update: mockUpdate,
+}));
+
+describe('PromptsController', () => {
+  let controller: PromptsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PromptsController],
+      providers: [{ provide: PromptsService, useFactory: mockPromptsServiceFactory }],
+    }).compile();
+
+    controller = module.get<PromptsController>(PromptsController);
+  });
+
+  describe('create', () => {
+    it('should create a prompt and wrap it in a PromptDto', async () => {
+      const dto = new CreatePromptDto();
+
+      const result = await controller.create(dto);
+
+      expect(mockCreate).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(new PromptDto(mockPrompt));
+    });
+  });
+
+  describe('getAll', () => {
+    it('should get all prompts mapped to PromptDto', async () => {
+      const result = await controller.getAll();
+
+      expect(mockFindAll).toHaveBeenCalled();
+      expect(result).toEqual([new PromptDto(mockPrompt), new PromptDto(mockPrompt)]);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a prompt by id', async () => {
+      await controller.remove(mockId);
+
+      expect(mockRemove).toHaveBeenCalledWith(mockId);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a prompt and wrap it in a PromptDto', async () => {
+      const dto = new UpdatePromptDto();
+
+      const result = await controller.update(mockId, dto);
+
+      expect(mockUpdate).toHaveBeenCalledWith(mockId, dto);
+      expect(result).toEqual(new PromptDto(mockPrompt));
+    });
+  });
+});

--- a/nestjs/src/prompts/prompts.service.spec.ts
+++ b/nestjs/src/prompts/prompts.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Mocked } from 'vitest';
+import { Prompt } from '@entities/prompt';
+import { PromptsService } from './prompts.service';
+import { CreatePromptDto } from './dto/create-prompt.dto';
+import { UpdatePromptDto } from './dto/update-prompt.dto';
+
+const mockId = 1;
+const mockPrompt = { id: mockId, type: 'system', text: 'Hello', temperature: 0.5 } as Partial<Prompt> as Prompt;
+
+describe('PromptsService', () => {
+  let service: PromptsService;
+  let repository: Mocked<Repository<Prompt>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PromptsService,
+        {
+          provide: getRepositoryToken(Prompt),
+          useValue: {
+            find: vi.fn(),
+            findOneByOrFail: vi.fn(),
+            save: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PromptsService>(PromptsService);
+    repository = module.get(getRepositoryToken(Prompt));
+  });
+
+  describe('create', () => {
+    it('should save only text/type/temperature and return the freshly fetched prompt', async () => {
+      const dto = { text: 'Hello', type: 'system', temperature: 0.5 } as CreatePromptDto;
+      repository.save.mockResolvedValue({ id: mockId } as Prompt);
+      repository.findOneByOrFail.mockResolvedValue(mockPrompt);
+
+      const result = await service.create(dto);
+
+      expect(repository.save).toHaveBeenCalledWith({ text: 'Hello', type: 'system', temperature: 0.5 });
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: mockId });
+      expect(result).toEqual(mockPrompt);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all prompts', async () => {
+      const items = [mockPrompt, mockPrompt];
+      repository.find.mockResolvedValue(items);
+
+      const result = await service.findAll();
+
+      expect(repository.find).toHaveBeenCalledWith();
+      expect(result).toEqual(items);
+    });
+
+    it('should return an empty array when there are no prompts', async () => {
+      repository.find.mockResolvedValue([]);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('should update the prompt and return the freshly fetched entity', async () => {
+      const dto = { text: 'Updated' } as UpdatePromptDto;
+      repository.findOneByOrFail.mockResolvedValue(mockPrompt);
+
+      const result = await service.update(mockId, dto);
+
+      expect(repository.update).toHaveBeenCalledWith(mockId, dto);
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: mockId });
+      expect(result).toEqual(mockPrompt);
+    });
+  });
+
+  describe('remove', () => {
+    it('should hard-delete the prompt by id', async () => {
+      await service.remove(mockId);
+
+      expect(repository.delete).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/schedule/schedule.controller.spec.ts
+++ b/nestjs/src/schedule/schedule.controller.spec.ts
@@ -1,0 +1,75 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserNotificationsService } from 'src/users-notifications/users.notifications.service';
+import { ScheduleController } from './schedule.controller';
+import { ScheduleService } from './schedule.service';
+
+// Flush the microtask queue so the fire-and-forget notification promise runs.
+const flush = () => new Promise<void>(resolve => setImmediate(resolve));
+
+describe('ScheduleController', () => {
+  let controller: ScheduleController;
+  let scheduleService: Mocked<ScheduleService>;
+  let notificationService: Mocked<UserNotificationsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ScheduleController],
+      providers: [
+        { provide: ScheduleService, useValue: { getChangedCoursesRecipients: vi.fn() } },
+        { provide: UserNotificationsService, useValue: { sendEventNotification: vi.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get(ScheduleController);
+    scheduleService = module.get(ScheduleService);
+    notificationService = module.get(UserNotificationsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('notifyScheduleChanges', () => {
+    it('fetches recipients for the requested window and sends a notification per recipient', async () => {
+      const courses = [{ course: { id: 1 }, changes: [] }];
+      scheduleService.getChangedCoursesRecipients.mockResolvedValue([[42, courses]] as never);
+      notificationService.sendEventNotification.mockResolvedValue(undefined as never);
+
+      await controller.notifyScheduleChanges({ lastHours: 6 });
+      await flush();
+
+      expect(scheduleService.getChangedCoursesRecipients).toHaveBeenCalledWith(6);
+      expect(notificationService.sendEventNotification).toHaveBeenCalledWith({
+        data: { courses },
+        notificationId: 'courseScheduleChange',
+        userId: 42,
+      });
+    });
+
+    it('passes undefined lastHours straight through to the service', async () => {
+      scheduleService.getChangedCoursesRecipients.mockResolvedValue([] as never);
+
+      await controller.notifyScheduleChanges({});
+      await flush();
+
+      expect(scheduleService.getChangedCoursesRecipients).toHaveBeenCalledWith(undefined);
+      expect(notificationService.sendEventNotification).not.toHaveBeenCalled();
+    });
+
+    it('continues notifying remaining recipients when one notification rejects', async () => {
+      scheduleService.getChangedCoursesRecipients.mockResolvedValue([
+        [1, []],
+        [2, []],
+      ] as never);
+      notificationService.sendEventNotification
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined as never);
+
+      await controller.notifyScheduleChanges({ lastHours: 2 });
+      await flush();
+
+      expect(notificationService.sendEventNotification).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/nestjs/src/schedule/schedule.service.spec.ts
+++ b/nestjs/src/schedule/schedule.service.spec.ts
@@ -1,0 +1,506 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from '@entities/user';
+import { History } from '@entities/history';
+import { CourseEvent } from '@entities/courseEvent';
+import { CoursesService } from 'src/courses/courses.service';
+import { ScheduleService } from './schedule.service';
+
+// Fluent query-builder mock: chainable methods return the qb; the terminal
+// method (getMany / getRawMany) resolves to the supplied rows.
+function makeQb(terminal: 'getMany' | 'getRawMany', rows: unknown[]) {
+  const qb: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'addSelect', 'leftJoin', 'innerJoin', 'where', 'orderBy', 'groupBy']) {
+    qb[m] = vi.fn(() => qb);
+  }
+  qb[terminal] = vi.fn(async () => rows);
+  return qb;
+}
+
+describe('ScheduleService', () => {
+  let service: ScheduleService;
+  let courseService: { getByIds: ReturnType<typeof vi.fn> };
+  let userRepository: { createQueryBuilder: ReturnType<typeof vi.fn> };
+  let historyRepository: { createQueryBuilder: ReturnType<typeof vi.fn> };
+  let courseEventRepository: { query: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    courseService = { getByIds: vi.fn() };
+    userRepository = { createQueryBuilder: vi.fn() };
+    historyRepository = { createQueryBuilder: vi.fn() };
+    courseEventRepository = { query: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScheduleService,
+        { provide: CoursesService, useValue: courseService },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: getRepositoryToken(History), useValue: historyRepository },
+        { provide: getRepositoryToken(CourseEvent), useValue: courseEventRepository },
+      ],
+    }).compile();
+
+    service = module.get(ScheduleService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getInsertFields', () => {
+    it('returns dateTime only for an event without a place', () => {
+      const result = service.getInsertFields('course_event', { dateTime: '2024-01-01' } as never);
+
+      expect(result).toEqual({ dateTime: '2024-01-01' });
+    });
+
+    it('includes place for an event that has one', () => {
+      const result = service.getInsertFields('course_event', {
+        dateTime: '2024-01-01',
+        place: 'Online',
+      } as never);
+
+      expect(result).toEqual({ dateTime: '2024-01-01', place: 'Online' });
+    });
+
+    it('returns student dates for a task without a cross-check end date', () => {
+      const result = service.getInsertFields('course_task', {
+        studentStartDate: '2024-01-01',
+        studentEndDate: '2024-01-10',
+      } as never);
+
+      expect(result).toEqual({ studentStartDate: '2024-01-01', studentEndDate: '2024-01-10' });
+    });
+
+    it('includes crossCheckEndDate for a task that has one', () => {
+      const result = service.getInsertFields('course_task', {
+        studentStartDate: '2024-01-01',
+        studentEndDate: '2024-01-10',
+        crossCheckEndDate: '2024-01-15',
+      } as never);
+
+      expect(result).toEqual({
+        studentStartDate: '2024-01-01',
+        studentEndDate: '2024-01-10',
+        crossCheckEndDate: '2024-01-15',
+      });
+    });
+  });
+
+  describe('getUpdatedFields', () => {
+    describe('course_event', () => {
+      it('reports both place and dateTime changes with their old values', () => {
+        const result = service.getUpdatedFields(
+          'course_event',
+          { place: 'New', dateTime: '2024-02-01' } as never,
+          { place: 'Old', dateTime: '2024-01-01' } as never,
+        );
+
+        expect(result).toEqual({
+          place: 'New',
+          placeOld: 'Old',
+          dateTime: '2024-02-01',
+          dateTimeOld: '2024-01-01',
+        });
+      });
+
+      it('reports only the changed place when the dateTime is unchanged', () => {
+        const result = service.getUpdatedFields(
+          'course_event',
+          { place: 'New', dateTime: '2024-01-01' } as never,
+          { place: 'Old', dateTime: '2024-01-01' } as never,
+        );
+
+        expect(result).toEqual({ place: 'New', placeOld: 'Old' });
+      });
+
+      it('returns undefined when nothing changed', () => {
+        const result = service.getUpdatedFields(
+          'course_event',
+          { place: 'Same', dateTime: '2024-01-01' } as never,
+          { place: 'Same', dateTime: '2024-01-01' } as never,
+        );
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('course_task', () => {
+      it('reports all three date changes with old values', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-02-01',
+            studentEndDate: '2024-02-10',
+            crossCheckEndDate: '2024-02-15',
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+          } as never,
+        );
+
+        expect(result).toEqual({
+          studentStartDate: '2024-02-01',
+          studentStartDateOld: '2024-01-01',
+          studentEndDate: '2024-02-10',
+          studentEndDateOld: '2024-01-10',
+          crossCheckEndDate: '2024-02-15',
+          crossCheckEndDateOld: '2024-01-15',
+        });
+      });
+
+      it('reports only studentEndDate when just the end date changed', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-02-10',
+            crossCheckEndDate: '2024-01-15',
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+          } as never,
+        );
+
+        expect(result).toEqual({ studentEndDate: '2024-02-10', studentEndDateOld: '2024-01-10' });
+      });
+
+      it('reports only crossCheckEndDate when just the cross-check date changed', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-02-15',
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+          } as never,
+        );
+
+        expect(result).toEqual({ crossCheckEndDate: '2024-02-15', crossCheckEndDateOld: '2024-01-15' });
+      });
+
+      it('returns an empty object when no task date changed', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+          } as never,
+        );
+
+        expect(result).toEqual({});
+      });
+
+      it('treats two null dates as equal and reports no change', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: null,
+            studentEndDate: null,
+            crossCheckEndDate: null,
+          } as never,
+          {
+            studentStartDate: null,
+            studentEndDate: null,
+            crossCheckEndDate: null,
+          } as never,
+        );
+
+        expect(result).toEqual({});
+      });
+
+      it('coerces missing previous dates to undefined in every old field', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-02-01',
+            studentEndDate: '2024-02-10',
+            crossCheckEndDate: '2024-02-15',
+          } as never,
+          {
+            studentStartDate: null,
+            studentEndDate: null,
+            crossCheckEndDate: null,
+          } as never,
+        );
+
+        // all three changed (null -> value); every old value is null -> undefined
+        expect(result).toEqual({
+          studentStartDate: '2024-02-01',
+          studentStartDateOld: undefined,
+          studentEndDate: '2024-02-10',
+          studentEndDateOld: undefined,
+          crossCheckEndDate: '2024-02-15',
+          crossCheckEndDateOld: undefined,
+        });
+      });
+    });
+  });
+
+  describe('getChangedCoursesRecipients', () => {
+    it('returns an empty array when there are no active updated courses', async () => {
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', []));
+      courseEventRepository.query.mockResolvedValue([]);
+      courseService.getByIds.mockResolvedValue([]);
+
+      const result = await service.getChangedCoursesRecipients();
+
+      expect(courseService.getByIds).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('defaults to a 2-hour lookback window', async () => {
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', []));
+      courseEventRepository.query.mockResolvedValue([]);
+      courseService.getByIds.mockResolvedValue([]);
+
+      await service.getChangedCoursesRecipients();
+
+      // getScheduleUpdatedRecords builds a where with MoreThanOrEqual(date); we just
+      // assert the query builder was used (lastHours default exercised without error).
+      expect(historyRepository.createQueryBuilder).toHaveBeenCalledWith('entry');
+    });
+
+    it('builds recipients from history changes, joining course aliases per user', async () => {
+      const insertRecord = {
+        operation: 'insert',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200, studentStartDate: '2024-01-01', studentEndDate: '2024-01-10' },
+        previous: null,
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [insertRecord]));
+
+      // buildTaskEventMap query resolves task names
+      courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
+
+      // active course matching the changed courseId
+      const course = { id: 5, alias: 'course-a', name: 'Course A', completed: false };
+      courseService.getByIds.mockResolvedValue([course]);
+
+      // user enrolled into that course alias
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(courseService.getByIds).toHaveBeenCalledWith([5], expect.any(Object));
+      expect(result).toHaveLength(1);
+      const [userId, courses] = result[0];
+      expect(userId).toBe(42);
+      expect(courses[0].course).toBe(course);
+      expect(courses[0].changes[0]).toMatchObject({ isNew: true, type: 'task', name: 'Task 200' });
+    });
+
+    it('skips users that have no matching course aliases', async () => {
+      const insertRecord = {
+        operation: 'insert',
+        entityId: 100,
+        event: 'course_event',
+        update: { courseId: 5, eventId: 300, dateTime: '2024-01-01' },
+        previous: null,
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [insertRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 300, name: 'Event 300', type: 'event' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      // user with empty aliases must be filtered out
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: [] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(result).toEqual([]);
+    });
+
+    it('marks a removed entry when the operation is remove', async () => {
+      const removeRecord = {
+        operation: 'remove',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200 },
+        previous: { courseId: 5, taskId: 200, studentStartDate: '2024-01-01', studentEndDate: '2024-01-10' },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [removeRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(result[0][1][0].changes[0]).toMatchObject({ isRemoved: true, type: 'task' });
+    });
+
+    it('treats a disabled-task update as a removal', async () => {
+      const disableRecord = {
+        operation: 'update',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200, disabled: true },
+        previous: { courseId: 5, taskId: 200, studentStartDate: '2024-01-01', studentEndDate: '2024-01-10' },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [disableRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(result[0][1][0].changes[0]).toMatchObject({ isRemoved: true });
+    });
+
+    it('records an updated entry merging previous and new fields', async () => {
+      const updateRecord = {
+        operation: 'update',
+        entityId: 100,
+        event: 'course_event',
+        update: { courseId: 5, eventId: 300, place: 'New', dateTime: '2024-02-01' },
+        previous: { courseId: 5, eventId: 300, place: 'Old', dateTime: '2024-01-01' },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [updateRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 300, name: 'Event 300', type: 'event' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(result[0][1][0].changes[0]).toMatchObject({
+        type: 'event',
+        place: 'New',
+        placeOld: 'Old',
+        name: 'Event 300',
+      });
+    });
+
+    it('falls back to the previous entry courseId/parentId when the update is empty', async () => {
+      // previous-only path drives getParentId via previousEntry and courseId via entryPrevious
+      const removeRecord = {
+        operation: 'remove',
+        entityId: 100,
+        event: 'course_event',
+        update: {},
+        previous: { courseId: 5, eventId: 300, dateTime: '2024-01-01' },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [removeRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 300, name: 'Event 300', type: 'event' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(courseService.getByIds).toHaveBeenCalledWith([5], expect.any(Object));
+      expect(result[0][1][0].changes[0]).toMatchObject({ isRemoved: true, name: 'Event 300' });
+    });
+
+    it('reuses an existing course bucket for multiple changes of the same course', async () => {
+      const records = [
+        {
+          operation: 'insert',
+          entityId: 100,
+          event: 'course_task',
+          update: { courseId: 5, taskId: 200, studentStartDate: '2024-01-01', studentEndDate: '2024-01-10' },
+          previous: null,
+        },
+        {
+          operation: 'insert',
+          entityId: 101,
+          event: 'course_event',
+          update: { courseId: 5, eventId: 300, dateTime: '2024-01-05' },
+          previous: null,
+        },
+      ] as unknown as History[];
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', records));
+      courseEventRepository.query.mockResolvedValue([
+        { id: 200, name: 'Task 200', type: 'task' },
+        { id: 300, name: 'Event 300', type: 'event' },
+      ]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      // both changes land in the single course-a bucket for user 42
+      expect(courseService.getByIds).toHaveBeenCalledWith([5], expect.any(Object));
+      expect(result[0][1][0].changes).toHaveLength(2);
+    });
+
+    it('merges a later update onto an earlier change for the same entry key', async () => {
+      const records = [
+        {
+          operation: 'insert',
+          entityId: 100,
+          event: 'course_event',
+          update: { courseId: 5, eventId: 300, dateTime: '2024-01-01', place: 'Old' },
+          previous: null,
+        },
+        {
+          operation: 'update',
+          entityId: 100,
+          event: 'course_event',
+          update: { courseId: 5, eventId: 300, dateTime: '2024-01-01', place: 'New' },
+          previous: { courseId: 5, eventId: 300, dateTime: '2024-01-01', place: 'Old' },
+        },
+      ] as unknown as History[];
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', records));
+      courseEventRepository.query.mockResolvedValue([{ id: 300, name: 'Event 300', type: 'event' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      // single entry key -> one merged change carrying the place update over the insert
+      const changes = result[0][1][0].changes;
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toMatchObject({ isNew: true, place: 'New', placeOld: 'Old' });
+    });
+
+    it('ignores records with an unrecognized operation', async () => {
+      const unknownRecord = {
+        operation: 'unknown',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200 },
+        previous: { courseId: 5, taskId: 200 },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [unknownRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      // course bucket exists (courseId tracked) but no change was recorded
+      expect(result[0][1][0].changes).toEqual([]);
+    });
+
+    it('defaults the change name to an empty string when no task/event entry is found', async () => {
+      const insertRecord = {
+        operation: 'insert',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200, studentStartDate: '2024-01-01', studentEndDate: '2024-01-10' },
+        previous: null,
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [insertRecord]));
+      // no matching name rows returned
+      courseEventRepository.query.mockResolvedValue([]);
+      courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(result[0][1][0].changes[0]).toMatchObject({ name: '' });
+    });
+  });
+});

--- a/nestjs/src/session/session.controller.spec.ts
+++ b/nestjs/src/session/session.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CurrentRequest } from 'src/auth';
+import { SessionController } from './session.controller';
+
+describe('SessionController', () => {
+  let controller: SessionController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SessionController],
+    }).compile();
+
+    controller = module.get(SessionController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getSession', () => {
+    it('returns the authenticated user from the request', () => {
+      const user = { id: 1, githubId: 'johndoe' };
+      const req = { user } as unknown as CurrentRequest;
+
+      const result = controller.getSession(req);
+
+      expect(result).toBe(user);
+    });
+
+    it('returns undefined when the request has no user', () => {
+      const req = {} as CurrentRequest;
+
+      const result = controller.getSession(req);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/nestjs/src/tasks/tasks-criteria/tasks-criteria.controller.spec.ts
+++ b/nestjs/src/tasks/tasks-criteria/tasks-criteria.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CrossCheckCriteriaType } from '@entities/taskCriteria';
+import { TasksCriteriaController } from './tasks-criteria.controller';
+import { TasksCriteriaService } from './tasks-criteria.service';
+import { TaskCriteriaDto } from './dto/task-criteria.dto';
+import { CriteriaDto } from './dto/criteria.dto';
+
+const taskId = 1;
+
+const mockCriteria: CriteriaDto[] = [{ type: CrossCheckCriteriaType.Title, text: 'Title', key: 'k1', index: 0 }];
+
+const mockTaskCriteriaDto: TaskCriteriaDto = { criteria: mockCriteria };
+
+const mockGetCriteria = vi.fn(() => Promise.resolve(mockTaskCriteriaDto));
+const mockCreateCriteria = vi.fn(() => Promise.resolve(mockTaskCriteriaDto));
+const mockUpdateCriteria = vi.fn(() => Promise.resolve(mockTaskCriteriaDto));
+
+const mockServiceFactory = vi.fn(() => ({
+  getCriteria: mockGetCriteria,
+  createCriteria: mockCreateCriteria,
+  updateCriteria: mockUpdateCriteria,
+}));
+
+describe('TasksCriteriaController', () => {
+  let controller: TasksCriteriaController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TasksCriteriaController],
+      providers: [{ provide: TasksCriteriaService, useFactory: mockServiceFactory }],
+    }).compile();
+
+    controller = module.get<TasksCriteriaController>(TasksCriteriaController);
+  });
+
+  describe('get', () => {
+    it('should return the criteria for the task', async () => {
+      const result = await controller.get(taskId);
+
+      expect(mockGetCriteria).toHaveBeenCalledWith(taskId);
+      expect(result).toEqual(mockTaskCriteriaDto);
+    });
+  });
+
+  describe('create', () => {
+    it('should delegate the criteria array to the service', async () => {
+      const result = await controller.create(taskId, mockTaskCriteriaDto);
+
+      expect(mockCreateCriteria).toHaveBeenCalledWith(taskId, mockCriteria);
+      expect(result).toEqual(mockTaskCriteriaDto);
+    });
+  });
+
+  describe('update', () => {
+    it('should delegate the whole dto to the service', async () => {
+      const result = await controller.update(taskId, mockTaskCriteriaDto);
+
+      expect(mockUpdateCriteria).toHaveBeenCalledWith(taskId, mockTaskCriteriaDto);
+      expect(result).toEqual(mockTaskCriteriaDto);
+    });
+  });
+});

--- a/nestjs/src/tasks/tasks-criteria/tasks-criteria.service.spec.ts
+++ b/nestjs/src/tasks/tasks-criteria/tasks-criteria.service.spec.ts
@@ -1,0 +1,138 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Mocked } from 'vitest';
+import { CrossCheckCriteriaType, TaskCriteria } from '@entities/taskCriteria';
+import { Task } from '@entities/task';
+import { TasksCriteriaService } from './tasks-criteria.service';
+import { CriteriaDto } from './dto/criteria.dto';
+
+const taskId = 1;
+
+const mockCriteria: CriteriaDto[] = [
+  { type: CrossCheckCriteriaType.Title, text: 'Title', key: 'k1', index: 0 },
+  { type: CrossCheckCriteriaType.Subtask, text: 'Subtask', key: 'k2', index: 1, max: 5 },
+];
+
+const mockTask = { id: taskId } as Partial<Task> as Task;
+
+const mockTaskCriteriaEntity = {
+  taskId,
+  criteria: mockCriteria,
+} as Partial<TaskCriteria> as TaskCriteria;
+
+describe('TasksCriteriaService', () => {
+  let service: TasksCriteriaService;
+  let taskCriteriaRepository: Mocked<Repository<TaskCriteria>>;
+  let taskRepository: Mocked<Repository<Task>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksCriteriaService,
+        {
+          provide: getRepositoryToken(TaskCriteria),
+          useValue: {
+            findOne: vi.fn(),
+            save: vi.fn(),
+            update: vi.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Task),
+          useValue: {
+            findOneBy: vi.fn(),
+            update: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TasksCriteriaService>(TasksCriteriaService);
+    taskCriteriaRepository = module.get(getRepositoryToken(TaskCriteria));
+    taskRepository = module.get(getRepositoryToken(Task));
+  });
+
+  describe('getCriteria', () => {
+    it('should return the criteria when the record exists', async () => {
+      taskCriteriaRepository.findOne.mockResolvedValue(mockTaskCriteriaEntity);
+
+      const result = await service.getCriteria(taskId);
+
+      expect(taskCriteriaRepository.findOne).toHaveBeenCalledWith({ where: { taskId } });
+      expect(result).toEqual({ criteria: mockCriteria });
+    });
+
+    it('should return undefined criteria when the record does not exist', async () => {
+      taskCriteriaRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getCriteria(taskId);
+
+      expect(result).toEqual({ criteria: undefined });
+    });
+  });
+
+  describe('createCriteria', () => {
+    it('should create criteria, link them to the task and return them', async () => {
+      // First getCriteria call: no existing criteria. Second: returns saved criteria.
+      taskCriteriaRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(mockTaskCriteriaEntity);
+      taskRepository.findOneBy.mockResolvedValue(mockTask);
+
+      const result = await service.createCriteria(taskId, mockCriteria);
+
+      expect(taskRepository.findOneBy).toHaveBeenCalledWith({ id: taskId });
+      expect(taskCriteriaRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId, criteria: mockCriteria }),
+      );
+      expect(taskCriteriaRepository.save).toHaveBeenCalledWith(expect.any(TaskCriteria));
+      expect(taskRepository.update).toHaveBeenCalledWith(
+        { id: taskId },
+        { criteria: expect.objectContaining({ taskId, criteria: mockCriteria }) },
+      );
+      expect(result).toEqual({ criteria: mockCriteria });
+    });
+
+    it('should throw BadRequestException when criteria already exist', async () => {
+      taskCriteriaRepository.findOne.mockResolvedValue(mockTaskCriteriaEntity);
+
+      await expect(service.createCriteria(taskId, mockCriteria)).rejects.toBeInstanceOf(BadRequestException);
+      expect(taskRepository.findOneBy).not.toHaveBeenCalled();
+      expect(taskCriteriaRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the task does not exist', async () => {
+      taskCriteriaRepository.findOne.mockResolvedValue(null);
+      taskRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.createCriteria(taskId, mockCriteria)).rejects.toBeInstanceOf(NotFoundException);
+      expect(taskCriteriaRepository.save).not.toHaveBeenCalled();
+      expect(taskRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateCriteria', () => {
+    it('should update existing criteria and return the new ones', async () => {
+      const newCriteria: CriteriaDto[] = [
+        { type: CrossCheckCriteriaType.Penalty, text: 'Penalty', key: 'k3', index: 0, max: -2 },
+      ];
+      const updatedEntity = { taskId, criteria: newCriteria } as Partial<TaskCriteria> as TaskCriteria;
+      // First getCriteria: existing. Second getCriteria: updated.
+      taskCriteriaRepository.findOne.mockResolvedValueOnce(mockTaskCriteriaEntity).mockResolvedValueOnce(updatedEntity);
+
+      const result = await service.updateCriteria(taskId, { criteria: newCriteria });
+
+      expect(taskCriteriaRepository.update).toHaveBeenCalledWith({ taskId }, { criteria: newCriteria });
+      expect(result).toEqual({ criteria: newCriteria });
+    });
+
+    it('should throw NotFoundException when no criteria exist yet', async () => {
+      taskCriteriaRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.updateCriteria(taskId, { criteria: mockCriteria })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(taskCriteriaRepository.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/nestjs/src/tasks/tasks.controller.spec.ts
+++ b/nestjs/src/tasks/tasks.controller.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Task } from '@entities/task';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto, TaskDto, UpdateTaskDto } from './dto';
+
+const mockId = 1;
+
+const mockTask = {
+  id: mockId,
+  name: 'Task 1',
+  type: 'jstask',
+  descriptionUrl: 'http://example.com',
+  description: 'desc',
+  githubRepoName: 'repo',
+  sourceGithubRepoUrl: 'http://example.com/repo',
+  discipline: null,
+  courseTasks: [],
+  githubPrRequired: false,
+  tags: [],
+  skills: [],
+  attributes: {},
+  createdDate: '1684609801766',
+  updatedDate: '1684609810052',
+} as Partial<Task> as Task;
+
+const mockCreate = vi.fn(() => Promise.resolve(mockTask));
+const mockGetAll = vi.fn(() => Promise.resolve([mockTask, mockTask]));
+const mockDelete = vi.fn(() => Promise.resolve());
+const mockUpdate = vi.fn(() => Promise.resolve(mockTask));
+
+const mockTasksServiceFactory = vi.fn(() => ({
+  create: mockCreate,
+  getAll: mockGetAll,
+  delete: mockDelete,
+  update: mockUpdate,
+}));
+
+describe('TasksController', () => {
+  let controller: TasksController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TasksController],
+      providers: [{ provide: TasksService, useFactory: mockTasksServiceFactory }],
+    }).compile();
+
+    controller = module.get<TasksController>(TasksController);
+  });
+
+  describe('create', () => {
+    it('should create a new task and wrap it in a TaskDto', async () => {
+      const mockCreateTaskDto = new CreateTaskDto();
+
+      const result = await controller.create(mockCreateTaskDto);
+
+      expect(mockCreate).toHaveBeenCalledWith(mockCreateTaskDto);
+      expect(result).toEqual(new TaskDto(mockTask));
+    });
+  });
+
+  describe('getAll', () => {
+    it('should get all tasks mapped to TaskDto', async () => {
+      const result = await controller.getAll();
+
+      expect(mockGetAll).toHaveBeenCalled();
+      expect(result).toEqual([new TaskDto(mockTask), new TaskDto(mockTask)]);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a task by id', async () => {
+      await controller.delete(mockId);
+
+      expect(mockDelete).toHaveBeenCalledWith(mockId);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a task and wrap it in a TaskDto', async () => {
+      const mockUpdateTaskDto = new UpdateTaskDto();
+
+      const result = await controller.update(mockId, mockUpdateTaskDto);
+
+      expect(mockUpdate).toHaveBeenCalledWith(mockId, mockUpdateTaskDto);
+      expect(result).toEqual(new TaskDto(mockTask));
+    });
+  });
+});

--- a/nestjs/src/tasks/tasks.service.spec.ts
+++ b/nestjs/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Mocked } from 'vitest';
+import { Task } from '@entities/task';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto, UpdateTaskDto } from './dto';
+
+const mockTask = { id: 1, name: 'Task 1' } as Partial<Task> as Task;
+const mockFindResponse = [mockTask, mockTask];
+const mockSaveResponse = { id: 1 } as Task;
+
+const mockId = 1;
+
+describe('TasksService', () => {
+  let service: TasksService;
+  let repository: Mocked<Repository<Task>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        {
+          provide: getRepositoryToken(Task),
+          useValue: {
+            find: vi.fn(),
+            findOneBy: vi.fn(),
+            findOneByOrFail: vi.fn(),
+            save: vi.fn(),
+            update: vi.fn(),
+            softDelete: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TasksService>(TasksService);
+    repository = module.get(getRepositoryToken(Task));
+  });
+
+  describe('getAll', () => {
+    it('should return all tasks with relations ordered by updatedDate DESC', async () => {
+      repository.find.mockResolvedValue(mockFindResponse);
+
+      const result = await service.getAll();
+
+      expect(repository.find).toHaveBeenCalledWith({
+        relations: {
+          discipline: true,
+          courseTasks: { course: true },
+        },
+        order: {
+          updatedDate: 'DESC',
+        },
+      });
+      expect(result).toEqual(mockFindResponse);
+    });
+
+    it('should return an empty array when there are no tasks', async () => {
+      repository.find.mockResolvedValue([]);
+
+      const result = await service.getAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return a task by id', async () => {
+      repository.findOneBy.mockResolvedValue(mockTask);
+
+      const result = await service.getById(mockId);
+
+      expect(repository.findOneBy).toHaveBeenCalledWith({ id: mockId });
+      expect(result).toEqual(mockTask);
+    });
+
+    it('should return null when the task is not found', async () => {
+      repository.findOneBy.mockResolvedValue(null);
+
+      const result = await service.getById(mockId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('should save the task and return the freshly fetched entity', async () => {
+      const mockData = { name: 'Task 1' } as CreateTaskDto;
+      repository.save.mockResolvedValue(mockSaveResponse);
+      repository.findOneByOrFail.mockResolvedValue(mockTask);
+
+      const result = await service.create(mockData);
+
+      expect(repository.save).toHaveBeenCalledWith(mockData);
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: mockSaveResponse.id });
+      expect(result).toEqual(mockTask);
+    });
+  });
+
+  describe('update', () => {
+    it('should update the task and return the freshly fetched entity', async () => {
+      const mockData = { name: 'Updated' } as UpdateTaskDto;
+      repository.findOneByOrFail.mockResolvedValue(mockTask);
+
+      const result = await service.update(mockId, mockData);
+
+      expect(repository.update).toHaveBeenCalledWith(mockId, mockData);
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: mockId });
+      expect(result).toEqual(mockTask);
+    });
+  });
+
+  describe('delete', () => {
+    it('should soft-delete the task by id', async () => {
+      await service.delete(mockId);
+
+      expect(repository.softDelete).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/user-groups/user-groups.controller.spec.ts
+++ b/nestjs/src/user-groups/user-groups.controller.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserGroupsController } from './user-groups.controller';
+import { UserGroupsService } from './user-groups.service';
+import { CreateUserGroupDto, UpdateUserGroupDto } from './dto';
+import { UserGroupDto } from './dto/user-group.dto';
+
+const mockId = 1;
+
+const mockUserGroup = {
+  id: mockId,
+  name: 'Group',
+  roles: [],
+  users: [{ id: 10, githubId: 'github-a', name: 'Anna Apple' }],
+} as unknown as UserGroupDto;
+
+const mockCreate = vi.fn(() => Promise.resolve(mockUserGroup));
+const mockGetAll = vi.fn(() => Promise.resolve([mockUserGroup, mockUserGroup]));
+const mockUpdate = vi.fn(() => Promise.resolve(mockUserGroup));
+const mockDelete = vi.fn(() => Promise.resolve());
+
+const mockUserGroupsServiceFactory = vi.fn(() => ({
+  create: mockCreate,
+  getAll: mockGetAll,
+  update: mockUpdate,
+  delete: mockDelete,
+}));
+
+describe('UserGroupsController', () => {
+  let controller: UserGroupsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserGroupsController],
+      providers: [{ provide: UserGroupsService, useFactory: mockUserGroupsServiceFactory }],
+    }).compile();
+
+    controller = module.get<UserGroupsController>(UserGroupsController);
+  });
+
+  describe('create', () => {
+    it('should create a user group and wrap it in a UserGroupDto', async () => {
+      const dto = new CreateUserGroupDto();
+
+      const result = await controller.create(dto);
+
+      expect(mockCreate).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(new UserGroupDto(mockUserGroup));
+    });
+  });
+
+  describe('getAll', () => {
+    it('should get all user groups mapped to UserGroupDto', async () => {
+      const result = await controller.getAll();
+
+      expect(mockGetAll).toHaveBeenCalled();
+      expect(result).toEqual([new UserGroupDto(mockUserGroup), new UserGroupDto(mockUserGroup)]);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a user group and wrap it in a UserGroupDto', async () => {
+      const dto = new UpdateUserGroupDto();
+
+      const result = await controller.update(mockId, dto);
+
+      expect(mockUpdate).toHaveBeenCalledWith(mockId, dto);
+      expect(result).toEqual(new UserGroupDto(mockUserGroup));
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a user group by id', async () => {
+      await controller.delete(mockId);
+
+      expect(mockDelete).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/user-groups/user-groups.service.spec.ts
+++ b/nestjs/src/user-groups/user-groups.service.spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Mocked } from 'vitest';
+import { User } from '@entities/user';
+import { UserGroup } from '@entities/userGroup';
+import { UsersService } from 'src/users/users.service';
+import { UserGroupsService } from './user-groups.service';
+import { CreateUserGroupDto, UpdateUserGroupDto } from './dto';
+
+const mockId = 1;
+
+const makeUser = (id: number, githubId: string, firstName: string, lastName: string): User =>
+  ({ id, githubId, firstName, lastName }) as Partial<User> as User;
+
+const userA = makeUser(10, 'github-a', 'Anna', 'Apple');
+const userB = makeUser(20, 'github-b', 'Bob', 'Berry');
+
+const makeGroup = (id: number, name: string, users: number[]): UserGroup =>
+  ({ id, name, users, roles: [] }) as Partial<UserGroup> as UserGroup;
+
+describe('UserGroupsService', () => {
+  let service: UserGroupsService;
+  let repository: Mocked<Repository<UserGroup>>;
+  let usersService: Mocked<UsersService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserGroupsService,
+        {
+          provide: getRepositoryToken(UserGroup),
+          useValue: {
+            find: vi.fn(),
+            create: vi.fn(),
+            save: vi.fn(),
+            update: vi.fn(),
+            findOneByOrFail: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            getUsersByUserIds: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserGroupsService>(UserGroupsService);
+    repository = module.get(getRepositoryToken(UserGroup));
+    usersService = module.get(UsersService);
+  });
+
+  describe('getAll', () => {
+    it('should collect distinct user ids across groups, format and sort groups by name', async () => {
+      const groupZ = makeGroup(1, 'Zebra', [10, 20]);
+      const groupA = makeGroup(2, 'Alpha', [10, 10]); // duplicate user within a group
+      repository.find.mockResolvedValue([groupZ, groupA]);
+      usersService.getUsersByUserIds.mockResolvedValue([userA, userB]);
+
+      const result = await service.getAll();
+
+      // distinct ids only, preserving discovery order
+      expect(usersService.getUsersByUserIds).toHaveBeenCalledWith([10, 20]);
+      // sorted alphabetically: Alpha before Zebra
+      expect(result.map(g => g.name)).toEqual(['Alpha', 'Zebra']);
+      expect(result[0].users).toEqual([
+        { id: 10, githubId: 'github-a', name: 'Anna Apple' },
+        { id: 10, githubId: 'github-a', name: 'Anna Apple' },
+      ]);
+      expect(result[1].users).toEqual([
+        { id: 10, githubId: 'github-a', name: 'Anna Apple' },
+        { id: 20, githubId: 'github-b', name: 'Bob Berry' },
+      ]);
+    });
+
+    it('should substitute an UNKNOWN placeholder for users that cannot be resolved', async () => {
+      const group = makeGroup(1, 'Group', [99]);
+      repository.find.mockResolvedValue([group]);
+      usersService.getUsersByUserIds.mockResolvedValue([]);
+
+      const result = await service.getAll();
+
+      expect(result[0].users).toEqual([{ id: -1, githubId: 'UNKNOWN', name: '' }]);
+    });
+
+    it('should handle groups with no users', async () => {
+      const group = makeGroup(1, 'Empty', []);
+      repository.find.mockResolvedValue([group]);
+      usersService.getUsersByUserIds.mockResolvedValue([]);
+
+      const result = await service.getAll();
+
+      expect(usersService.getUsersByUserIds).toHaveBeenCalledWith([]);
+      expect(result[0].users).toEqual([]);
+    });
+
+    it('should join only the non-empty parts of the user name', async () => {
+      const onlyFirst = makeUser(30, 'github-c', 'Cleo', '');
+      const group = makeGroup(1, 'Group', [30]);
+      repository.find.mockResolvedValue([group]);
+      usersService.getUsersByUserIds.mockResolvedValue([onlyFirst]);
+
+      const result = await service.getAll();
+
+      expect(result[0].users).toEqual([{ id: 30, githubId: 'github-c', name: 'Cleo' }]);
+    });
+  });
+
+  describe('create', () => {
+    it('should create, save and format the new group', async () => {
+      const dto = { name: 'New', users: [10], roles: [] } as CreateUserGroupDto;
+      const created = makeGroup(5, 'New', [10]);
+      repository.create.mockReturnValue(created);
+      repository.save.mockResolvedValue(created);
+      usersService.getUsersByUserIds.mockResolvedValue([userA]);
+
+      const result = await service.create(dto);
+
+      expect(repository.create).toHaveBeenCalledWith(dto);
+      expect(repository.save).toHaveBeenCalledWith(created);
+      expect(usersService.getUsersByUserIds).toHaveBeenCalledWith([10]);
+      expect(result).toEqual({
+        id: 5,
+        name: 'New',
+        roles: [],
+        users: [{ id: 10, githubId: 'github-a', name: 'Anna Apple' }],
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should update, reload and format the group', async () => {
+      const dto = { name: 'Updated', users: [20], roles: [] } as UpdateUserGroupDto;
+      const reloaded = makeGroup(mockId, 'Updated', [20]);
+      repository.findOneByOrFail.mockResolvedValue(reloaded);
+      usersService.getUsersByUserIds.mockResolvedValue([userB]);
+
+      const result = await service.update(mockId, dto);
+
+      expect(repository.update).toHaveBeenCalledWith(mockId, dto);
+      expect(repository.findOneByOrFail).toHaveBeenCalledWith({ id: mockId });
+      expect(usersService.getUsersByUserIds).toHaveBeenCalledWith([20]);
+      expect(result).toEqual({
+        id: mockId,
+        name: 'Updated',
+        roles: [],
+        users: [{ id: 20, githubId: 'github-b', name: 'Bob Berry' }],
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('should hard-delete the group by id', async () => {
+      await service.delete(mockId);
+
+      expect(repository.delete).toHaveBeenCalledWith(mockId);
+    });
+  });
+});

--- a/nestjs/src/users-notifications/users.notifications.controller.spec.ts
+++ b/nestjs/src/users-notifications/users.notifications.controller.spec.ts
@@ -1,0 +1,183 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CurrentRequest } from 'src/auth';
+import { User } from '@entities/user';
+import { NotificationUserConnection } from '@entities/notificationUserConnection';
+import { UsersNotificationsController } from './users.notifications.controller';
+import { UserNotificationsService } from './users.notifications.service';
+import { AuthService } from '../auth';
+import { UsersService } from '../users/users.service';
+
+const req = (id: number) => ({ user: { id } }) as Partial<CurrentRequest> as CurrentRequest;
+
+describe('UsersNotificationsController', () => {
+  let controller: UsersNotificationsController;
+  const userNotificationsService = {
+    getUserNotificationsSettings: vi.fn(),
+    getUserConnections: vi.fn(),
+    saveUserNotificationSettings: vi.fn(),
+    sendEmailConfirmation: vi.fn(),
+    getUserConnection: vi.fn(),
+    saveUserConnection: vi.fn(),
+    sendEventNotification: vi.fn(),
+  };
+  const authService = { getLoginStateByUserId: vi.fn() };
+  const usersService = { getUserByUserId: vi.fn() };
+
+  beforeEach(async () => {
+    Object.values(userNotificationsService).forEach(fn => fn.mockReset());
+    authService.getLoginStateByUserId.mockReset();
+    usersService.getUserByUserId.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersNotificationsController],
+      providers: [
+        { provide: UserNotificationsService, useValue: userNotificationsService },
+        { provide: AuthService, useValue: authService },
+        { provide: UsersService, useValue: usersService },
+      ],
+    }).compile();
+
+    controller = module.get(UsersNotificationsController);
+  });
+
+  describe('getUserConnections', () => {
+    it('maps connections to a keyed dto and attaches lastLinkSentAt for the matching channel', async () => {
+      userNotificationsService.getUserConnections.mockResolvedValue([
+        { channelId: 'email', externalId: 'a@b.com', enabled: true },
+        { channelId: 'telegram', externalId: '111', enabled: false },
+      ]);
+      const createdDate = new Date();
+      authService.getLoginStateByUserId.mockResolvedValue({ data: { channelId: 'email' }, createdDate });
+      usersService.getUserByUserId.mockResolvedValue({ discord: null } as User);
+
+      const result = await controller.getUserConnections(req(7));
+
+      expect(result.connections.email).toEqual({
+        value: 'a@b.com',
+        enabled: true,
+        lastLinkSentAt: createdDate,
+      });
+      // telegram channel does not match the last link channel → undefined
+      expect(result.connections.telegram).toEqual({
+        value: '111',
+        enabled: false,
+        lastLinkSentAt: undefined,
+      });
+      expect(result.connections.discord).toBeUndefined();
+    });
+
+    it('adds a synthetic always-enabled discord connection from the profile', async () => {
+      userNotificationsService.getUserConnections.mockResolvedValue([]);
+      authService.getLoginStateByUserId.mockResolvedValue(null);
+      usersService.getUserByUserId.mockResolvedValue({ discord: { id: 999 } } as Partial<User> as User);
+
+      const result = await controller.getUserConnections(req(7));
+
+      expect(result.connections.discord).toEqual({ value: '999', enabled: true });
+    });
+
+    it('omits lastLinkSentAt when there is no last login state', async () => {
+      userNotificationsService.getUserConnections.mockResolvedValue([
+        { channelId: 'email', externalId: 'a@b.com', enabled: true },
+      ]);
+      authService.getLoginStateByUserId.mockResolvedValue(null);
+      usersService.getUserByUserId.mockResolvedValue({ discord: null } as User);
+
+      const result = await controller.getUserConnections(req(7));
+
+      expect(result.connections.email.lastLinkSentAt).toBeUndefined();
+    });
+  });
+
+  describe('getUserNotifications', () => {
+    it('combines settings and connections into the response shape', async () => {
+      userNotificationsService.getUserNotificationsSettings.mockResolvedValue([
+        { id: 'taskGrade', name: 'Task grade', enabled: true, settings: [{ channelId: 'email', enabled: true }] },
+      ]);
+      userNotificationsService.getUserConnections.mockResolvedValue([]);
+      authService.getLoginStateByUserId.mockResolvedValue(null);
+      usersService.getUserByUserId.mockResolvedValue({ discord: null } as User);
+
+      const result = await controller.getUserNotifications(req(7));
+
+      expect(userNotificationsService.getUserNotificationsSettings).toHaveBeenCalledWith(7);
+      expect(result.notifications).toEqual([
+        { id: 'taskGrade', name: 'Task grade', enabled: true, settings: { email: true } },
+      ]);
+      expect(result.connections).toEqual({});
+    });
+  });
+
+  describe('updateUserNotifications', () => {
+    it('delegates to the service with the user id and dto', async () => {
+      userNotificationsService.saveUserNotificationSettings.mockResolvedValue(undefined);
+      const dto = [{ notificationId: 'taskGrade', channelId: 'email' as const, enabled: true }];
+
+      await controller.updateUserNotifications(req(7), dto);
+
+      expect(userNotificationsService.saveUserNotificationSettings).toHaveBeenCalledWith(7, dto);
+    });
+  });
+
+  describe('sendEmailConfirmation', () => {
+    it('delegates to the service with the user id', async () => {
+      userNotificationsService.sendEmailConfirmation.mockResolvedValue(undefined);
+
+      await controller.sendEmailConfirmation(req(7));
+
+      expect(userNotificationsService.sendEmailConfirmation).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('findConnection', () => {
+    it('returns a NotificationConnectionDto when found', async () => {
+      const connection = {
+        channelId: 'email',
+        externalId: 'a@b.com',
+        userId: 7,
+        enabled: true,
+      } as Partial<NotificationUserConnection> as NotificationUserConnection;
+      userNotificationsService.getUserConnection.mockResolvedValue(connection);
+
+      const result = await controller.findConnection({ channelId: 'email', externalId: 'a@b.com' });
+
+      expect(result).toMatchObject({ channelId: 'email', externalId: 'a@b.com', userId: 7, enabled: true });
+    });
+
+    it('throws NotFoundException when there is no connection', async () => {
+      userNotificationsService.getUserConnection.mockResolvedValue(null);
+
+      await expect(controller.findConnection({ channelId: 'email' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createUserConnection', () => {
+    it('saves the connection and wraps it in a NotificationConnectionDto', async () => {
+      const saved = {
+        channelId: 'email',
+        externalId: 'a@b.com',
+        userId: 7,
+        enabled: true,
+      } as Partial<NotificationUserConnection> as NotificationUserConnection;
+      userNotificationsService.saveUserConnection.mockResolvedValue(saved);
+      const dto = { channelId: 'email' as const, externalId: 'a@b.com', userId: 7, enabled: true };
+
+      const result = await controller.createUserConnection(dto);
+
+      expect(userNotificationsService.saveUserConnection).toHaveBeenCalledWith(dto);
+      expect(result).toMatchObject({ channelId: 'email', userId: 7 });
+    });
+  });
+
+  describe('sendNotification', () => {
+    it('delegates to the service', async () => {
+      userNotificationsService.sendEventNotification.mockResolvedValue(undefined);
+      const dto = { notificationId: 'taskGrade' as const, userId: 7, data: {} };
+
+      await controller.sendNotification(dto);
+
+      expect(userNotificationsService.sendEventNotification).toHaveBeenCalledWith(dto);
+    });
+  });
+});

--- a/nestjs/src/users-notifications/users.notifications.service.spec.ts
+++ b/nestjs/src/users-notifications/users.notifications.service.spec.ts
@@ -1,0 +1,393 @@
+import type { Mocked } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Notification } from '@entities/notification';
+import { NotificationUserSettings } from '@entities/notificationUserSettings';
+import { NotificationUserConnection } from '@entities/notificationUserConnection';
+import { NotificationChannelSettings } from '@entities/notificationChannelSettings';
+import { User } from '@entities/user';
+import { IsNull } from 'typeorm';
+import { UserNotificationsService } from './users.notifications.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { AuthService } from '../auth';
+import { UsersService } from '../users/users.service';
+import { GithubStrategy } from '../auth/strategies/github.strategy';
+
+type QueryBuilderMock = {
+  leftJoinAndMapMany: ReturnType<typeof vi.fn>;
+  innerJoinAndMapMany: ReturnType<typeof vi.fn>;
+  innerJoinAndMapOne: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  getMany: ReturnType<typeof vi.fn>;
+  getOne: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  into: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  orUpdate: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+};
+
+const createQueryBuilderMock = (): QueryBuilderMock => {
+  const qb: Partial<QueryBuilderMock> = {
+    leftJoinAndMapMany: vi.fn(),
+    innerJoinAndMapMany: vi.fn(),
+    innerJoinAndMapOne: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    getMany: vi.fn(),
+    getOne: vi.fn(),
+    insert: vi.fn(),
+    into: vi.fn(),
+    values: vi.fn(),
+    orUpdate: vi.fn(),
+    execute: vi.fn(),
+  };
+  qb.leftJoinAndMapMany!.mockReturnValue(qb);
+  qb.innerJoinAndMapMany!.mockReturnValue(qb);
+  qb.innerJoinAndMapOne!.mockReturnValue(qb);
+  qb.where!.mockReturnValue(qb);
+  qb.orderBy!.mockReturnValue(qb);
+  qb.insert!.mockReturnValue(qb);
+  qb.into!.mockReturnValue(qb);
+  qb.values!.mockReturnValue(qb);
+  qb.orUpdate!.mockReturnValue(qb);
+  return qb as QueryBuilderMock;
+};
+
+describe('UserNotificationsService', () => {
+  let service: UserNotificationsService;
+  let notificationsRepository: Mocked<{ createQueryBuilder: ReturnType<typeof vi.fn> }>;
+  let userNotificationsRepository: Mocked<{ createQueryBuilder: ReturnType<typeof vi.fn> }>;
+  let connectionRepository: Mocked<{
+    findOne: ReturnType<typeof vi.fn>;
+    find: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  }>;
+  let channelsSettingsRepository: Mocked<{ createQueryBuilder: ReturnType<typeof vi.fn> }>;
+  let notificationsService: Mocked<{
+    getNotification: ReturnType<typeof vi.fn>;
+    buildChannelMessage: ReturnType<typeof vi.fn>;
+    publishNotification: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+  }>;
+  let authService: Mocked<{ getLoginStateByUserId: ReturnType<typeof vi.fn> }>;
+  let usersService: Mocked<{ getUserByUserId: ReturnType<typeof vi.fn> }>;
+  let githubService: Mocked<{ getAuthorizeUrl: ReturnType<typeof vi.fn> }>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserNotificationsService,
+        { provide: getRepositoryToken(Notification), useValue: { createQueryBuilder: vi.fn() } },
+        { provide: getRepositoryToken(NotificationUserSettings), useValue: { createQueryBuilder: vi.fn() } },
+        {
+          provide: getRepositoryToken(NotificationUserConnection),
+          useValue: { findOne: vi.fn(), find: vi.fn(), save: vi.fn(), delete: vi.fn() },
+        },
+        { provide: getRepositoryToken(NotificationChannelSettings), useValue: { createQueryBuilder: vi.fn() } },
+        {
+          provide: NotificationsService,
+          useValue: {
+            getNotification: vi.fn(),
+            buildChannelMessage: vi.fn(),
+            publishNotification: vi.fn(),
+            sendMessage: vi.fn(),
+          },
+        },
+        { provide: AuthService, useValue: { getLoginStateByUserId: vi.fn() } },
+        { provide: UsersService, useValue: { getUserByUserId: vi.fn() } },
+        { provide: GithubStrategy, useValue: { getAuthorizeUrl: vi.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(UserNotificationsService);
+    notificationsRepository = module.get(getRepositoryToken(Notification));
+    userNotificationsRepository = module.get(getRepositoryToken(NotificationUserSettings));
+    connectionRepository = module.get(getRepositoryToken(NotificationUserConnection));
+    channelsSettingsRepository = module.get(getRepositoryToken(NotificationChannelSettings));
+    notificationsService = module.get(NotificationsService);
+    authService = module.get(AuthService);
+    usersService = module.get(UsersService);
+    githubService = module.get(GithubStrategy);
+  });
+
+  describe('getUserNotificationsSettings', () => {
+    it('builds an enabled event-notification query with mapped user settings', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([{ id: 'taskGrade', settings: [] }]);
+      notificationsRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getUserNotificationsSettings(7);
+
+      expect(notificationsRepository.createQueryBuilder).toHaveBeenCalledWith('notification');
+      expect(qb.leftJoinAndMapMany).toHaveBeenCalledWith(
+        'notification.settings',
+        NotificationUserSettings,
+        'userSettings',
+        'userSettings.notificationId = notification.id and userSettings.userId = :userId',
+        { userId: 7 },
+      );
+      expect(qb.where).toHaveBeenCalledWith({ enabled: true, type: 'event', parent: IsNull() });
+      expect(qb.orderBy).toHaveBeenCalledWith('name');
+      expect(result).toEqual([{ id: 'taskGrade', settings: [] }]);
+    });
+  });
+
+  describe('saveUserNotificationSettings', () => {
+    it('upserts settings rows, mapping each notification to the user id', async () => {
+      const qb = createQueryBuilderMock();
+      qb.execute.mockResolvedValue({});
+      userNotificationsRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.saveUserNotificationSettings(7, [
+        { notificationId: 'taskGrade', channelId: 'email', enabled: true },
+      ]);
+
+      expect(qb.into).toHaveBeenCalledWith(NotificationUserSettings);
+      expect(qb.values).toHaveBeenCalledWith([
+        { notificationId: 'taskGrade', channelId: 'email', enabled: true, userId: 7 },
+      ]);
+      expect(qb.orUpdate).toHaveBeenCalledWith(['enabled'], ['channelId', 'userId', 'notificationId']);
+      expect(qb.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('getUserConnection', () => {
+    it('returns undefined when neither userId nor externalId is provided', () => {
+      const result = service.getUserConnection({ channelId: 'email' });
+      expect(result).toBeUndefined();
+      expect(connectionRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('queries by externalId when provided (preferred over userId)', () => {
+      connectionRepository.findOne.mockReturnValue('found' as never);
+
+      const result = service.getUserConnection({ channelId: 'email', externalId: 'a@b.com', userId: 5 });
+
+      expect(connectionRepository.findOne).toHaveBeenCalledWith({
+        where: { channelId: 'email', externalId: 'a@b.com' },
+      });
+      expect(result).toBe('found');
+    });
+
+    it('queries by userId when externalId is absent', () => {
+      connectionRepository.findOne.mockReturnValue('found' as never);
+
+      service.getUserConnection({ channelId: 'telegram', userId: 5 });
+
+      expect(connectionRepository.findOne).toHaveBeenCalledWith({
+        where: { channelId: 'telegram', userId: 5 },
+      });
+    });
+  });
+
+  describe('getUserConnections', () => {
+    it('finds all connections for a user', () => {
+      connectionRepository.find.mockReturnValue('list' as never);
+
+      const result = service.getUserConnections(7);
+
+      expect(connectionRepository.find).toHaveBeenCalledWith({ where: { userId: 7 } });
+      expect(result).toBe('list');
+    });
+  });
+
+  describe('saveUserConnection', () => {
+    it('delegates to repository save', () => {
+      connectionRepository.save.mockReturnValue('saved' as never);
+      const dto = { channelId: 'email' as const, externalId: 'a@b.com', userId: 7, enabled: true };
+
+      const result = service.saveUserConnection(dto);
+
+      expect(connectionRepository.save).toHaveBeenCalledWith(dto);
+      expect(result).toBe('saved');
+    });
+  });
+
+  describe('deleteUserConnection', () => {
+    it('delegates to repository delete', () => {
+      connectionRepository.delete.mockReturnValue('deleted' as never);
+
+      const result = service.deleteUserConnection({ channelId: 'email', userId: 7 });
+
+      expect(connectionRepository.delete).toHaveBeenCalledWith({ channelId: 'email', userId: 7 });
+      expect(result).toBe('deleted');
+    });
+  });
+
+  describe('sendEventNotification', () => {
+    const dto = { notificationId: 'taskGrade' as const, userId: 7, data: { name: 'John' } };
+
+    it('returns early when the notification is missing', async () => {
+      notificationsService.getNotification.mockResolvedValue(null);
+
+      await service.sendEventNotification(dto);
+
+      expect(notificationsService.publishNotification).not.toHaveBeenCalled();
+    });
+
+    it('returns early when the notification is disabled', async () => {
+      notificationsService.getNotification.mockResolvedValue({ enabled: false, type: 'event' });
+
+      await service.sendEventNotification(dto);
+
+      expect(notificationsService.publishNotification).not.toHaveBeenCalled();
+    });
+
+    it('publishes built messages for event-type notifications, skipping discord channels', async () => {
+      notificationsService.getNotification.mockResolvedValue({ enabled: true, type: 'event' });
+
+      // getUserNotificationSettings (event path) uses the notifications query builder
+      const qb = createQueryBuilderMock();
+      qb.getOne.mockResolvedValue({
+        channels: [{ channelId: 'email' }, { channelId: 'telegram' }, { channelId: 'discord' }],
+        userSettings: [
+          { channelId: 'email', enabled: true },
+          { channelId: 'telegram', enabled: true },
+        ],
+        connections: [
+          { channelId: 'email', externalId: 'a@b.com', enabled: true },
+          { channelId: 'telegram', externalId: '111', enabled: true },
+          { channelId: 'discord', externalId: '222', enabled: true },
+        ],
+      });
+      notificationsRepository.createQueryBuilder.mockReturnValue(qb);
+
+      notificationsService.buildChannelMessage.mockImplementation((channel: { channelId: string }) => ({
+        channelId: channel.channelId,
+        to: 'to',
+        template: { body: 'b' },
+      }));
+
+      await service.sendEventNotification(dto);
+
+      // discord channel is filtered out before buildChannelMessage
+      const builtChannelIds = notificationsService.buildChannelMessage.mock.calls.map(
+        (call: [{ channelId: string }]) => call[0].channelId,
+      );
+      expect(builtChannelIds).toContain('email');
+      expect(builtChannelIds).toContain('telegram');
+      expect(builtChannelIds).not.toContain('discord');
+
+      expect(notificationsService.publishNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notificationId: 'taskGrade',
+          userId: 7,
+          channelId: expect.arrayContaining(['email', 'telegram']),
+        }),
+      );
+    });
+
+    it('does not publish when no message could be built (empty channel map)', async () => {
+      notificationsService.getNotification.mockResolvedValue({ enabled: true, type: 'event' });
+      const qb = createQueryBuilderMock();
+      qb.getOne.mockResolvedValue({
+        channels: [{ channelId: 'email' }],
+        userSettings: [{ channelId: 'email', enabled: true }],
+        connections: [{ channelId: 'email', externalId: 'a@b.com', enabled: true }],
+      });
+      notificationsRepository.createQueryBuilder.mockReturnValue(qb);
+      notificationsService.buildChannelMessage.mockReturnValue(undefined);
+
+      await service.sendEventNotification(dto);
+
+      expect(notificationsService.publishNotification).not.toHaveBeenCalled();
+    });
+
+    it('uses the connection-settings path for non-event (message) notifications', async () => {
+      notificationsService.getNotification.mockResolvedValue({ enabled: true, type: 'message' });
+
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        { channelId: 'email', connection: { externalId: 'a@b.com', enabled: false } },
+        { channelId: 'telegram', connection: { externalId: '111', enabled: true } },
+      ]);
+      channelsSettingsRepository.createQueryBuilder.mockReturnValue(qb);
+      notificationsService.buildChannelMessage.mockImplementation((channel: { channelId: string }) => ({
+        channelId: channel.channelId,
+        to: 'to',
+        template: { body: 'b' },
+      }));
+
+      await service.sendEventNotification(dto);
+
+      // email is allowed despite enabled=false (special-cased); telegram enabled=true also passes
+      expect(channelsSettingsRepository.createQueryBuilder).toHaveBeenCalledWith('channel');
+      expect(notificationsService.publishNotification).toHaveBeenCalled();
+    });
+  });
+
+  describe('sendEmailConfirmation', () => {
+    const mockUser = { id: 7, contactsEmail: 'a@b.com' } as Partial<User> as User;
+
+    it('returns early when the user has no contacts email', async () => {
+      usersService.getUserByUserId.mockResolvedValue({ id: 7, contactsEmail: null } as User);
+      authService.getLoginStateByUserId.mockResolvedValue(null);
+      connectionRepository.find.mockResolvedValue([]);
+
+      await service.sendEmailConfirmation(7);
+
+      expect(githubService.getAuthorizeUrl).not.toHaveBeenCalled();
+      expect(notificationsService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns early when an enabled email connection already exists', async () => {
+      usersService.getUserByUserId.mockResolvedValue(mockUser);
+      authService.getLoginStateByUserId.mockResolvedValue(null);
+      connectionRepository.find.mockResolvedValue([{ channelId: 'email', enabled: true }]);
+
+      await service.sendEmailConfirmation(7);
+
+      expect(notificationsService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('throws when a link was sent less than a minute ago', async () => {
+      usersService.getUserByUserId.mockResolvedValue(mockUser);
+      authService.getLoginStateByUserId.mockResolvedValue({ createdDate: new Date() as never });
+      connectionRepository.find.mockResolvedValue([]);
+
+      await expect(service.sendEmailConfirmation(7)).rejects.toThrow(BadRequestException);
+      expect(notificationsService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends a confirmation message with an authorize url', async () => {
+      usersService.getUserByUserId.mockResolvedValue(mockUser);
+      // login state older than a minute → no throttle
+      authService.getLoginStateByUserId.mockResolvedValue({
+        createdDate: new Date(Date.now() - 1000 * 120) as never,
+      });
+      connectionRepository.find.mockResolvedValue([{ channelId: 'email', enabled: false }]);
+      githubService.getAuthorizeUrl.mockResolvedValue('https://auth.example/confirm');
+
+      await service.sendEmailConfirmation(7);
+
+      expect(githubService.getAuthorizeUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 7,
+          data: { channelId: 'email', externalId: 'a@b.com' },
+        }),
+      );
+      expect(notificationsService.sendMessage).toHaveBeenCalledWith({
+        notificationId: 'emailConfirmation',
+        userId: 7,
+        data: { confirmationLink: 'https://auth.example/confirm' },
+        channelId: 'email',
+        channelValue: 'a@b.com',
+      });
+    });
+
+    it('skips the login-state lookup and throttle when checkTimeLimit is false', async () => {
+      usersService.getUserByUserId.mockResolvedValue(mockUser);
+      connectionRepository.find.mockResolvedValue([]);
+      githubService.getAuthorizeUrl.mockResolvedValue('https://auth.example/confirm');
+
+      await service.sendEmailConfirmation(7, false);
+
+      expect(authService.getLoginStateByUserId).not.toHaveBeenCalled();
+      expect(notificationsService.sendMessage).toHaveBeenCalled();
+    });
+  });
+});

--- a/nestjs/src/users/users-extra.spec.ts
+++ b/nestjs/src/users/users-extra.spec.ts
@@ -1,0 +1,345 @@
+import type { Mocked } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { In } from 'typeorm';
+import { User } from '@entities/user';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+// Module-scope fixtures
+const mockUser = {
+  id: 1,
+  githubId: 'john-doe',
+  firstName: 'John',
+  lastName: 'Doe',
+  primaryEmail: 'john@example.com',
+} as Partial<User> as User;
+
+type QueryBuilderMock = {
+  where: ReturnType<typeof vi.fn>;
+  orWhere: ReturnType<typeof vi.fn>;
+  andWhere: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  getMany: ReturnType<typeof vi.fn>;
+  getRawMany: ReturnType<typeof vi.fn>;
+};
+
+const createQueryBuilderMock = (): QueryBuilderMock => {
+  const qb: Partial<QueryBuilderMock> = {
+    where: vi.fn(),
+    orWhere: vi.fn(),
+    andWhere: vi.fn(),
+    select: vi.fn(),
+    limit: vi.fn(),
+    getMany: vi.fn(),
+    getRawMany: vi.fn(),
+  };
+  qb.where!.mockReturnValue(qb);
+  qb.orWhere!.mockReturnValue(qb);
+  qb.andWhere!.mockReturnValue(qb);
+  qb.select!.mockReturnValue(qb);
+  qb.limit!.mockReturnValue(qb);
+  return qb as QueryBuilderMock;
+};
+
+describe('UsersService (extended)', () => {
+  let service: UsersService;
+  let repo: Mocked<{
+    find: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+    findOneOrFail: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    createQueryBuilder: ReturnType<typeof vi.fn>;
+  }>;
+
+  beforeEach(async () => {
+    const repoValue = {
+      find: vi.fn(),
+      findOne: vi.fn(),
+      findOneOrFail: vi.fn(),
+      save: vi.fn(),
+      update: vi.fn(),
+      createQueryBuilder: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UsersService, { provide: getRepositoryToken(User), useValue: repoValue }],
+    }).compile();
+
+    service = module.get(UsersService);
+    repo = module.get(getRepositoryToken(User));
+  });
+
+  describe('getByGithubId', () => {
+    it('lowercases the id and returns the first matched user', async () => {
+      repo.find.mockResolvedValue([mockUser]);
+
+      const result = await service.getByGithubId('John-Doe');
+
+      expect(repo.find).toHaveBeenCalledWith({ where: { githubId: 'john-doe' } });
+      expect(result).toBe(mockUser);
+    });
+
+    it('returns null when no user is found', async () => {
+      repo.find.mockResolvedValue([]);
+
+      const result = await service.getByGithubId('Nobody');
+
+      expect(repo.find).toHaveBeenCalledWith({ where: { githubId: 'nobody' } });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUserByProvider', () => {
+    it('queries by provider and providerUserId with relations', async () => {
+      repo.findOne.mockResolvedValue(mockUser);
+
+      const result = await service.getUserByProvider('github', '12345');
+
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { provider: 'github', providerUserId: '12345' },
+        relations: ['mentors', 'students', 'mentors.course', 'students.course', 'courseUsers', 'courseUsers.course'],
+      });
+      expect(result).toBe(mockUser);
+    });
+  });
+
+  describe('saveUser', () => {
+    it('delegates to the repository save', async () => {
+      const partial = { githubId: 'john-doe' };
+      repo.save.mockResolvedValue(mockUser);
+
+      const result = await service.saveUser(partial);
+
+      expect(repo.save).toHaveBeenCalledWith(partial);
+      expect(result).toBe(mockUser);
+    });
+  });
+
+  describe('updateUser', () => {
+    it('delegates to the repository update with id and partial', async () => {
+      repo.update.mockResolvedValue({} as never);
+
+      await service.updateUser(1, { firstName: 'Jane' });
+
+      expect(repo.update).toHaveBeenCalledWith(1, { firstName: 'Jane' });
+    });
+  });
+
+  describe('getUserByUserId', () => {
+    it('uses findOneOrFail by id', async () => {
+      repo.findOneOrFail.mockResolvedValue(mockUser);
+
+      const result = await service.getUserByUserId(1);
+
+      expect(repo.findOneOrFail).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(result).toBe(mockUser);
+    });
+  });
+
+  describe('getUsersByUserIds', () => {
+    it('queries with an In clause on ids', async () => {
+      repo.find.mockResolvedValue([mockUser]);
+
+      const result = await service.getUsersByUserIds([1, 2, 3]);
+
+      expect(repo.find).toHaveBeenCalledWith({ where: { id: In([1, 2, 3]) } });
+      expect(result).toEqual([mockUser]);
+    });
+  });
+
+  describe('getFullName (static)', () => {
+    it('joins trimmed first and last names', () => {
+      expect(UsersService.getFullName({ firstName: ' John ', lastName: ' Doe ' })).toBe('John Doe');
+    });
+
+    it('returns only first name when last name is empty', () => {
+      expect(UsersService.getFullName({ firstName: 'John', lastName: '' })).toBe('John');
+    });
+
+    it('returns only last name when first name is empty', () => {
+      expect(UsersService.getFullName({ firstName: '', lastName: 'Doe' })).toBe('Doe');
+    });
+
+    it('returns an empty string when both are empty', () => {
+      expect(UsersService.getFullName({ firstName: '', lastName: '' })).toBe('');
+    });
+  });
+
+  describe('searchUsers', () => {
+    it('returns an empty list when query is missing', async () => {
+      const result = await service.searchUsers();
+
+      expect(result).toEqual([]);
+      expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list when query is an empty string', async () => {
+      const result = await service.searchUsers('');
+
+      expect(result).toEqual([]);
+      expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('builds one bracket per search term and loads full users by ids', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getRawMany.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+      repo.createQueryBuilder.mockReturnValue(qb);
+      repo.find.mockResolvedValue([mockUser]);
+
+      const result = await service.searchUsers(' John Doe ');
+
+      // 'John Doe%' split by space => two terms => two andWhere calls
+      expect(qb.select).toHaveBeenCalledWith(['id']);
+      expect(qb.limit).toHaveBeenCalledWith(20);
+      expect(qb.andWhere).toHaveBeenCalledTimes(2);
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { id: In([1, 2]) },
+        relations: ['mentors', 'students', 'mentors.course', 'students.course', 'students.certificate'],
+      });
+      expect(result).toEqual([mockUser]);
+    });
+
+    it('returns an empty list and skips the second query when no ids match', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getRawMany.mockResolvedValue([]);
+      repo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.searchUsers('ghost');
+
+      expect(result).toEqual([]);
+      expect(repo.find).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPrimaryUserFields (static)', () => {
+    it('uses the default "user" model name', () => {
+      expect(UsersService.getPrimaryUserFields()).toEqual([
+        'user.id',
+        'user.firstName',
+        'user.lastName',
+        'user.githubId',
+        'user.cityName',
+        'user.countryName',
+        'user.discord',
+      ]);
+    });
+
+    it('prefixes with a custom model name', () => {
+      expect(UsersService.getPrimaryUserFields('student')).toEqual([
+        'student.id',
+        'student.firstName',
+        'student.lastName',
+        'student.githubId',
+        'student.cityName',
+        'student.countryName',
+        'student.discord',
+      ]);
+    });
+  });
+
+  describe('getUserContactsFields (static)', () => {
+    it('uses the default "user" model name', () => {
+      expect(UsersService.getUserContactsFields()).toEqual([
+        'user.contactsEmail',
+        'user.contactsTelegram',
+        'user.contactsLinkedIn',
+        'user.contactsSkype',
+        'user.contactsPhone',
+      ]);
+    });
+
+    it('prefixes with a custom model name', () => {
+      expect(UsersService.getUserContactsFields('m')).toEqual([
+        'm.contactsEmail',
+        'm.contactsTelegram',
+        'm.contactsLinkedIn',
+        'm.contactsSkype',
+        'm.contactsPhone',
+      ]);
+    });
+  });
+});
+
+describe('UsersController.searchUsers', () => {
+  const mockSearchUsers = vi.fn();
+  let controller: UsersController;
+
+  const adminReq = { user: { isAdmin: true, isHirer: false } } as never;
+  const hirerReq = { user: { isAdmin: false, isHirer: true } } as never;
+  const plainReq = { user: { isAdmin: false, isHirer: false } } as never;
+
+  const fullUser = {
+    id: 1,
+    githubId: 'john-doe',
+    firstName: 'John',
+    lastName: 'Doe',
+    primaryEmail: 'john@example.com',
+    cityName: 'Minsk',
+    countryName: 'Belarus',
+    discord: null,
+    contactsEmail: 'john@contact.com',
+    students: [],
+    mentors: [],
+  } as Partial<User> as User;
+
+  beforeEach(async () => {
+    mockSearchUsers.mockReset();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: { searchUsers: mockSearchUsers } }],
+    }).compile();
+
+    controller = module.get(UsersController);
+  });
+
+  it('delegates the query to the service', async () => {
+    mockSearchUsers.mockResolvedValue([]);
+
+    await controller.searchUsers(plainReq, 'john');
+
+    expect(mockSearchUsers).toHaveBeenCalledWith('john');
+  });
+
+  it('passes elevated visibility (true) for admins, exposing contacts', async () => {
+    mockSearchUsers.mockResolvedValue([fullUser]);
+
+    const result = await controller.searchUsers(adminReq, 'john');
+
+    // Admin visibility => UserSearchDto exposes the real contact/city fields
+    expect(result).toHaveLength(1);
+    expect(result[0].contactsEmail).toBe('john@contact.com');
+    expect(result[0].primaryEmail).toBe('john@example.com');
+    expect(result[0].cityName).toBe('Minsk');
+  });
+
+  it('passes elevated visibility (true) for hirers, exposing contacts', async () => {
+    mockSearchUsers.mockResolvedValue([fullUser]);
+
+    const result = await controller.searchUsers(hirerReq, 'john');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].contactsEmail).toBe('john@contact.com');
+  });
+
+  it('passes restricted visibility (false) for regular users, masking contacts', async () => {
+    mockSearchUsers.mockResolvedValue([fullUser]);
+
+    const result = await controller.searchUsers(plainReq, 'john');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].contactsEmail).toBeNull();
+    expect(result[0].primaryEmail).toBeNull();
+    expect(result[0].cityName).toBeNull();
+  });
+
+  it('maps an empty result list to an empty array', async () => {
+    mockSearchUsers.mockResolvedValue([]);
+
+    const result = await controller.searchUsers(adminReq, 'nobody');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/nestjs/vitest.config.mts
+++ b/nestjs/vitest.config.mts
@@ -47,14 +47,17 @@ export default mergeConfig(
           'src/constants.ts',
         ],
         reportsDirectory: './coverage',
-        // Ratcheted floor enforced in CI: starts just below the post-exclude
-        // baseline so this config-only change passes, then bumps up as each
-        // unit-test tier lands so coverage can only move up, never regress.
+        // Coverage floor: a flat 90% — the project's quality bar, NOT pinned to
+        // the current ~99.6%. Intent: coverage may move freely as long as it
+        // stays >= 90% (a refactor that drops 99.6% -> 92% is fine and won't
+        // fail CI); only dropping below 90% fails. We deliberately avoid
+        // vitest's `autoUpdate` ratchet, which would keep raising the floor
+        // toward 100% and then fail on any dip below the new high-water mark.
         thresholds: {
-          statements: 63,
-          branches: 66,
-          functions: 57,
-          lines: 63,
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
         },
       },
       deps: {


### PR DESCRIPTION
## What & why

**Phase 4 of 4** — the long tail. Comprehensive specs for the remaining standalone feature modules and their thin controllers, then set the final coverage floor. After this lands the nestjs backend is at **~99.6% statements / 97.8% branches / 99.7% functions / 99.6% lines** (178 spec files, ~2011 tests).

> Stacked on #3072. Merge the earlier phases first; GitHub retargets this automatically as they land.

## Changes
New co-located specs (no source changes — behavior asserted as-is) for: users & users-notifications, notifications, tasks & tasks-criteria, events, opportunities, certificates (+ template catalog), alerts, contributors, activity (webhook signature verification), discord-servers, devtools, auto-test, schedule, session, user-groups, prompts, cloud-api, config, and the course listener. Controllers assert each route delegates with the right args and returns its result; services cover every branch and error path.

Plus: set `coverage.thresholds` to a flat **90%** in `vitest.config.mts`.

## Coverage policy (flat 90%, not pinned to current)
The floor is the project's quality bar (90%), **not** the current ~99.6%. Intent:
- coverage may move freely as long as it stays **≥ 90%** — a refactor that drops 99.6% → 92% is fine and won't fail CI;
- only dropping **below 90%** fails.

We deliberately don't use vitest's `autoUpdate` ratchet (it would keep raising the floor toward 100% and then fail on any dip below the new high-water mark). 90% also gives a wide buffer against the v8 provider's occasional measurement jitter.

## Verification
- ✅ `npm run test:ci` (nestjs, Node 24): **178 files, ~2011 tests, all green**; coverage **99.6 / 97.8 / 99.7 / 99.6**, clears the 90% floor.
- ✅ `eslint src` clean; `oxfmt --check` clean.

## Result
The whole nestjs backend now has comprehensive, branch-level unit coverage with a stable ≥90% gate enforced via the existing `test:ci` step, completing the four-phase initiative (#3070 → #3071 → #3072 → this).

Phase 4 of 4 — nestjs unit-test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)