### PR TITLE
test(client): scope coverage reporting and gate test:ci on it

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "prod": "next start -p 8080",
     "lint": "eslint src",
     "test": "vitest run",
-    "test:ci": "vitest run",
+    "test:ci": "vitest run --coverage",
     "test:watch": "vitest",
     "test:e2e": "npx playwright test",
     "coverage": "vitest run --coverage"

--- a/client/vitest.config.mts
+++ b/client/vitest.config.mts
@@ -17,11 +17,44 @@ export default mergeConfig(
       environment: 'jsdom',
       include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
       setupFiles: ['src/setupTests.ts'],
-      testTimeout: 30000,
+      // antd v6 in jsdom is CPU-heavy; under coverage instrumentation + parallelism
+      // the slowest Table/Form-validation tests can exceed 30s on busy/CI runners.
+      testTimeout: 60000,
+      hookTimeout: 60000,
       env: {
         TZ: 'UTC',
       },
       css: false,
+      coverage: {
+        include: ['src/**/*.{ts,tsx}'],
+        // Measure real component/hook/service logic — exclude generated, route
+        // shims, static, presentational-only and test/support files.
+        exclude: [
+          'src/**/*.test.{ts,tsx}',
+          'src/__tests__/**',
+          'src/__mocks__/**',
+          'src/api/**', // generated OpenAPI client
+          'src/pages/**', // Next.js route shims (module-level */pages/* components stay)
+          'src/data/**',
+          'src/configs/**',
+          'src/styles/**',
+          'src/shared/components/Icons/**',
+          'src/**/*.stories.tsx',
+          'src/**/index.ts', // barrel re-exports
+          'src/**/*.d.ts',
+          'src/setupTests.ts',
+        ],
+        reportsDirectory: './coverage',
+        // Ratcheted floor enforced in CI via `test:ci`: starts just below the
+        // post-exclude baseline so this config-only change passes, then bumps up
+        // as each test tier lands, ending at a flat 90% (free above 90, fail below).
+        thresholds: {
+          statements: 34,
+          branches: 33,
+          functions: 30,
+          lines: 34,
+        },
+      },
       deps: {
         optimizer: {
           web: {


### PR DESCRIPTION
## What & why

The client had low, hard-to-interpret unit-test coverage (~30% over a denominator inflated by the generated API client, Next.js page shims, static data/configs/styles and icons). This is **phase 1 of N** of a frontend coverage initiative that mirrors the backend one: tests render components and drive them as a real user does (fill inputs, click, toggle), mocking only the API/external boundary. This PR lays the groundwork — config only, no test/source changes.

## Changes
- **Scope coverage to real logic** (`client/vitest.config.mts`): add `coverage.exclude` for files with no testable component/hook/service logic — generated `src/api/**`, `src/pages/**` (Next route shims; module-level `*/pages/*` components stay), `src/data/**`, `src/configs/**`, `src/styles/**`, `src/shared/components/Icons/**`, `src/__mocks__/**` + `src/__tests__/**`, `src/**/index.ts` barrels, `*.stories.tsx`, `*.d.ts`, `setupTests.ts`.
- **Gate the test step on coverage** (`client/package.json`): `test:ci` now runs `vitest run --coverage`. CI keeps calling `npm run test:ci` (no workflow change), but it now enforces the `coverage.thresholds`.
- **Stabilize antd-heavy tests**: raise `testTimeout`/`hookTimeout` to 60s. antd v6 in jsdom is CPU-heavy and the slowest Table/Form-validation tests intermittently exceed 30s once coverage instrumentation is added; 60s removes the flake.
- **Ratcheted threshold**: set just below the post-exclude baseline (`statements 34 / branches 33 / functions 30 / lines 34`); subsequent tier PRs bump it up, ending at a flat 90%.

## Verification
- ✅ `npm run test:ci` (client, Node 24): **141 files, 896 tests green**; coverage **35.07 / 34.07 / 31.53 / 35.29** over the corrected denominator, clears the floor and now fails on regression.
- ✅ `oxfmt --check` clean.

## Result
Client coverage now reflects real component/hook/service logic and is enforced via the existing `test:ci` step. Follow-up PRs add user-interaction tests by feature area and ratchet the floor toward 90%.

Phase 1 — client unit-test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)