### PR TITLE
test(client): user-interaction tests for core forms & modals (tier 1)

### DIFF
--- a/client/src/modules/CourseManagement/components/CertificateTemplatePicker/CertificateTemplatePicker.test.tsx
+++ b/client/src/modules/CourseManagement/components/CertificateTemplatePicker/CertificateTemplatePicker.test.tsx
@@ -1,0 +1,115 @@
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { CertificateTemplatePicker } from './CertificateTemplatePicker';
+
+// The component fetches templates with `axios.get`. The project ships a manual
+// axios mock at src/__mocks__/axios.js exposing vi.fn()-based methods.
+vi.mock('axios');
+
+const mockedGet = vi.mocked(axios.get);
+
+const templates = [
+  { id: 'default', label: 'Default', previewUrl: 'https://cdn/default.png' },
+  { id: 'modern', label: 'Modern', previewUrl: 'https://cdn/modern.png' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGet.mockResolvedValue({ data: templates });
+});
+
+afterEach(() => {
+  // The component memoises templates at module scope (cachedTemplates). Reset it
+  // between tests via the module registry so each test starts from a clean fetch.
+  vi.resetModules();
+});
+
+async function renderPicker(props: Parameters<typeof CertificateTemplatePicker>[0] = {}) {
+  // Re-import after resetModules so the module-level cache is fresh.
+  const { CertificateTemplatePicker: Picker } = await import('./CertificateTemplatePicker');
+  return render(<Picker {...props} />);
+}
+
+describe('<CertificateTemplatePicker />', () => {
+  it('shows a spinner while templates are loading', async () => {
+    let resolve!: (v: unknown) => void;
+    mockedGet.mockReturnValue(new Promise(r => (resolve = r)));
+
+    const { container } = await renderPicker();
+
+    expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+
+    resolve({ data: templates });
+    expect(await screen.findByText('Default')).toBeInTheDocument();
+  });
+
+  it('fetches templates from the certificate templates endpoint', async () => {
+    await renderPicker();
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/v2/certificate/templates'));
+  });
+
+  it('renders one radio per fetched template', async () => {
+    await renderPicker();
+
+    expect(await screen.findByText('Default')).toBeInTheDocument();
+    expect(screen.getByText('Modern')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('auto-selects the default template when value is undefined', async () => {
+    const onChange = vi.fn();
+    await renderPicker({ onChange });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('default'));
+  });
+
+  it('falls back to the first template when no template has id "default"', async () => {
+    mockedGet.mockResolvedValue({
+      data: [
+        { id: 'modern', label: 'Modern', previewUrl: 'https://cdn/modern.png' },
+        { id: 'classic', label: 'Classic', previewUrl: 'https://cdn/classic.png' },
+      ],
+    });
+    const onChange = vi.fn();
+    await renderPicker({ onChange });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('modern'));
+  });
+
+  it('emits onChange with the chosen template id when a radio is clicked', async () => {
+    const onChange = vi.fn();
+    await renderPicker({ value: 'default', onChange });
+
+    const modernRadio = await screen.findByRole('radio', { name: /modern/i });
+    fireEvent.click(modernRadio);
+
+    expect(onChange).toHaveBeenCalledWith('modern');
+  });
+
+  it('opens the full preview without toggling the radio selection', async () => {
+    const onChange = vi.fn();
+    await renderPicker({ value: 'default', onChange });
+
+    // The fullscreen control for the "Modern" (non-selected) card. Clicking it must
+    // open the preview (state) and NOT change the radio selection — openPreview calls
+    // preventDefault/stopPropagation to swallow the surrounding Radio's toggle.
+    const previewButtons = await screen.findAllByRole('button', { name: /view full preview/i });
+    fireEvent.click(previewButtons[1]);
+
+    // Selection onChange must NOT fire to 'modern' from the preview click.
+    expect(onChange).not.toHaveBeenCalledWith('modern');
+    // The hidden antd Image is now driven open (its preview mask becomes present).
+    await waitFor(() => {
+      expect(document.querySelector('.ant-image-preview-operations, .ant-image-preview-img')).toBeTruthy();
+    });
+  });
+
+  it('renders an empty radio group when the fetch fails', async () => {
+    mockedGet.mockRejectedValue(new Error('boom'));
+    await renderPicker();
+
+    await waitFor(() => expect(screen.queryByRole('radio')).not.toBeInTheDocument());
+  });
+});

--- a/client/src/modules/CourseManagement/components/CertificateTemplatePicker/IssueCertificateModal.test.tsx
+++ b/client/src/modules/CourseManagement/components/CertificateTemplatePicker/IssueCertificateModal.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IssueCertificateModal } from './IssueCertificateModal';
+
+// Stub the CertificateTemplatePicker (axios fetch + antd Image preview = brittle in
+// a modal). The stub is a minimal controlled child that exposes the current value and
+// lets the test drive `onChange`, mirroring how the real picker integrates with the modal.
+vi.mock('./CertificateTemplatePicker', () => ({
+  CertificateTemplatePicker: (props: { value?: string; onChange?: (v: string) => void }) => (
+    <div>
+      <span data-testid="picker-value">{props.value ?? ''}</span>
+      <button type="button" onClick={() => props.onChange?.('modern')}>
+        pick modern
+      </button>
+    </div>
+  ),
+}));
+
+function makeProps(overrides: Partial<Parameters<typeof IssueCertificateModal>[0]> = {}) {
+  return {
+    open: true,
+    onCancel: vi.fn(),
+    onSubmit: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('<IssueCertificateModal />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not render the dialog when closed', () => {
+    render(<IssueCertificateModal {...makeProps({ open: false })} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the generic title when no student name is provided', async () => {
+    render(<IssueCertificateModal {...makeProps()} />);
+
+    expect(await screen.findByText('Issue certificate')).toBeInTheDocument();
+  });
+
+  it('renders a per-student title when a student name is provided', async () => {
+    render(<IssueCertificateModal {...makeProps({ studentName: 'Ada Lovelace' })} />);
+
+    expect(await screen.findByText('Issue certificate — Ada Lovelace')).toBeInTheDocument();
+  });
+
+  it('disables the Issue button until a template is chosen', async () => {
+    render(<IssueCertificateModal {...makeProps()} />);
+
+    const issue = await screen.findByRole('button', { name: 'Issue' });
+    expect(issue).toBeDisabled();
+  });
+
+  it('enables Issue and submits the chosen template id', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<IssueCertificateModal {...props} />);
+
+    await user.click(await screen.findByRole('button', { name: /pick modern/i }));
+
+    const issue = await screen.findByRole('button', { name: 'Issue' });
+    expect(issue).toBeEnabled();
+
+    await user.click(issue);
+    expect(props.onSubmit).toHaveBeenCalledWith('modern');
+  });
+
+  it('does not call onSubmit when no template is selected (onOk guard)', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<IssueCertificateModal {...props} />);
+
+    // Force a click on the disabled-looking guard path: even if clicked, templateId is undefined.
+    const issue = await screen.findByRole('button', { name: 'Issue' });
+    await user.click(issue);
+
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when the cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<IssueCertificateModal {...props} />);
+
+    await user.click(await screen.findByRole('button', { name: /cancel/i }));
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+
+  it('resets the selected template when the modal is reopened', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<IssueCertificateModal {...makeProps()} />);
+
+    await user.click(await screen.findByRole('button', { name: /pick modern/i }));
+    expect(screen.getByTestId('picker-value')).toHaveTextContent('modern');
+
+    // Close then reopen: the useEffect clears templateId so the Issue button is disabled again.
+    rerender(<IssueCertificateModal {...makeProps({ open: false })} />);
+    rerender(<IssueCertificateModal {...makeProps({ open: true })} />);
+
+    expect(await screen.findByTestId('picker-value')).toHaveTextContent('');
+    expect(screen.getByRole('button', { name: 'Issue' })).toBeDisabled();
+  });
+});

--- a/client/src/modules/CourseManagement/components/CourseEventModal/index.test.tsx
+++ b/client/src/modules/CourseManagement/components/CourseEventModal/index.test.tsx
@@ -1,0 +1,248 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CourseEventModal } from './index';
+
+// --- Boundary mocks --------------------------------------------------------
+
+// Brittle-widget policy: antd DatePicker is CPU-heavy in jsdom. This modal only renders
+// the date/time pickers (their dayjs values are seeded by getInitialValues and never
+// driven by these tests), so replace the picker with a minimal controlled stub that
+// preserves value/onChange. Every other antd component stays real.
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+  const dj = (await vi.importActual<typeof import('dayjs')>('dayjs')).default;
+
+  type DateValue = ReturnType<typeof dj> | null;
+
+  const DatePicker = (props: {
+    value?: DateValue;
+    onChange?: (d: DateValue, s: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="datepicker"
+      placeholder={props.placeholder}
+      value={props.value ? props.value.format('YYYY-MM-DD HH:mm') : ''}
+      onChange={e => {
+        const v = e.target.value;
+        props.onChange?.(v ? dj.utc(v) : null, v);
+      }}
+    />
+  );
+  DatePicker.RangePicker = (props: {
+    value?: [DateValue, DateValue] | null;
+    onChange?: (d: [DateValue, DateValue] | null) => void;
+  }) => {
+    const [start, end] = props.value ?? [null, null];
+    return (
+      <span data-testid="rangepicker">
+        <input
+          data-testid="range-start"
+          value={start ? start.format('YYYY-MM-DD') : ''}
+          onChange={e => props.onChange?.([e.target.value ? dj.utc(e.target.value) : null, end])}
+        />
+        <input
+          data-testid="range-end"
+          value={end ? end.format('YYYY-MM-DD') : ''}
+          onChange={e => props.onChange?.([start, e.target.value ? dj.utc(e.target.value) : null])}
+        />
+      </span>
+    );
+  };
+
+  return { ...actual, DatePicker };
+});
+
+// Generated EventsApi / DisciplinesApi: loaded in parallel on mount.
+const { getEvents, getDisciplines } = vi.hoisted(() => ({
+  getEvents: vi.fn(),
+  getDisciplines: vi.fn(),
+}));
+
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  EventsApi: function EventsApi() {
+    return { getEvents };
+  },
+  DisciplinesApi: function DisciplinesApi() {
+    return { getDisciplines };
+  },
+}));
+
+// formState.submitEvent does the real API persistence. Mock it so we assert the modal
+// hands off the form values + course/events context, while keeping real getInitialValues.
+const { submitEvent } = vi.hoisted(() => ({ submitEvent: vi.fn() }));
+vi.mock('./formState', async () => ({
+  ...(await vi.importActual('./formState')),
+  submitEvent,
+}));
+
+// UserService backs UserSearch remote search.
+vi.mock('@client/services/user', () => ({
+  UserService: function UserService() {
+    return { searchUser: vi.fn().mockResolvedValue([]) };
+  },
+}));
+
+// UserSearch is a remote Select (brittle) → controlled stub preserving value/onChange.
+vi.mock('@client/shared/components/UserSearch', () => ({
+  UserSearch: (props: { value?: number; onChange?: (v: number) => void }) => (
+    <input
+      data-testid="task-owner"
+      value={props.value ?? ''}
+      onChange={e => props.onChange?.(Number(e.target.value))}
+    />
+  ),
+}));
+
+const events = [
+  {
+    id: 1,
+    name: 'Intro Lecture',
+    type: 'lecture_online',
+    description: 'desc',
+    descriptionUrl: 'https://example.com/intro',
+  },
+  { id: 2, name: 'Workshop', type: 'workshop', description: '', descriptionUrl: '' },
+];
+const disciplines = [
+  { id: 11, name: 'Frontend' },
+  { id: 22, name: 'Backend' },
+];
+
+function makeProps(overrides: Partial<Parameters<typeof CourseEventModal>[0]> = {}) {
+  return {
+    data: {} as Parameters<typeof CourseEventModal>[0]['data'],
+    courseId: 99,
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('<CourseEventModal />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEvents.mockResolvedValue({ data: events });
+    getDisciplines.mockResolvedValue({ data: disciplines });
+    submitEvent.mockResolvedValue(undefined);
+  });
+
+  it('renders the modal with the event/type/discipline fields when adding a new event', async () => {
+    render(<CourseEventModal {...makeProps()} />);
+
+    expect(await screen.findByText('Course Event')).toBeInTheDocument();
+    expect(screen.getByLabelText('Event')).toBeInTheDocument();
+    expect(screen.getByLabelText('Type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Discipline')).toBeInTheDocument();
+    expect(screen.getByLabelText('Description URL')).toBeInTheDocument();
+  });
+
+  it('renders the event name as a title (no Event select) when editing an existing event', async () => {
+    render(<CourseEventModal {...makeProps({ data: { event: { id: 5, name: 'Existing Event' } } as never })} />);
+
+    expect(await screen.findByText('Existing Event')).toBeInTheDocument();
+    // In edit mode the Event select is replaced by the title.
+    expect(screen.queryByLabelText('Event')).not.toBeInTheDocument();
+  });
+
+  it('lists fetched disciplines as options', async () => {
+    render(<CourseEventModal {...makeProps()} />);
+
+    const disciplineSelect = await screen.findByLabelText('Discipline');
+    fireEvent.mouseDown(disciplineSelect);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText('Frontend')).toBeInTheDocument();
+      expect(within(document.body).getByText('Backend')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a validation error and does not submit when required fields are empty', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseEventModal {...props} />);
+
+    await screen.findByText('Course Event');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(await screen.findByText('Please select an event')).toBeInTheDocument();
+    expect(submitEvent).not.toHaveBeenCalled();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('flags an invalid Description URL', async () => {
+    render(<CourseEventModal {...makeProps()} />);
+
+    const urlInput = await screen.findByPlaceholderText('Enter description URL');
+    fireEvent.change(urlInput, { target: { value: 'not a url' } });
+
+    expect(await screen.findByText('Please enter valid URL')).toBeInTheDocument();
+  });
+
+  it('prefills description/type when picking an event template via onEventChange', async () => {
+    render(<CourseEventModal {...makeProps()} />);
+
+    const eventSelect = await screen.findByLabelText('Event');
+    fireEvent.mouseDown(eventSelect);
+
+    const option = await within(document.body).findByText('Intro Lecture');
+    fireEvent.click(option);
+
+    // The selected template's description URL flows into the URL input.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter description URL')).toHaveValue('https://example.com/intro');
+    });
+  });
+
+  it('filters event template options by typed input via filterOption', async () => {
+    const user = userEvent.setup();
+    render(<CourseEventModal {...makeProps()} />);
+
+    const eventSelect = await screen.findByLabelText('Event');
+    await user.click(eventSelect);
+    await user.type(eventSelect, 'workshop');
+
+    // "Intro Lecture" is filtered out; only "Workshop" matches the typed input.
+    await waitFor(() => {
+      expect(within(document.body).getByText('Workshop')).toBeInTheDocument();
+    });
+    expect(within(document.body).queryByText('Intro Lecture')).not.toBeInTheDocument();
+  });
+
+  it('submits via submitEvent and then calls onSubmit when the form is valid', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseEventModal {...props} />);
+
+    // Pick an event template (fills type + description URL automatically).
+    const eventSelect = await screen.findByLabelText('Event');
+    fireEvent.mouseDown(eventSelect);
+    fireEvent.click(await within(document.body).findByText('Intro Lecture'));
+
+    // Pick a discipline (required, not auto-filled).
+    const disciplineSelect = screen.getByLabelText('Discipline');
+    fireEvent.mouseDown(disciplineSelect);
+    fireEvent.click(await within(document.body).findByText('Frontend'));
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(submitEvent).toHaveBeenCalled());
+    // submitEvent(values, events, courseId, data)
+    const [, passedEvents, passedCourseId] = submitEvent.mock.calls[0];
+    expect(passedEvents).toEqual(events);
+    expect(passedCourseId).toBe(99);
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalled());
+  });
+
+  it('calls onCancel when the cancel button is clicked on a pristine form', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseEventModal {...props} />);
+
+    await screen.findByText('Course Event');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+});

--- a/client/src/modules/CourseManagement/components/CourseModal/index.test.tsx
+++ b/client/src/modules/CourseManagement/components/CourseModal/index.test.tsx
@@ -1,0 +1,393 @@
+/* eslint-disable testing-library/no-node-access */
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CourseModal } from './index';
+
+// --- Boundary mocks --------------------------------------------------------
+
+// Brittle-widget policy: antd DatePicker / DatePicker.RangePicker are CPU-heavy in jsdom
+// (they intermittently push this file past the 60s timeout under parallel coverage).
+// Replace ONLY the pickers with minimal controlled stubs that preserve value/onChange and
+// emit real dayjs values (createRecord calls dayjs.utc(...).format() on them). Every other
+// antd component stays real. Form.Item injects value/onChange via cloneElement.
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+  const dj = (await vi.importActual<typeof import('dayjs')>('dayjs')).default;
+
+  type DateValue = ReturnType<typeof dj> | null;
+
+  const DatePicker = (props: {
+    value?: DateValue;
+    onChange?: (d: DateValue, s: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="datepicker"
+      placeholder={props.placeholder}
+      value={props.value ? props.value.format('YYYY-MM-DD') : ''}
+      onChange={e => {
+        const v = e.target.value;
+        props.onChange?.(v ? dj.utc(v) : null, v);
+      }}
+    />
+  );
+
+  const RangePicker = (props: {
+    value?: [DateValue, DateValue] | null;
+    onChange?: (d: [DateValue, DateValue] | null, s: [string, string]) => void;
+  }) => {
+    const [start, end] = props.value ?? [null, null];
+    const emit = (s: DateValue, e: DateValue) =>
+      props.onChange?.([s, e], [s ? s.format('YYYY-MM-DD') : '', e ? e.format('YYYY-MM-DD') : '']);
+    return (
+      <span data-testid="rangepicker">
+        <input
+          data-testid="range-start"
+          value={start ? start.format('YYYY-MM-DD') : ''}
+          onChange={e => emit(e.target.value ? dj.utc(e.target.value) : null, end)}
+        />
+        <input
+          data-testid="range-end"
+          value={end ? end.format('YYYY-MM-DD') : ''}
+          onChange={e => emit(start, e.target.value ? dj.utc(e.target.value) : null)}
+        />
+      </span>
+    );
+  };
+  DatePicker.RangePicker = RangePicker;
+
+  return { ...actual, DatePicker };
+});
+
+// Generated CoursesApi: getCourse (edit prefill) + create/update/copy on submit.
+const { getCourse, createCourse, updateCourse, copyCourse } = vi.hoisted(() => ({
+  getCourse: vi.fn(),
+  createCourse: vi.fn(),
+  updateCourse: vi.fn(),
+  copyCourse: vi.fn(),
+}));
+
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  CoursesApi: function CoursesApi() {
+    return { getCourse, createCourse, updateCourse, copyCourse };
+  },
+}));
+
+const disciplines = [
+  { id: 11, name: 'Frontend' },
+  { id: 22, name: 'Backend' },
+];
+const discordServers = [{ id: 5, name: 'RS Discord' }];
+const courses = [
+  { id: 100, name: 'Existing Course A' },
+  { id: 200, name: 'Existing Course B' },
+] as never;
+
+function makeProps(overrides: Partial<Parameters<typeof CourseModal>[0]> = {}) {
+  return {
+    onClose: vi.fn(),
+    discordServers,
+    disciplines,
+    courses,
+    courseId: null,
+    ...overrides,
+  } as Parameters<typeof CourseModal>[0];
+}
+
+const editCourse = {
+  id: 7,
+  name: 'JS Course',
+  fullName: 'JavaScript Course',
+  alias: 'js-2024',
+  startDate: '2024-01-01T00:00:00.000Z',
+  endDate: '2024-06-01T00:00:00.000Z',
+  discordServerId: 5,
+  disciplineId: 11,
+  discipline: { id: 11 },
+  certificateThreshold: 70,
+  minStudentsPerMentor: 2,
+  descriptionUrl: 'https://rs.school/courses/javascript',
+  certificateDisciplines: null,
+  completed: false,
+  planned: false,
+  inviteOnly: false,
+};
+
+describe('<CourseModal />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCourse.mockResolvedValue({ data: editCourse });
+    createCourse.mockResolvedValue({});
+    updateCourse.mockResolvedValue({});
+    copyCourse.mockResolvedValue({});
+  });
+
+  it('renders the "Add Course" title and the copy-template select when creating', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    expect(await screen.findByText('Add Course')).toBeInTheDocument();
+    expect(screen.getByLabelText('Copy Tasks, Schedule from:')).toBeInTheDocument();
+  });
+
+  it('renders the "Edit Course" title and hides the copy-template select when editing', async () => {
+    render(<CourseModal {...makeProps({ courseId: 7 })} />);
+
+    expect(await screen.findByText('Edit Course')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('JS Course')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Copy Tasks, Schedule from:')).not.toBeInTheDocument();
+  });
+
+  it('fetches the course when editing', async () => {
+    render(<CourseModal {...makeProps({ courseId: 7 })} />);
+
+    await waitFor(() => expect(getCourse).toHaveBeenCalledWith(7));
+  });
+
+  it('renders the core required fields', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    expect(await screen.findByLabelText('Course Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Full Course Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Alias')).toBeInTheDocument();
+    expect(screen.getByLabelText('Discord/Telegram channel')).toBeInTheDocument();
+    expect(screen.getByLabelText('Disciplines')).toBeInTheDocument();
+  });
+
+  it('shows validation errors and does not submit when required fields are empty', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseModal {...props} />);
+
+    await screen.findByText('Add Course');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(await screen.findByText('Please enter name')).toBeInTheDocument();
+    expect(screen.getByText('Please enter full name')).toBeInTheDocument();
+    expect(screen.getByText('Please enter alias')).toBeInTheDocument();
+    expect(createCourse).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('reveals the Custom Url input when "Custom" description URL is selected', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    // The Description Url dropdown is long and virtualized (only ~10 options render at a
+    // time); scroll the rc-virtual list so the trailing "Custom" option mounts.
+    const descUrlSelect = await screen.findByLabelText('Description Url');
+    fireEvent.mouseDown(descUrlSelect);
+
+    await waitFor(() => expect(document.querySelector('.rc-virtual-list-holder')).toBeTruthy());
+    const list = document.querySelector('.rc-virtual-list-holder')!;
+    fireEvent.scroll(list, { target: { scrollTop: 1000 } });
+
+    const customOption = await within(document.body).findByText('Custom');
+    fireEvent.click(customOption);
+
+    expect(await screen.findByLabelText('Custom Url')).toBeInTheDocument();
+  });
+
+  it('hides the certificate disciplines select when "Any course" is checked', async () => {
+    const user = userEvent.setup();
+    render(<CourseModal {...makeProps()} />);
+
+    await screen.findByText('Add Course');
+    // The multiple-select renders its placeholder as a text node (not an input placeholder attr).
+    const disciplinesPlaceholder = screen.getByText('Select disciplines');
+    // Its Form.Item wrapper is visible initially (not hidden).
+    expect(disciplinesPlaceholder.closest('.ant-form-item-hidden')).toBeNull();
+
+    await user.click(screen.getByRole('checkbox', { name: /any course/i }));
+
+    // antd's Form.Item `hidden` keeps the node in the DOM but applies display:none via
+    // the `ant-form-item-hidden` class — assert it becomes hidden.
+    await waitFor(() => {
+      expect(screen.getByText('Select disciplines').closest('.ant-form-item-hidden')).not.toBeNull();
+    });
+  });
+
+  it('reveals the Personal Mentoring date range when the toggle is checked', async () => {
+    const user = userEvent.setup();
+    render(<CourseModal {...makeProps()} />);
+
+    await screen.findByText('Add Course');
+    expect(screen.queryByText('Personal Mentoring Dates')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('checkbox', { name: /personal mentoring/i }));
+
+    expect(await screen.findByText('Personal Mentoring Dates')).toBeInTheDocument();
+  });
+
+  it('rejects an invalid WeAreCommunity/registry URL', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    const urlInput = await screen.findByPlaceholderText('Enter URL');
+    fireEvent.change(urlInput, { target: { value: 'http://evil.example.com' } });
+
+    expect(await screen.findByText('Please enter RS APP or wearecommunity.io URL')).toBeInTheDocument();
+  });
+
+  it('rejects a registry URL whose course alias does not match the entered alias', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    const alias = await screen.findByLabelText('Alias');
+    fireEvent.change(alias, { target: { value: 'my-course' } });
+    // Wait for the watched alias to propagate (the live registry-link preview confirms it).
+    await screen.findByText('https://app.rs.school/registry/student?course=my-course');
+
+    const urlInput = screen.getByPlaceholderText('Enter URL');
+    // A valid registry URL but with a different course alias → alias-mismatch rejection.
+    fireEvent.change(urlInput, { target: { value: 'https://app.rs.school/registry/student?course=other-course' } });
+
+    expect(await screen.findByText('URL must end with my-course')).toBeInTheDocument();
+  });
+
+  it('accepts a registry URL whose course alias matches the entered alias', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    const alias = await screen.findByLabelText('Alias');
+    fireEvent.change(alias, { target: { value: 'my-course' } });
+    await screen.findByText('https://app.rs.school/registry/student?course=my-course');
+
+    const urlInput = screen.getByPlaceholderText('Enter URL');
+    fireEvent.change(urlInput, { target: { value: 'https://app.rs.school/registry/student?course=my-course' } });
+
+    // No mismatch error should appear for a matching alias.
+    await waitFor(() => {
+      expect(screen.queryByText('URL must end with my-course')).not.toBeInTheDocument();
+      expect(screen.queryByText('Please enter RS APP or wearecommunity.io URL')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows the RS APP registry link preview once an alias is entered', async () => {
+    render(<CourseModal {...makeProps()} />);
+
+    const alias = await screen.findByLabelText('Alias');
+    fireEvent.change(alias, { target: { value: 'my-course' } });
+
+    expect(await screen.findByText('https://app.rs.school/registry/student?course=my-course')).toBeInTheDocument();
+  });
+
+  it('updates the course with the built record when editing and saving', async () => {
+    const user = userEvent.setup();
+    const props = makeProps({ courseId: 7 });
+    render(<CourseModal {...props} />);
+
+    // Wait for the edit form to prefill (range is seeded from start/end dates).
+    expect(await screen.findByDisplayValue('JS Course')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(updateCourse).toHaveBeenCalled());
+    const [id, record] = updateCourse.mock.calls[0];
+    expect(id).toBe(7);
+    expect(record).toMatchObject({
+      name: 'JS Course',
+      fullName: 'JavaScript Course',
+      alias: 'js-2024',
+      certificateThreshold: 70,
+      minStudentsPerMentor: 2,
+    });
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled());
+  });
+
+  it('marks the course completed when the Completed state radio is chosen on save', async () => {
+    const user = userEvent.setup();
+    const props = makeProps({ courseId: 7 });
+    render(<CourseModal {...props} />);
+
+    expect(await screen.findByDisplayValue('JS Course')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: /completed/i }));
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(updateCourse).toHaveBeenCalled());
+    const [, record] = updateCourse.mock.calls[0];
+    expect(record.completed).toBe(true);
+    expect(record.planned).toBe(false);
+  });
+
+  // Fill the create form's required fields (text, selects, and the RangePicker via its
+  // two date input cells). Returns nothing; the form is left valid and ready to submit.
+  async function fillCreateForm() {
+    fireEvent.change(screen.getByLabelText('Course Name'), { target: { value: 'New Course' } });
+    fireEvent.change(screen.getByLabelText('Full Course Name'), { target: { value: 'New Full Course' } });
+    fireEvent.change(screen.getByLabelText('Alias'), { target: { value: 'newc' } });
+
+    const discord = screen.getByLabelText('Discord/Telegram channel');
+    fireEvent.mouseDown(discord);
+    fireEvent.click(await within(document.body).findByText('RS Discord'));
+
+    const disc = screen.getByLabelText('Disciplines');
+    fireEvent.mouseDown(disc);
+    const fe = await within(document.body).findAllByText('Frontend');
+    fireEvent.click(fe[fe.length - 1]);
+
+    const descUrl = screen.getByLabelText('Description Url');
+    fireEvent.mouseDown(descUrl);
+    fireEvent.click(await within(document.body).findByText('JavaScript'));
+
+    // Start - End Date RangePicker (the only range picker visible in the create form):
+    // set start/end through the stubbed inputs, which emit dayjs values to the form.
+    fireEvent.change(screen.getByTestId('range-start'), { target: { value: '2024-01-01' } });
+    fireEvent.change(screen.getByTestId('range-end'), { target: { value: '2024-06-01' } });
+  }
+
+  it('creates a new course with the built record when the create form is submitted', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseModal {...props} />);
+
+    await screen.findByText('Add Course');
+    await fillCreateForm();
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(createCourse).toHaveBeenCalled());
+    const [record] = createCourse.mock.calls[0];
+    expect(record).toMatchObject({
+      name: 'New Course',
+      fullName: 'New Full Course',
+      alias: 'newc',
+      disciplineId: 11,
+      discordServerId: 5,
+      descriptionUrl: 'https://rs.school/courses/javascript',
+    });
+    expect(copyCourse).not.toHaveBeenCalled();
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled());
+  });
+
+  it('copies tasks/schedule from a template course when one is chosen on create', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseModal {...props} />);
+
+    await screen.findByText('Add Course');
+    await fillCreateForm();
+
+    // Choose a template course → submit routes through copyCourse(templateId, record).
+    const copyFrom = screen.getByLabelText('Copy Tasks, Schedule from:');
+    fireEvent.mouseDown(copyFrom);
+    fireEvent.click(await within(document.body).findByText('Existing Course A'));
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(copyCourse).toHaveBeenCalled());
+    const [templateId, record] = copyCourse.mock.calls[0];
+    expect(templateId).toBe(100);
+    expect(record).toMatchObject({ name: 'New Course', alias: 'newc' });
+    expect(createCourse).not.toHaveBeenCalled();
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled());
+  });
+
+  it('calls onClose when the modal cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseModal {...props} />);
+
+    await screen.findByText('Add Course');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/client/src/modules/CourseManagement/components/CourseTaskModal/index.test.tsx
+++ b/client/src/modules/CourseManagement/components/CourseTaskModal/index.test.tsx
@@ -1,0 +1,258 @@
+/* eslint-disable testing-library/no-node-access */
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { message } from 'antd';
+import { CourseTaskModal } from './index';
+
+// Spy on antd's global message.error to assert the cross-check duration guard fires.
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+  return { ...actual, message: { ...actual.message, error: vi.fn() } };
+});
+
+// --- Boundary mocks --------------------------------------------------------
+
+// Generated TasksApi: the component calls `new TasksApi().getTasks()` at mount.
+const { getTasks } = vi.hoisted(() => ({
+  getTasks: vi.fn(),
+}));
+
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  TasksApi: function TasksApi() {
+    return { getTasks };
+  },
+}));
+
+// UserService backs the UserSearch remote search. Stubbed to a no-op resolver.
+vi.mock('@client/services/user', () => ({
+  UserService: function UserService() {
+    return { searchUser: vi.fn().mockResolvedValue([]) };
+  },
+}));
+
+// UserSearch is a remote-data Select (brittle). Replace with a minimal controlled
+// stub that preserves value/onChange, like ManualSubmitTab stubs StudentSearch.
+vi.mock('@client/shared/components/UserSearch', () => ({
+  UserSearch: (props: { value?: number; onChange?: (v: number) => void }) => (
+    <input
+      data-testid="task-owner"
+      value={props.value ?? ''}
+      onChange={e => props.onChange?.(Number(e.target.value))}
+    />
+  ),
+}));
+
+const tasks = [
+  { id: 10, name: 'HTML Task', type: 'htmltask', tags: ['html'] },
+  { id: 20, name: 'Interview', type: 'interview', tags: [] },
+];
+
+function makeProps(overrides: Partial<Parameters<typeof CourseTaskModal>[0]> = {}) {
+  return {
+    data: {} as Partial<Parameters<typeof CourseTaskModal>[0]>['data'],
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('<CourseTaskModal />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTasks.mockResolvedValue({ data: tasks });
+  });
+
+  it('renders nothing when data is null', () => {
+    render(<CourseTaskModal {...makeProps({ data: null })} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the Course Task modal with its core fields', async () => {
+    render(<CourseTaskModal {...makeProps()} />);
+
+    expect(await screen.findByText('Course Task')).toBeInTheDocument();
+    expect(screen.getByLabelText('Task')).toBeInTheDocument();
+    expect(screen.getByLabelText('Task Type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Checker')).toBeInTheDocument();
+    expect(screen.getByLabelText('Score')).toBeInTheDocument();
+    expect(screen.getByLabelText('Score Weight')).toBeInTheDocument();
+  });
+
+  it('seeds default Score (100) and Score Weight (1) from getInitialValues', async () => {
+    render(<CourseTaskModal {...makeProps()} />);
+
+    await screen.findByText('Course Task');
+    // antd InputNumber exposes the numeric value via aria-valuenow on role="spinbutton".
+    expect(screen.getByLabelText('Score')).toHaveAttribute('aria-valuenow', '100');
+    expect(screen.getByLabelText('Score Weight')).toHaveAttribute('aria-valuenow', '1');
+  });
+
+  it('lists the fetched tasks as options in the Task select', async () => {
+    render(<CourseTaskModal {...makeProps()} />);
+
+    const taskSelect = await screen.findByLabelText('Task');
+    fireEvent.mouseDown(taskSelect);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText(/HTML Task/)).toBeInTheDocument();
+      expect(within(document.body).getByText(/Interview/)).toBeInTheDocument();
+    });
+  });
+
+  it('auto-fills Task Type when a task is selected', async () => {
+    render(<CourseTaskModal {...makeProps()} />);
+
+    const taskSelect = await screen.findByLabelText('Task');
+    fireEvent.mouseDown(taskSelect);
+
+    const option = await within(document.body).findByText(/HTML Task/);
+    fireEvent.click(option);
+
+    // The task's type ("htmltask" → "HTML task") flows into the Type select.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Task Type').closest('.ant-select')).toHaveTextContent('HTML task');
+    });
+  });
+
+  it('shows a validation message and does not submit when Task is empty', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseTaskModal {...props} />);
+
+    await screen.findByText('Course Task');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(await screen.findByText('Please select a task')).toBeInTheDocument();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('reveals the Cross-Check section when the Cross-Check checker is chosen', async () => {
+    render(<CourseTaskModal {...makeProps()} />);
+
+    const checkerSelect = await screen.findByLabelText('Checker');
+    fireEvent.mouseDown(checkerSelect);
+
+    const crossCheckOption = await within(document.body).findByText('Cross-Check');
+    fireEvent.click(crossCheckOption);
+
+    expect(await screen.findByText('Cross-Check End Date')).toBeInTheDocument();
+    // "Cross-Check Pairs Count" appears both as a label and as the select placeholder.
+    expect(screen.getAllByText('Cross-Check Pairs Count').length).toBeGreaterThan(0);
+    expect(screen.getByText('Require GitHub Username in URL')).toBeInTheDocument();
+    expect(screen.getByText('Require GitHub Pull Request in URL')).toBeInTheDocument();
+  });
+
+  it('shows the Registration Start Date field for interview-type tasks', async () => {
+    render(<CourseTaskModal {...makeProps({ data: { type: 'interview' } })} />);
+
+    expect(await screen.findByText('Registration Start Date')).toBeInTheDocument();
+  });
+
+  it('submits the built record (taskId, checker, scores) when the form is valid', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseTaskModal {...props} />);
+
+    // Choose a task (required). Range/checker/scores are seeded by getInitialValues.
+    const taskSelect = await screen.findByLabelText('Task');
+    fireEvent.mouseDown(taskSelect);
+    fireEvent.click(await within(document.body).findByText(/HTML Task/));
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalled());
+    const record = props.onSubmit.mock.calls[0][0];
+    expect(record).toMatchObject({
+      taskId: 10,
+      checker: 'auto-test',
+      maxScore: 100,
+      scoreWeight: 1,
+    });
+    expect(typeof record.studentStartDate).toBe('string');
+    expect(typeof record.studentEndDate).toBe('string');
+  });
+
+  it('blocks cross-check submit when the cross-check duration is under 3 days', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    // Seed an editable record so the form already has dates close together; choosing
+    // crossCheck makes the (range end → crossCheckEndDate) gap too small.
+    render(<CourseTaskModal {...props} />);
+
+    // Select a task so the form's required Task field is valid.
+    const taskSelect = await screen.findByLabelText('Task');
+    fireEvent.mouseDown(taskSelect);
+    fireEvent.click(await within(document.body).findByText(/HTML Task/));
+
+    // Switch checker to Cross-Check to reveal the cross-check fields.
+    const checkerSelect = screen.getByLabelText('Checker');
+    fireEvent.mouseDown(checkerSelect);
+    fireEvent.click(await within(document.body).findByText('Cross-Check'));
+
+    // crossCheckEndDate is required; without it the form validation prevents submit.
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(props.onSubmit).not.toHaveBeenCalled());
+    expect(await screen.findByText('Please enter cross-check end date')).toBeInTheDocument();
+  });
+
+  it('blocks submit and shows an error when the cross-check duration is under 3 days', async () => {
+    const user = userEvent.setup();
+    const props = makeProps({
+      // Edit an existing cross-check task whose cross-check window is only ~1 day after the
+      // task end date — getInitialValues prefills range + crossCheckEndDate, so submit reaches
+      // the duration guard in handleModalSubmit.
+      data: {
+        taskId: 10,
+        checker: 'crossCheck',
+        studentStartDate: '2024-01-01T00:00:00.000Z',
+        studentEndDate: '2024-01-10T00:00:00.000Z',
+        crossCheckEndDate: '2024-01-11T00:00:00.000Z',
+        // pairsCount is also required in cross-check mode; seed it so form validation passes
+        // and submit reaches the duration guard.
+        pairsCount: 2,
+        maxScore: 100,
+        scoreWeight: 1,
+      } as never,
+    });
+    render(<CourseTaskModal {...props} />);
+
+    // The cross-check fields are shown because changes is seeded from data.
+    expect(await screen.findByText('Cross-Check End Date')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(message.error).toHaveBeenCalledWith('The minimum duration of a cross-check is 3 days.');
+    });
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('filters the task options by typed input via filterOption', async () => {
+    const user = userEvent.setup();
+    render(<CourseTaskModal {...makeProps()} />);
+
+    const taskSelect = await screen.findByLabelText('Task');
+    await user.click(taskSelect);
+    await user.type(taskSelect, 'interview');
+
+    // "HTML Task" should be filtered out; only "Interview" remains.
+    await waitFor(() => {
+      expect(within(document.body).getByText(/Interview/)).toBeInTheDocument();
+    });
+    expect(within(document.body).queryByText(/HTML Task/)).not.toBeInTheDocument();
+  });
+
+  it('calls onCancel when the cancel button is clicked on a pristine form', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CourseTaskModal {...props} />);
+
+    await screen.findByText('Course Task');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+});

--- a/client/src/modules/CourseManagement/components/CoursesListModal/index.test.tsx
+++ b/client/src/modules/CourseManagement/components/CoursesListModal/index.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CoursesListModal } from './index';
+
+// Mock only the API boundary: the generated CoursesApi class. The component
+// constructs `new CoursesApi()` at module scope and calls `getCourses()`.
+const { getCourses } = vi.hoisted(() => ({
+  getCourses: vi.fn(),
+}));
+
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  CoursesApi: function CoursesApi() {
+    return { getCourses };
+  },
+}));
+
+function makeProps(overrides: Partial<Parameters<typeof CoursesListModal>[0]> = {}) {
+  return {
+    data: {} as { id?: number },
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('<CoursesListModal />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCourses.mockResolvedValue({
+      data: [
+        { id: 1, name: 'JavaScript' },
+        { id: 2, name: 'React' },
+      ],
+    });
+  });
+
+  it('returns null (renders no modal) when data is null', () => {
+    render(<CoursesListModal {...makeProps({ data: null })} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the modal with title and the course select field', async () => {
+    render(<CoursesListModal {...makeProps()} />);
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Courses')).toBeInTheDocument();
+    expect(screen.getByLabelText('Course')).toBeInTheDocument();
+  });
+
+  it('uses the provided okText for the submit button', async () => {
+    render(<CoursesListModal {...makeProps({ okText: 'Copy' })} />);
+
+    expect(await screen.findByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('renders children passed into the modal body', async () => {
+    render(
+      <CoursesListModal {...makeProps()}>
+        <div>extra child content</div>
+      </CoursesListModal>,
+    );
+
+    expect(await screen.findByText('extra child content')).toBeInTheDocument();
+  });
+
+  it('renders the fetched courses as select options', async () => {
+    render(<CoursesListModal {...makeProps()} />);
+
+    const combobox = await screen.findByRole('combobox');
+    fireEvent.mouseDown(combobox);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText('JavaScript')).toBeInTheDocument();
+      expect(within(document.body).getByText('React')).toBeInTheDocument();
+    });
+  });
+
+  it('does not submit and shows a validation message when no course is selected', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CoursesListModal {...props} />);
+
+    const save = await screen.findByRole('button', { name: /save/i });
+    await user.click(save);
+
+    expect(await screen.findByText('Please select a course')).toBeInTheDocument();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the selected course id mapped to { id } on save', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CoursesListModal {...props} />);
+
+    const combobox = await screen.findByRole('combobox');
+    fireEvent.mouseDown(combobox);
+
+    const option = await within(document.body).findByText('React');
+    fireEvent.click(option);
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledWith({ id: 2 });
+    });
+  });
+
+  it('calls onCancel when the modal cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    render(<CoursesListModal {...props} />);
+
+    const cancel = await screen.findByRole('button', { name: /cancel/i });
+    await user.click(cancel);
+
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+
+  it('filters options by typed input via filterOption', async () => {
+    const user = userEvent.setup();
+    render(<CoursesListModal {...makeProps()} />);
+
+    const combobox = await screen.findByRole('combobox');
+    await user.click(combobox);
+    await user.type(combobox, 'react');
+
+    // "JavaScript" should be filtered out; only "React" remains visible.
+    await waitFor(() => {
+      expect(within(document.body).getByText('React')).toBeInTheDocument();
+    });
+    expect(within(document.body).queryByText('JavaScript')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/modules/Feedback/components/FeedbackForm.test.tsx
+++ b/client/src/modules/Feedback/components/FeedbackForm.test.tsx
@@ -1,0 +1,255 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateStudentFeedbackDtoEnglishLevelEnum as EnglishLevelEnum,
+  CreateStudentFeedbackDtoRecommendationEnum as RecommendationEnum,
+  SoftSkillEntryIdEnum,
+  SoftSkillEntryValueEnum,
+  MentorStudentDto,
+} from '@client/api';
+import { FeedbackForm } from './FeedbackForm';
+
+// UserSearch is a debounced, async, search-driven antd Select (a genuinely brittle
+// widget). Replace it with a minimal controlled <select> that preserves the
+// value/onChange contract Form.Item injects via cloneElement, so we can drive the
+// "student change" branch like a user picking an option.
+vi.mock('@client/shared/components/UserSearch', () => ({
+  UserSearch: (props: {
+    value?: number | string;
+    onChange?: (value: string) => void;
+    defaultValues?: { id: number; name: string }[];
+  }) => (
+    <select data-testid="user-search" value={props.value ?? ''} onChange={e => props.onChange?.(e.target.value)}>
+      <option value="">none</option>
+      {(props.defaultValues ?? []).map(s => (
+        <option key={s.id} value={s.id}>
+          {s.name}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const { routerPush } = vi.hoisted(() => ({ routerPush: vi.fn() }));
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: routerPush, query: {}, pathname: '/feedback' }),
+}));
+
+function makeStudent(overrides: Partial<MentorStudentDto> = {}): MentorStudentDto {
+  return {
+    name: 'Alice',
+    githubId: 'alice',
+    id: 1,
+    active: true,
+    cityName: null,
+    countryName: null,
+    totalScore: 0,
+    rank: 0,
+    feedbacks: [],
+    ...overrides,
+  } as MentorStudentDto;
+}
+
+const studentWithFeedback = makeStudent({
+  name: 'Bob',
+  githubId: 'bob',
+  id: 2,
+  feedbacks: [
+    {
+      id: 99,
+      createdDate: '2024-01-01',
+      updatedDate: '2024-01-01',
+      recommendation: RecommendationEnum.Hire,
+      englishLevel: EnglishLevelEnum.B2,
+      content: {
+        suggestions: 'Keep practicing',
+        recommendationComment: 'Great work',
+        softSkills: [
+          { id: SoftSkillEntryIdEnum.Responsible, value: SoftSkillEntryValueEnum.Excellent },
+          { id: SoftSkillEntryIdEnum.TeamPlayer, value: SoftSkillEntryValueEnum.Good },
+          { id: SoftSkillEntryIdEnum.Communicable, value: SoftSkillEntryValueEnum.Fair },
+        ],
+      },
+    },
+  ] as MentorStudentDto['feedbacks'],
+});
+
+describe('<FeedbackForm />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the recommendation radios, comment field, english levels and soft-skill rates', () => {
+    render(<FeedbackForm studentId={1} students={[makeStudent()]} onSubmit={vi.fn()} />);
+
+    // Recommendation radios.
+    expect(screen.getByRole('radio', { name: /^hire$/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /not hire/i })).toBeInTheDocument();
+
+    // Conditional comment field is always present (label "What was good").
+    expect(screen.getByLabelText(/what was good/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/what could be improved/i)).toBeInTheDocument();
+
+    // English levels rendered uppercased.
+    ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'].forEach(level => {
+      expect(screen.getByRole('radio', { name: level })).toBeInTheDocument();
+    });
+
+    // Three soft-skill Rate widgets, labelled by their skill names.
+    expect(screen.getByText('Responsible')).toBeInTheDocument();
+    expect(screen.getByText('Good team player')).toBeInTheDocument();
+    expect(screen.getByText('Communicable')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /^submit$/i })).toBeInTheDocument();
+  });
+
+  it('blocks submit and shows required errors when recommendation and comment are empty', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<FeedbackForm studentId={1} students={[makeStudent()]} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    // Two required fields (recommendation + recommendationComment) -> two "Required" messages.
+    await waitFor(() => {
+      expect(screen.getAllByText('Required')).toHaveLength(2);
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the full payload to onSubmit when required fields are filled (Hire, english level, soft skills)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<FeedbackForm studentId={1} students={[makeStudent()]} onSubmit={onSubmit} />);
+
+    // antd Radio.Button inner input has `pointer-events: none` in jsdom, which
+    // userEvent.click rejects; fireEvent.click on the radio is the supported path.
+    fireEvent.click(screen.getByRole('radio', { name: /^hire$/i }));
+    await user.type(screen.getByLabelText(/what was good/i), 'Excellent communication');
+    await user.type(screen.getByLabelText(/what could be improved/i), 'More tests');
+    fireEvent.click(screen.getByRole('radio', { name: 'B1' }));
+
+    // Rate the first soft-skill star = 1 (-> Poor). In antd v6 a Rate exposes its
+    // stars as elements with role="radio" and accessible name "star star"; the
+    // recommendation/english radios have distinct names, so filtering by /star/i
+    // yields only Rate stars. Index 0 = first star of the first Rate widget.
+    const stars = screen.getAllByRole('radio', { name: /star/i });
+    fireEvent.click(stars[0]);
+
+    await user.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    const [studentId, payload, existingFeedbackId] = onSubmit.mock.calls[0];
+    expect(studentId).toBe(1);
+    expect(existingFeedbackId).toBeUndefined();
+    expect(payload.recommendation).toBe(RecommendationEnum.Hire);
+    expect(payload.englishLevel).toBe(EnglishLevelEnum.B1);
+    expect(payload.content.recommendationComment).toBe('Excellent communication');
+    expect(payload.content.suggestions).toBe('More tests');
+    // First soft skill rated 1 -> Poor; others unrated -> None.
+    expect(payload.content.softSkills).toEqual([
+      { id: SoftSkillEntryIdEnum.Responsible, value: SoftSkillEntryValueEnum.Poor },
+      { id: SoftSkillEntryIdEnum.TeamPlayer, value: SoftSkillEntryValueEnum.None },
+      { id: SoftSkillEntryIdEnum.Communicable, value: SoftSkillEntryValueEnum.None },
+    ]);
+  });
+
+  it('defaults englishLevel to Unknown and suggestions to empty string when left blank', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<FeedbackForm studentId={1} students={[makeStudent()]} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: /not hire/i }));
+    await user.type(screen.getByLabelText(/what was good/i), 'ok');
+
+    await user.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const [, payload] = onSubmit.mock.calls[0];
+    expect(payload.recommendation).toBe(RecommendationEnum.NotHire);
+    expect(payload.englishLevel).toBe(EnglishLevelEnum.Unknown);
+    expect(payload.content.suggestions).toBe('');
+  });
+
+  it('prefills values from an existing feedback and submits with the existing feedback id', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<FeedbackForm studentId={2} students={[studentWithFeedback]} onSubmit={onSubmit} />);
+
+    // Prefilled comment and suggestions.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/what was good/i)).toHaveValue('Great work');
+    });
+    expect(screen.getByLabelText(/what could be improved/i)).toHaveValue('Keep practicing');
+    // Prefilled Hire radio is checked.
+    expect(screen.getByRole('radio', { name: /^hire$/i })).toBeChecked();
+    // Prefilled english level B2 is checked.
+    expect(screen.getByRole('radio', { name: 'B2' })).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const [studentId, payload, existingFeedbackId] = onSubmit.mock.calls[0];
+    expect(studentId).toBe(2);
+    expect(existingFeedbackId).toBe(99);
+    // Soft skill values mapped back to enums from the prefilled numeric ratings.
+    expect(payload.content.softSkills).toEqual([
+      { id: SoftSkillEntryIdEnum.Responsible, value: SoftSkillEntryValueEnum.Excellent },
+      { id: SoftSkillEntryIdEnum.TeamPlayer, value: SoftSkillEntryValueEnum.Good },
+      { id: SoftSkillEntryIdEnum.Communicable, value: SoftSkillEntryValueEnum.Fair },
+    ]);
+  });
+
+  it('resets the form and pushes the new studentId to the router when the student changes', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<FeedbackForm studentId={1} students={[makeStudent(), studentWithFeedback]} onSubmit={onSubmit} />);
+
+    // Type something into the comment, then switch student -> form resets.
+    fireEvent.change(screen.getByLabelText(/what was good/i), { target: { value: 'temp text' } });
+    expect(screen.getByLabelText(/what was good/i)).toHaveValue('temp text');
+
+    // Switch to the student that HAS feedback -> resets + prefills from their feedback.
+    fireEvent.change(screen.getByTestId('user-search'), { target: { value: '2' } });
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith({ pathname: '/feedback', query: { studentId: 2 } }, undefined, {
+        shallow: true,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/what was good/i)).toHaveValue('Great work');
+    });
+  });
+
+  it('resets to a blank form when switching to a student without existing feedback', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<FeedbackForm studentId={2} students={[studentWithFeedback, makeStudent()]} onSubmit={onSubmit} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/what was good/i)).toHaveValue('Great work');
+    });
+
+    // Switch to the student WITHOUT feedback (id 1) -> blank form.
+    fireEvent.change(screen.getByTestId('user-search'), { target: { value: '1' } });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/what was good/i)).toHaveValue('');
+    });
+    expect(routerPush).toHaveBeenCalledWith({ pathname: '/feedback', query: { studentId: 1 } }, undefined, {
+      shallow: true,
+    });
+  });
+
+  it('shows an error message when onSubmit rejects', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup();
+    render(<FeedbackForm studentId={1} students={[makeStudent()]} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: /^hire$/i }));
+    await user.type(screen.getByLabelText(/what was good/i), 'ok');
+    await user.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(await screen.findByText(/error occurred while creating feedback/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/modules/Interview/Student/components/ExtraInfo.test.tsx
+++ b/client/src/modules/Interview/Student/components/ExtraInfo.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExtraInfo } from './ExtraInfo';
+
+// Real antd Button/Tag + real isRegistrationNotStarted domain helper.
+
+const FUTURE = '2999-01-01T00:00:00.000Z';
+const PAST = '2000-01-01T00:00:00.000Z';
+
+describe('<ExtraInfo />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders an enabled "Register" button when registration is open and the user is not registered', () => {
+    const onRegister = vi.fn();
+    render(<ExtraInfo id={42} registrationStart={PAST} isRegistered={false} onRegister={onRegister} />);
+
+    const button = screen.getByRole('button', { name: /^register$/i });
+    expect(button).toBeEnabled();
+
+    fireEvent.click(button);
+    expect(onRegister).toHaveBeenCalledWith('42');
+  });
+
+  it('renders a disabled "Registered" button (with check icon) and does not fire onRegister when already registered', () => {
+    const onRegister = vi.fn();
+    render(<ExtraInfo id={42} registrationStart={PAST} isRegistered={true} onRegister={onRegister} />);
+
+    const button = screen.getByRole('button', { name: /registered/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+    expect(onRegister).not.toHaveBeenCalled();
+  });
+
+  it('renders a "Registration starts on" tag (no button) when registration has not started', () => {
+    render(<ExtraInfo id={42} registrationStart={FUTURE} isRegistered={false} onRegister={vi.fn()} />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText(/registration starts on/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/modules/Interview/Student/components/InterviewCard.test.tsx
+++ b/client/src/modules/Interview/Student/components/InterviewCard.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InterviewDto } from '@client/api';
+import { InterviewDetails, InterviewStatus } from '@client/domain/interview';
+import { Decision } from '@client/data/interviews/technical-screening';
+import { InterviewCard } from './InterviewCard';
+
+// Real antd + real domain helpers are used; the only collaborator that reaches
+// outside is GithubUserLink (it pulls @client/hooks, already aliased to a mock).
+// No brittle widget here — register is a plain antd Button.
+
+const FUTURE = '2999-01-01T00:00:00.000Z';
+const PAST = '2000-01-01T00:00:00.000Z';
+
+function makeInterview(overrides: Partial<InterviewDto> = {}): InterviewDto {
+  return {
+    id: 7,
+    type: 'interview',
+    name: 'JS Interview',
+    startDate: '2024-05-01T00:00:00.000Z',
+    endDate: '2024-05-10T00:00:00.000Z',
+    description: 'desc',
+    descriptionUrl: 'https://example.com/interview',
+    attributes: {} as InterviewDto['attributes'],
+    studentRegistrationStartDate: PAST,
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<InterviewDetails> = {}): InterviewDetails {
+  return {
+    id: 100,
+    name: 'JS Interview',
+    completed: true,
+    status: InterviewStatus.Completed,
+    result: Decision.Yes,
+    descriptionUrl: 'https://example.com/interview',
+    startDate: '2024-05-01T00:00:00.000Z',
+    endDate: '2024-05-10T00:00:00.000Z',
+    interviewer: { name: 'Mentor One', githubId: 'mentor1' },
+    student: { name: 'Student One', githubId: 'student1' },
+    ...overrides,
+  };
+}
+
+describe('<InterviewCard />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the interview name as an external link to its description', () => {
+    render(<InterviewCard interview={makeInterview()} item={null} isRegistered={false} onRegister={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: 'JS Interview' });
+    expect(link).toHaveAttribute('href', 'https://example.com/interview');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  describe('not registered, registration open (no pair)', () => {
+    it('shows an enabled Register button and prompts to register', () => {
+      render(<InterviewCard interview={makeInterview()} item={null} isRegistered={false} onRegister={vi.fn()} />);
+
+      const register = screen.getByRole('button', { name: /^register$/i });
+      expect(register).toBeEnabled();
+      expect(screen.getByText(/register and get ready for your exciting interview/i)).toBeInTheDocument();
+    });
+
+    it('calls onRegister with the interview id (as string) on click', () => {
+      const onRegister = vi.fn();
+      render(
+        <InterviewCard interview={makeInterview({ id: 7 })} item={null} isRegistered={false} onRegister={onRegister} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /^register$/i }));
+
+      expect(onRegister).toHaveBeenCalledTimes(1);
+      expect(onRegister).toHaveBeenCalledWith('7');
+    });
+  });
+
+  describe('registered, no pair yet', () => {
+    it('shows a disabled "Registered" button and the "all set" message', () => {
+      const onRegister = vi.fn();
+      render(<InterviewCard interview={makeInterview()} item={null} isRegistered={true} onRegister={onRegister} />);
+
+      const registered = screen.getByRole('button', { name: /registered/i });
+      expect(registered).toBeDisabled();
+
+      fireEvent.click(registered);
+      expect(onRegister).not.toHaveBeenCalled();
+
+      expect(screen.getByText(/you’re all set! prepare for your upcoming interview/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('registration not started', () => {
+    it('shows a "Registration starts on" tag instead of a button and a come-back-later message', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview({ studentRegistrationStartDate: FUTURE })}
+          item={null}
+          isRegistered={false}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /^register$/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/registration starts on/i)).toBeInTheDocument();
+      expect(screen.getByText(/remember to come back and register after/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('has an interview pair (item present)', () => {
+    it('renders the interview details (interviewer, status, result) instead of the Register control', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview()}
+          item={makeItem({ status: InterviewStatus.Completed, result: Decision.Yes })}
+          isRegistered={true}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      // No register/registered button when a pair exists.
+      expect(screen.queryByRole('button', { name: /^register(ed)?$/i })).not.toBeInTheDocument();
+
+      // Details section.
+      expect(screen.getByText('Interviewer')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+      expect(screen.getByText('Result')).toBeInTheDocument();
+      // Completed status label + accepted result.
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+      expect(screen.getByText('Mentor accepted')).toBeInTheDocument();
+    });
+
+    it('shows the congratulations message when the interview passed with a "yes" result', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview()}
+          item={makeItem({ status: InterviewStatus.Completed, result: Decision.Yes })}
+          isRegistered={true}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/you have your interview result\. congratulations/i)).toBeInTheDocument();
+    });
+
+    it('shows the encouraging message when the interview passed with a "no" result', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview()}
+          item={makeItem({ status: InterviewStatus.Completed, result: Decision.No })}
+          isRegistered={true}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/mistakes are proof that you are trying/i)).toBeInTheDocument();
+      expect(screen.getByText('Mentor declined')).toBeInTheDocument();
+    });
+
+    it('shows the "check back later" message when the result is still a draft', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview()}
+          item={makeItem({ status: InterviewStatus.Completed, result: Decision.Draft })}
+          isRegistered={true}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/the mentor hasn't provided feedback yet/i)).toBeInTheDocument();
+    });
+
+    it('renders a "Canceled" status label when the interview pair was canceled', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview()}
+          item={makeItem({ status: InterviewStatus.Canceled, result: null })}
+          isRegistered={true}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Canceled')).toBeInTheDocument();
+    });
+
+    it('shows the "contact your interviewer" message when registered with a pair but not yet completed', () => {
+      render(
+        <InterviewCard
+          interview={makeInterview()}
+          item={makeItem({ status: InterviewStatus.NotCompleted, result: null })}
+          isRegistered={true}
+          onRegister={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/contact your interviewer to schedule the interview/i)).toBeInTheDocument();
+      expect(screen.getByText('Not Completed')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the comment alert only when a comment is provided', () => {
+    const { rerender } = render(
+      <InterviewCard interview={makeInterview()} item={null} isRegistered={false} onRegister={vi.fn()} />,
+    );
+    expect(screen.queryByText('Nice progress!')).not.toBeInTheDocument();
+
+    rerender(
+      <InterviewCard
+        interview={makeInterview()}
+        item={null}
+        isRegistered={false}
+        onRegister={vi.fn()}
+        comment="Nice progress!"
+      />,
+    );
+    expect(screen.getByText('Nice progress!')).toBeInTheDocument();
+  });
+});

--- a/client/src/modules/Interviews/pages/StageInterviewFeedback/FormItem.test.tsx
+++ b/client/src/modules/Interviews/pages/StageInterviewFeedback/FormItem.test.tsx
@@ -1,0 +1,406 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form } from 'antd';
+import { ReactNode } from 'react';
+import { FormItem } from './FormItem';
+import { StepForm } from './StepForm';
+import { FeedbackStep, FeedbackStepId, StepFormItem } from '@client/data/interviews/technical-screening';
+import { InputType } from '@client/data/interviews';
+
+// FormItem only renders a non-brittle widget per branch (Radio / RadioButton / Checkbox /
+// Input / TextArea). The Rating branch delegates to QuestionList, whose Form.List +
+// useWatch + Rate combo is genuinely brittle in jsdom — it has its own dedicated spec
+// (QuestionList.test.tsx), so here we stub it to a marker to keep this spec fast and to
+// assert the Rating branch is reached.
+vi.mock('./QuestionList', () => ({
+  QuestionList: ({ question }: { question: { id: string } }) => (
+    <div data-testid="question-list-stub">QuestionList:{question.id}</div>
+  ),
+}));
+
+// Helper: render a single FormItem inside a real antd Form so antd injects value/onChange
+// and runs validation. The caller owns the `onFinish` spy so we can assert submitted values.
+function renderItem(
+  item: StepFormItem,
+  onFinish: ReturnType<typeof vi.fn>,
+  initialValues: Record<string, unknown> = {},
+) {
+  render(
+    <Form onFinish={onFinish} initialValues={initialValues}>
+      <FormItem item={item} form={undefined as never} stepId={FeedbackStepId.Introduction} />
+      <button type="submit">submit</button>
+    </Form>,
+  );
+}
+
+// We pass `form={undefined}` for items that never touch `form` (every branch except Radio,
+// whose NestedRadio child needs a real form). For the Radio case we render with a real form.
+
+describe('FormItem branches', () => {
+  it('renders a TextArea and submits its typed value', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'comment',
+      type: InputType.TextArea,
+      title: 'Comment',
+      placeholder: 'Comment about skills',
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    const textarea = screen.getByPlaceholderText('Comment about skills');
+    await user.type(textarea, 'Great student');
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ comment: 'Great student' }));
+  });
+
+  it('blocks submit and shows "Required" for an empty required TextArea', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'comment',
+      type: InputType.TextArea,
+      title: 'Comment',
+      required: true,
+      placeholder: 'Comment',
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    expect(await screen.findByText('Required')).toBeInTheDocument();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('renders a text Input and submits its value', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'name',
+      type: InputType.Input,
+      title: 'Name',
+      inputType: 'text',
+      placeholder: 'Enter name',
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    await user.type(screen.getByPlaceholderText('Enter name'), 'Ada');
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ name: 'Ada' }));
+  });
+
+  it('renders a number Input (narrow style) and submits a numeric string', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'finalScore',
+      type: InputType.Input,
+      title: 'Final Score',
+      inputType: 'number',
+      min: 0,
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '42');
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ finalScore: '42' }));
+  });
+
+  it('renders RadioButton options (with description) and submits the chosen id', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'englishCertificate',
+      type: InputType.RadioButton,
+      title: 'English',
+      required: true,
+      description: 'Certified level',
+      options: [
+        { id: 'none', title: 'No certificate' },
+        { id: 'B1', title: 'B1' },
+        { id: 'B2', title: 'B2' },
+      ],
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    expect(screen.getByText('Certified level')).toBeInTheDocument();
+    // antd Radio.Button puts `pointer-events: none` on the underlying input and handles
+    // clicks on the visible label, so click the label text like a real user would.
+    await user.click(screen.getByText('B1'));
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ englishCertificate: 'B1' }));
+  });
+
+  it('shows "Required" for a required RadioButton left unselected', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'englishCertificate',
+      type: InputType.RadioButton,
+      title: 'English',
+      required: true,
+      options: [{ id: 'A1', title: 'A1' }],
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    expect(await screen.findByText('Required')).toBeInTheDocument();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('renders a Checkbox.Group and submits the checked ids as an array', async () => {
+    const user = userEvent.setup();
+    const item: StepFormItem = {
+      id: 'isGoodCandidate',
+      type: InputType.Checkbox,
+      title: 'Good candidate?',
+      options: [
+        { id: 'true', title: 'Good candidate' },
+        { id: 'maybe', title: 'Maybe' },
+      ],
+    };
+    const onFinish = vi.fn();
+    renderItem(item, onFinish);
+
+    await user.click(screen.getByRole('checkbox', { name: 'Good candidate' }));
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ isGoodCandidate: ['true'] }));
+  });
+
+  it('delegates the Rating type to QuestionList', () => {
+    const item: StepFormItem = {
+      id: 'questions',
+      type: InputType.Rating,
+      title: 'Questions',
+      questions: [{ id: 'q1', title: 'Q1' }],
+    };
+    render(
+      <Form>
+        <FormItem item={item} form={undefined as never} stepId={FeedbackStepId.Theory} />
+      </Form>,
+    );
+
+    expect(screen.getByTestId('question-list-stub')).toHaveTextContent('QuestionList:questions');
+  });
+
+  it('renders nothing for an unknown item type (default branch)', () => {
+    render(
+      <Form>
+        <FormItem
+          item={{ id: 'x', title: 'x', type: 'totally-unknown' } as unknown as StepFormItem}
+          form={undefined as never}
+          stepId={FeedbackStepId.Theory}
+        />
+      </Form>,
+    );
+    // Form renders, but no form control was produced by FormItem.
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});
+
+// The Radio branch wires a NestedRadio child that needs a live form instance.
+describe('FormItem Radio + nested conditional (real form)', () => {
+  function RadioHarness({ children }: { children: (form: ReturnType<typeof Form.useForm>[0]) => ReactNode }) {
+    const [form] = Form.useForm();
+    return <Form form={form}>{children(form)}</Form>;
+  }
+
+  const radioItem: StepFormItem = {
+    id: 'interviewResult',
+    type: InputType.Radio,
+    title: 'Show up?',
+    required: true,
+    options: [
+      { id: 'completed', title: "Yes, it's ok." },
+      {
+        id: 'missed',
+        title: 'No, failed.',
+        options: [
+          { id: 'reason', title: 'Has a reason.' },
+          { id: 'ignores', title: 'Ignores mentor.' },
+        ],
+      },
+    ],
+  };
+
+  it('shows nested sub-options only after the parent option with children is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <RadioHarness>
+        {form => <FormItem item={radioItem} form={form} stepId={FeedbackStepId.Introduction} />}
+      </RadioHarness>,
+    );
+
+    // Initially nested reasons are hidden.
+    expect(screen.queryByRole('radio', { name: 'Has a reason.' })).not.toBeInTheDocument();
+
+    // Selecting "No, failed." (which has child options) reveals the nested radios.
+    await user.click(screen.getByRole('radio', { name: 'No, failed.' }));
+    expect(await screen.findByRole('radio', { name: 'Has a reason.' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Ignores mentor.' })).toBeInTheDocument();
+
+    // Selecting the option WITHOUT children hides the nested group again.
+    await user.click(screen.getByRole('radio', { name: "Yes, it's ok." }));
+    await waitFor(() => expect(screen.queryByRole('radio', { name: 'Has a reason.' })).not.toBeInTheDocument());
+  });
+
+  it('does not render a nested group for a childless option', () => {
+    const user = userEvent.setup();
+    render(
+      <RadioHarness>
+        {form => <FormItem item={radioItem} form={form} stepId={FeedbackStepId.Introduction} />}
+      </RadioHarness>,
+    );
+    // "Yes, it's ok." has no `options`, so NestedRadio returns null → no extra radios.
+    void user;
+    expect(screen.getAllByRole('radio')).toHaveLength(2); // only the two top-level options
+  });
+});
+
+// StepForm wires the initial-values derivation (getInitialQuestions): an Input item with a
+// defaultValue should pre-fill, and Back/Next labels depend on isFirst/isLast.
+describe('<StepForm /> initial values + navigation labels', () => {
+  function makeStep(items: StepFormItem[], values?: FeedbackStep['values']): FeedbackStep {
+    return {
+      id: FeedbackStepId.Decision,
+      title: 'Mentor decision',
+      description: 'desc',
+      stepperDescription: 'stepper',
+      items,
+      isCompleted: false,
+      values,
+    };
+  }
+
+  it('pre-fills an Input item from its defaultValue when the step has no saved values', () => {
+    const step = makeStep([
+      {
+        id: 'finalScore',
+        type: InputType.Input,
+        title: 'Final Score',
+        inputType: 'number',
+        defaultValue: 77,
+        min: 0,
+      },
+    ]);
+    render(<StepForm step={step} next={vi.fn()} back={vi.fn()} isFirst isLast={false} onValuesChange={vi.fn()} />);
+
+    // <input type="number"> → jest-dom compares numerically.
+    expect(screen.getByRole('spinbutton')).toHaveValue(77);
+  });
+
+  it('prefers saved step values over the template defaults', () => {
+    const step = makeStep(
+      [{ id: 'finalScore', type: InputType.Input, title: 'Final Score', inputType: 'number', defaultValue: 77 }],
+      { finalScore: 12 },
+    );
+    render(<StepForm step={step} next={vi.fn()} back={vi.fn()} isFirst isLast={false} onValuesChange={vi.fn()} />);
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(12);
+  });
+
+  it('hides Back and shows "Next" on the first non-final step', () => {
+    const step = makeStep([{ id: 'comment', type: InputType.TextArea, title: 'c', placeholder: 'c' }]);
+    render(<StepForm step={step} next={vi.fn()} back={vi.fn()} isFirst isLast={false} onValuesChange={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+  });
+
+  it('shows Back and "Submit" on a final, non-first step and calls back on click', async () => {
+    const user = userEvent.setup();
+    const back = vi.fn();
+    const step = makeStep([{ id: 'comment', type: InputType.TextArea, title: 'c', placeholder: 'c' }]);
+    render(<StepForm step={step} next={vi.fn()} back={back} isFirst={false} isLast onValuesChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call next and runs onFinishFailed when a required field is empty on submit', async () => {
+    const user = userEvent.setup();
+    const next = vi.fn();
+    const step = makeStep([{ id: 'comment', type: InputType.TextArea, title: 'c', required: true, placeholder: 'c' }]);
+    render(<StepForm step={step} next={next} back={vi.fn()} isFirst isLast onValuesChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    // Validation fails → onFinishFailed (scrollToField) runs, next is never called.
+    expect(await screen.findByText('Required')).toBeInTheDocument();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next with the collected values on a valid submit', async () => {
+    const user = userEvent.setup();
+    const next = vi.fn();
+    const step = makeStep([{ id: 'comment', type: InputType.TextArea, title: 'c', placeholder: 'type' }]);
+    render(<StepForm step={step} next={next} back={vi.fn()} isFirst isLast onValuesChange={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('type'), 'all good');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(next).toHaveBeenCalledWith({ comment: 'all good' }));
+  });
+
+  it('reports value changes via onValuesChange as the user types', async () => {
+    const user = userEvent.setup();
+    const onValuesChange = vi.fn();
+    const step = makeStep([{ id: 'comment', type: InputType.TextArea, title: 'c', placeholder: 'type here' }]);
+    render(
+      <StepForm step={step} next={vi.fn()} back={vi.fn()} isFirst isLast={false} onValuesChange={onValuesChange} />,
+    );
+
+    await user.type(screen.getByPlaceholderText('type here'), 'x');
+    await waitFor(() => expect(onValuesChange).toHaveBeenCalled());
+    const [, allValues] = onValuesChange.mock.calls.at(-1) as [unknown, Record<string, unknown>];
+    expect(allValues).toMatchObject({ comment: 'x' });
+  });
+});
+
+// A focused check that nested options live in the same group as their parent.
+describe('FormItem Radio nested group structure', () => {
+  it('nests sub-options under the selected parent', async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form}>
+          <FormItem
+            item={{
+              id: 'interviewResult',
+              type: InputType.Radio,
+              title: 'Show up?',
+              required: true,
+              options: [
+                {
+                  id: 'missed',
+                  title: 'No, failed.',
+                  options: [{ id: 'reason', title: 'Has a reason.' }],
+                },
+              ],
+            }}
+            form={form}
+            stepId={FeedbackStepId.Introduction}
+          />
+        </Form>
+      );
+    }
+    render(<Harness />);
+
+    await user.click(screen.getByRole('radio', { name: 'No, failed.' }));
+    const groups = screen.getAllByRole('radiogroup');
+    // Outer group + the revealed nested group.
+    expect(groups.length).toBeGreaterThanOrEqual(2);
+    expect(within(groups[groups.length - 1]).getByRole('radio', { name: 'Has a reason.' })).toBeInTheDocument();
+  });
+});

--- a/client/src/modules/Interviews/pages/StageInterviewFeedback/QuestionList.test.tsx
+++ b/client/src/modules/Interviews/pages/StageInterviewFeedback/QuestionList.test.tsx
@@ -1,0 +1,262 @@
+// antd Rate / DeleteOutlined icon expose state only via CSS classes (no ARIA role), so the
+// row-count and delete-icon assertions reach into the DOM by class — intentional here.
+/* eslint-disable testing-library/no-node-access */
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+import { FeedbackStepId, QuestionItem } from '@client/data/interviews/technical-screening';
+import { InputType } from '@client/data/interviews';
+
+// Brittle-widget stub: antd v6 `Form.useWatch` on a `Form.List` field returns the internal
+// watch-store object (not the array) on first paint in jsdom, crashing QuestionList's
+// `formQuestions?.some(...)`. Everything else in antd stays real; we only repair useWatch by
+// reading the live field value from the passed form instance (value/onChange contract intact).
+vi.mock('antd', async () => {
+  const actual = (await vi.importActual('antd')) as typeof import('antd');
+  const RealForm = actual.Form;
+  const realUseWatch = RealForm.useWatch;
+  function useWatch(this: unknown, ...args: unknown[]) {
+    const opts = args[1] as { form?: import('antd').FormInstance } | undefined;
+    if (opts?.form) {
+      return opts.form.getFieldValue(args[0] as string | string[]);
+    }
+    return (realUseWatch as (...a: unknown[]) => unknown).apply(this, args);
+  }
+  const Form = Object.create(
+    Object.getPrototypeOf(RealForm),
+    Object.getOwnPropertyDescriptors(RealForm),
+  ) as typeof RealForm;
+  (Form as { useWatch: typeof useWatch }).useWatch = useWatch;
+  return { ...actual, Form };
+});
+
+import { Form } from 'antd';
+import { QuestionList } from './QuestionList';
+import { StepForm } from './StepForm';
+
+const baseQuestions = [
+  { id: 'html', title: 'HTML/CSS question', topic: 'HTML/CSS' },
+  { id: 'oop', title: 'OOP question', topic: 'CS' },
+];
+const poolOnly = { id: 'algorithms', title: 'Algorithms question', topic: 'CS' };
+
+function makeQuestion(overrides: Partial<QuestionItem> = {}): QuestionItem {
+  return {
+    id: 'questions',
+    title: 'Questions',
+    type: InputType.Rating,
+    required: true,
+    tooltips: ['a', 'b', 'c', 'd', 'e'],
+    questions: baseQuestions,
+    examples: [...baseQuestions, poolOnly],
+    ...overrides,
+  };
+}
+
+// Render QuestionList inside a real Form with the same initial structure the StepForm uses.
+function Harness({
+  question = makeQuestion(),
+  stepId = FeedbackStepId.Theory,
+  onFinish = vi.fn(),
+  initialQuestions = baseQuestions,
+}: {
+  question?: QuestionItem;
+  stepId?: FeedbackStepId;
+  onFinish?: (v: unknown) => void;
+  initialQuestions?: typeof baseQuestions;
+} = {}): ReactNode {
+  function Inner() {
+    const [form] = Form.useForm();
+    return (
+      <Form form={form} initialValues={{ [question.id]: initialQuestions }} onFinish={onFinish}>
+        <QuestionList form={form} question={question} stepId={stepId} />
+        <button type="submit">submit</button>
+      </Form>
+    );
+  }
+  return <Inner />;
+}
+
+describe('<QuestionList /> question picker + custom + remove', () => {
+  it('renders the initial questions with topic + title and a Rate per row', () => {
+    render(Harness());
+
+    expect(screen.getByText('HTML/CSS question')).toBeInTheDocument();
+    expect(screen.getByText('OOP question')).toBeInTheDocument();
+    // Two rows → two Rate widgets, each exposing 5 radio stars.
+    const rates = document.querySelectorAll('.ant-rate');
+    expect(rates).toHaveLength(2);
+  });
+
+  it('shows "Add from list" only while there are unused pool questions', () => {
+    // examples contains an extra pool question (algorithms) not in initial → button shown.
+    render(Harness());
+    expect(screen.getByRole('button', { name: /Add from list/i })).toBeInTheDocument();
+  });
+
+  it('hides "Add from list" when every example is already added', () => {
+    render(Harness({ question: makeQuestion({ examples: baseQuestions }) }));
+    expect(screen.queryByRole('button', { name: /Add from list/i })).not.toBeInTheDocument();
+    // The custom-question button is always available.
+    expect(screen.getByRole('button', { name: /Custom question/i })).toBeInTheDocument();
+  });
+
+  it('labels the custom button "Custom task" on the Practice step and "Custom question" otherwise', () => {
+    const { unmount } = render(Harness({ stepId: FeedbackStepId.Practice }));
+    expect(screen.getByRole('button', { name: /Custom task/i })).toBeInTheDocument();
+    unmount();
+
+    render(Harness({ stepId: FeedbackStepId.Theory }));
+    expect(screen.getByRole('button', { name: /Custom question/i })).toBeInTheDocument();
+  });
+
+  it('opens the picker modal, validates an empty selection, then adds a pooled question', async () => {
+    const user = userEvent.setup();
+    render(Harness());
+
+    await user.click(screen.getByRole('button', { name: /Add from list/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Add question')).toBeInTheDocument();
+    // Only the not-yet-added pool question (algorithms) is offered.
+    expect(within(dialog).getByText('Algorithms question')).toBeInTheDocument();
+    expect(within(dialog).queryByText('HTML/CSS question')).not.toBeInTheDocument();
+
+    // Submitting with nothing selected → validation error, modal stays open.
+    await user.click(within(dialog).getByRole('button', { name: 'Add' }));
+    expect(await screen.findByText('Please select questions to add to the feedback')).toBeInTheDocument();
+
+    // Select the pool question and confirm → it is appended as a new row.
+    await user.click(within(dialog).getByRole('checkbox', { name: 'Algorithms question' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Add' }));
+
+    expect(await screen.findByText('Algorithms question')).toBeInTheDocument();
+    // Now three rows → three Rate widgets.
+    await waitFor(() => expect(document.querySelectorAll('.ant-rate')).toHaveLength(3));
+  });
+
+  it('cancels the picker modal without adding anything', async () => {
+    const user = userEvent.setup();
+    render(Harness());
+
+    await user.click(screen.getByRole('button', { name: /Add from list/i }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /Cancel/i }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(document.querySelectorAll('.ant-rate')).toHaveLength(2);
+  });
+
+  it('adds a custom question (typed) as a new row and ignores blank input', async () => {
+    const user = userEvent.setup();
+    render(Harness());
+
+    await user.click(screen.getByRole('button', { name: /Custom question/i }));
+    const input = await screen.findByPlaceholderText('Enter your question');
+
+    // Blank/whitespace input → Save is a no-op (card stays, no new row).
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(document.querySelectorAll('.ant-rate')).toHaveLength(2);
+
+    await user.type(input, '  Explain closures  ');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Explain closures')).toBeInTheDocument();
+    await waitFor(() => expect(document.querySelectorAll('.ant-rate')).toHaveLength(3));
+  });
+
+  it('adds a custom question via Enter key (onPressEnter)', async () => {
+    const user = userEvent.setup();
+    render(Harness());
+
+    await user.click(screen.getByRole('button', { name: /Custom question/i }));
+    const input = await screen.findByPlaceholderText('Enter your question');
+
+    await user.type(input, 'Event loop?{Enter}');
+
+    expect(await screen.findByText('Event loop?')).toBeInTheDocument();
+  });
+
+  it('cancels the custom-question card without adding', async () => {
+    const user = userEvent.setup();
+    render(Harness());
+
+    await user.click(screen.getByRole('button', { name: /Custom question/i }));
+    await screen.findByPlaceholderText('Enter your question');
+    await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+    await waitFor(() => expect(screen.queryByPlaceholderText('Enter your question')).not.toBeInTheDocument());
+    expect(document.querySelectorAll('.ant-rate')).toHaveLength(2);
+  });
+
+  it('removes a question row (delete icon shown only when more than one row)', async () => {
+    const user = userEvent.setup();
+    render(Harness());
+
+    // Two rows → delete icons present.
+    const deletes = document.querySelectorAll('.anticon-delete');
+    expect(deletes.length).toBe(2);
+
+    await user.click(deletes[0] as Element);
+
+    await waitFor(() => expect(document.querySelectorAll('.ant-rate')).toHaveLength(1));
+    // With a single row left, the delete icon disappears.
+    expect(document.querySelectorAll('.anticon-delete')).toHaveLength(0);
+  });
+
+  it('submits the rated question values through the form', async () => {
+    const user = userEvent.setup();
+    const onFinish = vi.fn();
+    render(Harness({ onFinish }));
+
+    // Each row's Rate is `required`, so rate BOTH rows or validation blocks submit.
+    const rates = document.querySelectorAll('.ant-rate');
+    const firstRowStars = within(rates[0] as HTMLElement).getAllByRole('radio');
+    const secondRowStars = within(rates[1] as HTMLElement).getAllByRole('radio');
+    await user.click(firstRowStars[3]); // value 4
+    await user.click(secondRowStars[1]); // value 2
+
+    await user.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledTimes(1));
+    const submitted = onFinish.mock.calls[0][0] as { questions: Record<number, { value?: number }> };
+    // The Form.List stores each row's rating under its `value` field, indexed by row.
+    // (The id/title metadata is carried separately via form.getFieldValue, not in the
+    // submitted list payload — so we assert on the captured ratings at indices 0 and 1.)
+    expect(submitted.questions[0]).toMatchObject({ value: 4 });
+    expect(submitted.questions[1]).toMatchObject({ value: 2 });
+  });
+});
+
+// StepForm with a Rating step but no saved values exercises getInitialQuestions' default
+// init (acc[id] = item.questions), which seeds the Form.List from the template questions.
+describe('<StepForm /> Rating step default initialization', () => {
+  it('seeds the question list from the template when the step has no saved values', () => {
+    const step = {
+      id: FeedbackStepId.Theory,
+      title: 'Theory',
+      description: 'desc',
+      stepperDescription: 'stepper',
+      isCompleted: false,
+      items: [
+        {
+          id: 'questions',
+          type: InputType.Rating,
+          title: 'Questions',
+          required: true,
+          tooltips: ['a', 'b', 'c', 'd', 'e'],
+          questions: baseQuestions,
+          examples: baseQuestions,
+        },
+      ],
+    };
+    render(
+      <StepForm step={step as never} next={vi.fn()} back={vi.fn()} isFirst isLast={false} onValuesChange={vi.fn()} />,
+    );
+
+    // Both template questions are seeded as rows.
+    expect(screen.getByText('HTML/CSS question')).toBeInTheDocument();
+    expect(screen.getByText('OOP question')).toBeInTheDocument();
+    expect(document.querySelectorAll('.ant-rate')).toHaveLength(2);
+  });
+});

--- a/client/src/modules/Interviews/pages/StageInterviewFeedback/StageInterviewFeedback.test.tsx
+++ b/client/src/modules/Interviews/pages/StageInterviewFeedback/StageInterviewFeedback.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { ReactNode, useEffect, useState } from 'react';
+import { StageInterviewFeedback } from './StageInterviewFeedback';
+import { InterviewFeedbackDto, ProfileCourseDto, StudentDto, TaskDtoTypeEnum } from '@client/api';
+import { StageFeedbackProps } from '../../data';
+
+// --- Boundary & heavy-collaborator mocks -----------------------------------
+
+// Brittle-widget stub: repair antd v6 Form.useWatch on Form.List fields in jsdom
+// (see StepContext.test.tsx for the rationale) so the Theory/Practice steps render.
+vi.mock('antd', async () => {
+  const actual = (await vi.importActual('antd')) as typeof import('antd');
+  const RealForm = actual.Form;
+  const realUseWatch = RealForm.useWatch;
+  function useWatch(this: unknown, ...args: unknown[]) {
+    const opts = args[1] as { form?: import('antd').FormInstance } | undefined;
+    if (opts?.form) {
+      return opts.form.getFieldValue(args[0] as string | string[]);
+    }
+    return (realUseWatch as (...a: unknown[]) => unknown).apply(this, args);
+  }
+  const Form = Object.create(
+    Object.getPrototypeOf(RealForm),
+    Object.getOwnPropertyDescriptors(RealForm),
+  ) as typeof RealForm;
+  (Form as { useWatch: typeof useWatch }).useWatch = useWatch;
+  return { ...actual, Form };
+});
+
+// Header pulls in SessionContext, navigation, theme switch, etc. — replace with a marker.
+vi.mock('@client/shared/components/Header', () => ({
+  Header: ({ title }: { title: string }) => <header>{title}</header>,
+}));
+
+// The legacy technical-screening page is dynamically imported as a fallback. next/dynamic
+// returns the module's default export; replace the whole page with a marker so we don't
+// pull the legacy tree into jsdom.
+vi.mock('@client/pages/course/mentor/interview-technical-screening', () => ({
+  default: () => <div>Legacy tech screening</div>,
+}));
+
+// API boundary: the save call is exercised by StepContext.test.tsx; here just stub it.
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  CoursesInterviewsApi: function CoursesInterviewsApi() {
+    return { createInterviewFeedback: vi.fn().mockResolvedValue(undefined) };
+  },
+}));
+
+// next/dynamic: render the page's `loading` fallback first, then swap in the loaded
+// component once the loader resolves — mirroring real next/dynamic behaviour so the
+// page's `loading: () => <p>Loading...</p>` branch is exercised too.
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<{ default: () => ReactNode }>, options?: { loading?: () => ReactNode }) => {
+    const Lazy = (props: Record<string, unknown>) => {
+      const [Comp, setComp] = useState<(() => ReactNode) | null>(null);
+      useEffect(() => {
+        loader().then(m => setComp(() => m.default));
+      }, []);
+      return Comp ? <Comp {...props} /> : (options?.loading?.() ?? null);
+    };
+    return Lazy;
+  },
+}));
+
+// --- Fixtures --------------------------------------------------------------
+
+const student = {
+  githubId: 'ada',
+  name: 'Ada Lovelace',
+  rank: 1,
+  totalScore: 100,
+  cityName: 'London',
+  countryName: 'UK',
+} as StudentDto;
+
+function makeProps(feedback: Partial<InterviewFeedbackDto> = {}): StageFeedbackProps {
+  return {
+    student,
+    courseSummary: { totalScore: 1000, studentsCount: 10 },
+    interviewFeedback: { isCompleted: false, maxScore: 100, version: 1, ...feedback },
+    course: { id: 42, alias: 'rs-2024' } as ProfileCourseDto,
+    interviewId: 7,
+    type: TaskDtoTypeEnum.StageInterview,
+    session: {} as never,
+  } as StageFeedbackProps;
+}
+
+describe('<StageInterviewFeedback /> (page)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the full feedback form (header, sub-header, first step, student sidebar)', () => {
+    render(<StageInterviewFeedback {...makeProps()} />);
+
+    expect(screen.getByRole('banner')).toHaveTextContent('Technical screening');
+    expect(screen.getByText('Feedback form')).toBeInTheDocument();
+    // First step content.
+    expect(screen.getByRole('heading', { level: 3, name: 'Introduction' })).toBeInTheDocument();
+    // Sidebar student info.
+    expect(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeInTheDocument();
+    // Sub-header reflects the not-completed state.
+    expect(screen.getByText('Uncompleted')).toBeInTheDocument();
+  });
+
+  it('falls back to the legacy screening page when the feedback version is 0', async () => {
+    render(<StageInterviewFeedback {...makeProps({ version: 0 })} />);
+
+    // The dynamic loading fallback shows first, then the legacy page resolves in.
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(await screen.findByText('Legacy tech screening')).toBeInTheDocument();
+    // None of the new-form chrome is rendered.
+    expect(screen.queryByText('Feedback form')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the legacy screening page when the feedback feature toggle is off', async () => {
+    const features = await import('@client/services/features');
+    const original = features.featureToggles.feedback;
+    features.featureToggles.feedback = false;
+    try {
+      render(<StageInterviewFeedback {...makeProps({ version: 1 })} />);
+      expect(await screen.findByText('Legacy tech screening')).toBeInTheDocument();
+      expect(screen.queryByText('Feedback form')).not.toBeInTheDocument();
+    } finally {
+      features.featureToggles.feedback = original;
+    }
+  });
+
+  it('marks the sub-header tag "Completed" when the feedback is completed', () => {
+    render(<StageInterviewFeedback {...makeProps({ isCompleted: true })} />);
+
+    const tag = screen.getByText('Completed');
+    expect(tag).toBeInTheDocument();
+    expect(tag).toHaveClass('ant-tag-green');
+  });
+
+  it('treats a missing isCompleted flag as "Uncompleted" in the sub-header', () => {
+    render(<StageInterviewFeedback {...makeProps({ isCompleted: undefined as unknown as boolean })} />);
+
+    expect(screen.getByText('Uncompleted')).toBeInTheDocument();
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+  });
+
+  it('shows the vertical stepper with every template step', async () => {
+    render(<StageInterviewFeedback {...makeProps()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Interview confirmation')).toBeInTheDocument();
+      expect(screen.getByText('Student admission to the mentoring program')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/modules/Interviews/pages/StageInterviewFeedback/StepContext.test.tsx
+++ b/client/src/modules/Interviews/pages/StageInterviewFeedback/StepContext.test.tsx
@@ -1,0 +1,339 @@
+// antd Spin/Steps expose state only via CSS classes (no ARIA role), so a few assertions
+// reach into the DOM by class — direct node access is intentional and unavoidable here.
+/* eslint-disable testing-library/no-node-access */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useContext } from 'react';
+import { StepContextProvider, StepContext } from './StepContext';
+import { StepsContent } from './StepsContent';
+import { Steps } from './Steps';
+import { InterviewFeedbackDto, ProfileCourseDto } from '@client/api';
+
+// --- Boundary mocks --------------------------------------------------------
+
+// Brittle-widget stub: antd v6 `Form.useWatch` on a `Form.List` field returns the
+// internal watch-store object (not the array) on first paint in jsdom, which crashes
+// QuestionList's `formQuestions?.some(...)` on the Theory/Practice steps. Everything
+// else in antd stays real; we only repair useWatch by reading the live field value
+// from the form instance (preserving the value/onChange contract).
+vi.mock('antd', async () => {
+  const actual = (await vi.importActual('antd')) as typeof import('antd');
+  const RealForm = actual.Form;
+  const realUseWatch = RealForm.useWatch;
+  // Only intervene when a concrete form instance is passed (QuestionList does this);
+  // otherwise defer to the real useWatch so nothing else recurses.
+  function useWatch(this: unknown, ...args: unknown[]) {
+    const opts = args[1] as { form?: import('antd').FormInstance } | undefined;
+    if (opts?.form) {
+      return opts.form.getFieldValue(args[0] as string | string[]);
+    }
+    return (realUseWatch as (...a: unknown[]) => unknown).apply(this, args);
+  }
+  // Clone the Form component object (forwardRef render object + static members) so we
+  // never mutate the shared antd.Form — mutation would make realUseWatch point back at
+  // us → infinite recursion. The clone keeps prototype + descriptors, only swaps useWatch.
+  const Form = Object.create(
+    Object.getPrototypeOf(RealForm),
+    Object.getOwnPropertyDescriptors(RealForm),
+  ) as typeof RealForm;
+  (Form as { useWatch: typeof useWatch }).useWatch = useWatch;
+  return { ...actual, Form };
+});
+
+// The only network boundary: CoursesInterviewsApi.createInterviewFeedback.
+// vi.hoisted so the spy is available to the module factory below and to assertions.
+const { createInterviewFeedback } = vi.hoisted(() => ({
+  createInterviewFeedback: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@client/api', async () => ({
+  ...(await vi.importActual('@client/api')),
+  CoursesInterviewsApi: function CoursesInterviewsApi() {
+    return { createInterviewFeedback };
+  },
+}));
+
+// next/router is aliased to src/__mocks__/next/router by vitest config. Grab its push spy.
+import { useRouter } from 'next/router';
+const routerPush = (useRouter() as unknown as { push: ReturnType<typeof vi.fn> }).push;
+
+// --- Fixtures --------------------------------------------------------------
+
+const course = { id: 42, alias: 'rs-2024' } as ProfileCourseDto;
+
+function makeFeedback(overrides: Partial<InterviewFeedbackDto> = {}): InterviewFeedbackDto {
+  return {
+    isCompleted: false,
+    maxScore: 100,
+    version: 1,
+    ...overrides,
+  };
+}
+
+function renderProvider(feedback: InterviewFeedbackDto = makeFeedback()) {
+  return render(
+    <StepContextProvider
+      interviewFeedback={feedback}
+      course={course}
+      interviewId={7}
+      type="stage-interview"
+      interviewMaxScore={feedback.maxScore}
+    >
+      <StepsContent />
+      <Steps />
+    </StepContextProvider>,
+  );
+}
+
+// A tiny consumer that surfaces the raw context API for direct-state assertions.
+function ContextProbe() {
+  const { activeStepIndex, isFinalStep, steps } = useContext(StepContext);
+  return (
+    <div>
+      <span data-testid="active-index">{activeStepIndex}</span>
+      <span data-testid="is-final">{String(isFinalStep)}</span>
+      <span data-testid="step-count">{steps.length}</span>
+    </div>
+  );
+}
+
+// Helper: select the "Yes, it's ok." radio on the Introduction step.
+async function answerIntroductionAsConducted(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('radio', { name: /Yes, it's ok\./i }));
+}
+
+describe('<StepContextProvider /> (multi-step feedback container)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('starts on the Introduction step (step 0) with 5 steps total', () => {
+    renderProvider();
+    render(
+      <StepContextProvider
+        interviewFeedback={makeFeedback()}
+        course={course}
+        interviewId={7}
+        type="stage-interview"
+        interviewMaxScore={100}
+      >
+        <ContextProbe />
+      </StepContextProvider>,
+    );
+
+    const [probe] = screen.getAllByTestId('active-index');
+    expect(probe).toHaveTextContent('0');
+    expect(screen.getByTestId('step-count')).toHaveTextContent('5');
+    expect(screen.getByTestId('is-final')).toHaveTextContent('false');
+    // The Introduction title and Next button (not Submit, since not final).
+    expect(screen.getByRole('heading', { level: 3, name: 'Introduction' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+  });
+
+  it('blocks Next while a required field is empty (no API call, stays on step 0)', async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(await screen.findByText('Required')).toBeInTheDocument();
+    await waitFor(() => expect(createInterviewFeedback).not.toHaveBeenCalled());
+    // Still on Introduction.
+    expect(screen.getByRole('heading', { level: 3, name: 'Introduction' })).toBeInTheDocument();
+  });
+
+  it('saves the Introduction step and advances to Theory, calling the API with the exact payload', async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await answerIntroductionAsConducted(user);
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(createInterviewFeedback).toHaveBeenCalledTimes(1));
+
+    const [courseId, interviewId, type, payload] = createInterviewFeedback.mock.calls[0];
+    expect(courseId).toBe(42);
+    expect(interviewId).toBe(7);
+    expect(type).toBe('stage-interview');
+    expect(payload).toMatchObject({
+      isCompleted: false,
+      version: 1,
+      // interview conducted → decision/candidate computed from later (still-empty) steps.
+      isGoodCandidate: undefined,
+    });
+    // The persisted json must record the Introduction answer on the intro step.
+    const introStep = (payload.json as { steps: Record<string, { isCompleted: boolean; values?: object }> }).steps
+      .intro;
+    expect(introStep).toEqual({
+      isCompleted: true,
+      values: expect.objectContaining({ interviewResult: 'completed' }),
+    });
+
+    // Advanced to Theory.
+    expect(await screen.findByRole('heading', { level: 3, name: 'Theory' })).toBeInTheDocument();
+  });
+
+  it('navigates Back from Theory to Introduction without calling the API', async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await answerIntroductionAsConducted(user);
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await screen.findByRole('heading', { level: 3, name: 'Theory' });
+
+    createInterviewFeedback.mockClear();
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Introduction' })).toBeInTheDocument();
+    expect(createInterviewFeedback).not.toHaveBeenCalled();
+    // Back is hidden on the first step.
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+  });
+
+  it('marks the interview as missed → becomes final, shows Submit, and completes on submit', async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    // Choosing "No, interview is failed." reveals a nested required reason radio,
+    // and flips the form into a "canceled" → final state.
+    await user.click(screen.getByRole('radio', { name: /No, interview is failed\./i }));
+    await user.click(await screen.findByRole('radio', { name: /Student has a significant reason\./i }));
+
+    // Now the only button is Submit (final step), Back is hidden (still step 0).
+    const submit = await screen.findByRole('button', { name: 'Submit' });
+    await user.click(submit);
+
+    await waitFor(() => expect(createInterviewFeedback).toHaveBeenCalledTimes(1));
+    const payload = createInterviewFeedback.mock.calls[0][3];
+    expect(payload).toMatchObject({
+      isCompleted: true,
+      score: 0,
+      // missed interview → decision carries the reason key.
+      decision: 'missedWithReason',
+      isGoodCandidate: false,
+    });
+    // Final step → routes back to the interviews list.
+    await waitFor(() => expect(routerPush).toHaveBeenCalledWith('/course/mentor/interviews?course=rs-2024'));
+  });
+
+  it('shows an error and stays on the step when the save API rejects', async () => {
+    const user = userEvent.setup();
+    createInterviewFeedback.mockRejectedValueOnce(new Error('boom'));
+    renderProvider();
+
+    await answerIntroductionAsConducted(user);
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(createInterviewFeedback).toHaveBeenCalledTimes(1));
+    // Did NOT advance — still on Introduction because saveFeedback rejected.
+    expect(await screen.findByRole('heading', { level: 3, name: 'Introduction' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'Theory' })).not.toBeInTheDocument();
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it('opens directly on the final Decision step (Submit) when prior steps are already completed', async () => {
+    // Pre-fill all steps except Decision as completed; getDefaultStep lands on the last (Decision) step.
+    const json = {
+      steps: {
+        intro: { isCompleted: true, values: { interviewResult: 'completed' } },
+        theory: { isCompleted: true, values: { questions: [{ id: 'html', title: 'q', value: 5 }] } },
+        practice: { isCompleted: true, values: { questions: [{ id: '1', title: 'q', value: 5 }], comment: 'ok' } },
+        english: {
+          isCompleted: true,
+          values: { englishCertificate: 'none', selfAssessment: 'B1' },
+        },
+        decision: { isCompleted: false, values: {} },
+      },
+    };
+    renderProvider(makeFeedback({ json }));
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Mentor decision' })).toBeInTheDocument();
+    // Final step → Submit, and Back is available since index > 0.
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+  });
+
+  it('renders the vertical stepper with one entry per template step', () => {
+    renderProvider();
+    // antd Steps render each title; the sidebar stepper duplicates titles already in the form,
+    // so assert on the stepper-only descriptions.
+    expect(screen.getByText('Interview confirmation')).toBeInTheDocument();
+    expect(screen.getByText('Talk about theory, how things work')).toBeInTheDocument();
+    expect(screen.getByText('Propose technical tasks to solve')).toBeInTheDocument();
+    expect(screen.getByText('Check English level')).toBeInTheDocument();
+    expect(screen.getByText('Student admission to the mentoring program')).toBeInTheDocument();
+  });
+
+  it('falls back to "Step not found" when the active step is missing', () => {
+    // Render StepsContent with a hand-built context whose steps array is empty.
+    render(
+      <StepContext.Provider
+        value={{
+          activeStepIndex: 0,
+          steps: [],
+          next: vi.fn(),
+          prev: vi.fn(),
+          onValuesChange: vi.fn(),
+          loading: false,
+          isFinalStep: false,
+        }}
+      >
+        <StepsContent />
+      </StepContext.Provider>,
+    );
+
+    expect(screen.getByText('Step not found')).toBeInTheDocument();
+  });
+
+  it('marks completed prior steps as "finish" and the active one as "process" in the stepper', async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await answerIntroductionAsConducted(user);
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await screen.findByRole('heading', { level: 3, name: 'Theory' });
+
+    // The antd stepper exposes status via aria/class; assert the Introduction item is now finished.
+    const introductionConfirmation = screen.getByText('Interview confirmation');
+    const introItem = introductionConfirmation.closest('.ant-steps-item');
+    expect(introItem).toHaveClass('ant-steps-item-finish');
+
+    const theoryDesc = screen.getByText('Talk about theory, how things work');
+    const theoryItem = theoryDesc.closest('.ant-steps-item');
+    expect(theoryItem).toHaveClass('ant-steps-item-process');
+  });
+});
+
+describe('StepContext loading spinner', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('disables the form via Spin while the save request is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveSave: (v?: unknown) => void = () => {};
+    createInterviewFeedback.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveSave = resolve;
+      }),
+    );
+
+    render(
+      <StepContextProvider
+        interviewFeedback={makeFeedback()}
+        course={course}
+        interviewId={7}
+        type="stage-interview"
+        interviewMaxScore={100}
+      >
+        <StepsContent />
+      </StepContextProvider>,
+    );
+
+    await user.click(screen.getByRole('radio', { name: /Yes, it's ok\./i }));
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    // While pending, antd Spin renders the spinning indicator (no ARIA role → class query).
+    await waitFor(() => expect(document.querySelector('.ant-spin-spinning')).toBeTruthy());
+
+    // Resolve and the spinner clears.
+    resolveSave(undefined);
+    await waitFor(() => expect(document.querySelector('.ant-spin-spinning')).toBeFalsy());
+  });
+});

--- a/client/src/modules/Interviews/pages/StageInterviewFeedback/StudentInfo.test.tsx
+++ b/client/src/modules/Interviews/pages/StageInterviewFeedback/StudentInfo.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { StudentInfo } from './StudentInfo';
+import { StudentDto } from '@client/api';
+
+function makeStudent(overrides: Partial<StudentDto> = {}): StudentDto {
+  return {
+    githubId: 'ada-lovelace',
+    name: 'Ada Lovelace',
+    rank: 3,
+    totalScore: 850,
+    cityName: 'London',
+    countryName: 'UK',
+    ...overrides,
+  } as StudentDto;
+}
+
+const courseSummary = { totalScore: 1000, studentsCount: 50 };
+
+describe('<StudentInfo />', () => {
+  it('renders the student name, github link, rank/position, score and location', () => {
+    render(<StudentInfo student={makeStudent()} courseSummary={courseSummary} />);
+
+    expect(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /ada-lovelace/ });
+    expect(link).toHaveAttribute('href', 'https://github.com/ada-lovelace');
+    expect(link).toHaveAttribute('target', '_blank');
+
+    expect(screen.getByText('3/50')).toBeInTheDocument();
+    expect(screen.getByText('850/1000')).toBeInTheDocument();
+    expect(screen.getByText('London, UK')).toBeInTheDocument();
+  });
+
+  it('omits the name heading when the name is empty or the placeholder "(Empty)"', () => {
+    const { rerender } = render(
+      <StudentInfo student={makeStudent({ name: '(Empty)' })} courseSummary={courseSummary} />,
+    );
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    // Github link is still present.
+    expect(screen.getByRole('link', { name: /ada-lovelace/ })).toBeInTheDocument();
+
+    rerender(<StudentInfo student={makeStudent({ name: '' })} courseSummary={courseSummary} />);
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('joins only the populated location parts (city missing → country only)', () => {
+    render(
+      <StudentInfo
+        student={makeStudent({ cityName: undefined, countryName: 'Poland' })}
+        courseSummary={courseSummary}
+      />,
+    );
+    expect(screen.getByText('Poland')).toBeInTheDocument();
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument();
+  });
+
+  it('renders an empty location string when neither city nor country is set', () => {
+    render(
+      <StudentInfo
+        student={makeStudent({ cityName: undefined, countryName: undefined })}
+        courseSummary={courseSummary}
+      />,
+    );
+    // Position + Total Score labels still render.
+    expect(screen.getByText('Position')).toBeInTheDocument();
+    expect(screen.getByText('Total Score')).toBeInTheDocument();
+    expect(screen.getByText('Location')).toBeInTheDocument();
+  });
+});

--- a/client/src/modules/Interviews/pages/StageInterviewFeedback/SubHeader.test.tsx
+++ b/client/src/modules/Interviews/pages/StageInterviewFeedback/SubHeader.test.tsx
@@ -1,0 +1,42 @@
+// The back arrow is an antd icon with no accessible name/role, so the click target is found
+// by its icon class via the container — direct node access is intentional here.
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/router';
+import { SubHeader } from './SubHeader';
+
+// next/router is aliased to the shared mock by vitest config.
+const back = (useRouter() as unknown as { back: ReturnType<typeof vi.fn> }).back;
+
+describe('<SubHeader />', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the "Completed" green tag when isCompleted is true', () => {
+    render(<SubHeader isCompleted />);
+
+    expect(screen.getByText('Feedback form')).toBeInTheDocument();
+    const tag = screen.getByText('Completed');
+    expect(tag).toBeInTheDocument();
+    expect(tag).toHaveClass('ant-tag-green');
+  });
+
+  it('shows the "Uncompleted" tag (no green) when isCompleted is false', () => {
+    render(<SubHeader isCompleted={false} />);
+
+    const tag = screen.getByText('Uncompleted');
+    expect(tag).toBeInTheDocument();
+    expect(tag).not.toHaveClass('ant-tag-green');
+  });
+
+  it('navigates back when the back arrow is clicked', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<SubHeader isCompleted={false} />);
+
+    const arrow = container.querySelector('.anticon-arrow-left');
+    expect(arrow).toBeTruthy();
+    await user.click(arrow as Element);
+
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/shared/components/Forms/CommentInput.test.tsx
+++ b/client/src/shared/components/Forms/CommentInput.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button, Form } from 'antd';
+import { CommentInput } from './CommentInput';
+
+// CommentInput renders an antd `<Form.Item name="comment">` wrapping an `<Input.TextArea>`.
+// Form.Item injects value/onChange, so we render it inside a real antd Form and type like
+// a user. A submit button lets us trigger the (required, min: 30) validation.
+function renderCommentInput(props: Parameters<typeof CommentInput>[0] = {}, onFinish = vi.fn()) {
+  const utils = render(
+    <Form onFinish={onFinish}>
+      <CommentInput {...props} />
+      <Button htmlType="submit">Submit</Button>
+    </Form>,
+  );
+  return { ...utils, onFinish };
+}
+
+const LONG_COMMENT = 'This is a detailed comment that is well over thirty characters long.';
+
+describe('CommentInput', () => {
+  it('renders a "Comment" labelled textarea', () => {
+    renderCommentInput();
+
+    expect(screen.getByLabelText('Comment')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('lets the user type a comment and submits its value', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderCommentInput();
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, LONG_COMMENT);
+    expect(textarea).toHaveValue(LONG_COMMENT);
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ comment: LONG_COMMENT }));
+  });
+
+  it('shows a required error and blocks submit when empty', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderCommentInput();
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(await screen.findByText('Please leave a detailed comment')).toBeInTheDocument();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('shows the min-length error when the comment is shorter than 30 characters', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderCommentInput();
+
+    await user.type(screen.getByRole('textbox'), 'too short');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(await screen.findByText('Please leave a detailed comment')).toBeInTheDocument();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('skips validation entirely when notRequired is set', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderCommentInput({ notRequired: true });
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalled());
+    expect(screen.queryByText('Please leave a detailed comment')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/shared/components/Forms/GdprCheckbox.test.tsx
+++ b/client/src/shared/components/Forms/GdprCheckbox.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button, Form } from 'antd';
+import { GdprCheckbox } from './GdprCheckbox';
+
+// GdprCheckbox renders consent text plus an antd `<Form.Item name="gdpr" valuePropName="checked">`
+// wrapping a `<Checkbox>`. Form.Item injects `checked`/`onChange`, so we render it inside a real
+// antd Form and toggle the checkbox like a user, asserting the submitted form value.
+function renderGdprCheckbox(onFinish = vi.fn()) {
+  const utils = render(
+    <Form onFinish={onFinish}>
+      <GdprCheckbox />
+      <Button htmlType="submit">Submit</Button>
+    </Form>,
+  );
+  return { ...utils, onFinish };
+}
+
+describe('GdprCheckbox', () => {
+  it('renders both the English and Russian consent statements', () => {
+    renderGdprCheckbox();
+
+    expect(screen.getByText(/I hereby agree to the processing of my personal data/i)).toBeInTheDocument();
+    expect(screen.getByText(/Я согласен на обработку моих персональных данных/i)).toBeInTheDocument();
+  });
+
+  it('renders an unchecked checkbox by default', () => {
+    renderGdprCheckbox();
+
+    const checkbox = screen.getByRole('checkbox', { name: /I agree/i });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('checks the box when the user clicks it and submits checked: true', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderGdprCheckbox();
+
+    const checkbox = screen.getByRole('checkbox', { name: /I agree/i });
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ gdpr: true }));
+  });
+
+  it('toggles back to unchecked on a second click', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderGdprCheckbox();
+
+    const checkbox = screen.getByRole('checkbox', { name: /I agree/i });
+    await user.click(checkbox);
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ gdpr: false }));
+  });
+});

--- a/client/src/shared/components/Forms/LocationSelect.test.tsx
+++ b/client/src/shared/components/Forms/LocationSelect.test.tsx
@@ -1,0 +1,208 @@
+/* eslint-disable testing-library/no-node-access */
+// antd renders spinners, alerts and Select options with internal class names and no stable
+// role/text hooks, so a few `document.querySelector` calls on `.ant-*` nodes are unavoidable
+// here (same convention as the sibling CourseTaskSelect.test.tsx).
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { Location } from '@common/models/profile';
+import usePlacesAutocomplete from 'use-places-autocomplete';
+import { useInterval } from 'ahooks';
+import { LocationSelect } from './LocationSelect';
+
+// Boundary mocks: LocationSelect goes through the useGoogleMapsPlaces hook, which wraps
+// `use-places-autocomplete` (the Google Maps Places client) and ahooks' `useInterval`
+// (the API-load polling). We mock both so we can deterministically control the
+// initialized/error/data/value state and drive search, select and blur like a user.
+vi.mock('use-places-autocomplete');
+vi.mock('ahooks');
+
+const mockSetValue = vi.fn();
+const mockInit = vi.fn();
+const mockStopPolling = vi.fn();
+
+const usePlacesAutocompleteMock = vi.mocked(usePlacesAutocomplete);
+const useIntervalMock = vi.mocked(useInterval);
+
+function mockPlaces(overrides: Partial<ReturnType<typeof usePlacesAutocomplete>> = {}) {
+  usePlacesAutocompleteMock.mockReturnValue({
+    value: '',
+    suggestions: { data: [], loading: false },
+    setValue: mockSetValue,
+    init: mockInit,
+    ...overrides,
+  } as ReturnType<typeof usePlacesAutocomplete>);
+}
+
+// Capture and expose the polling callback so a test can mark the API as "loaded".
+// The returned trigger flushes the hook's state updates inside act() so the
+// initialized/error transitions cause a re-render the test can observe.
+function setupPolling() {
+  let pollCallback: (() => void) | null = null;
+  useIntervalMock.mockImplementation((cb: () => void) => {
+    pollCallback = cb;
+    return mockStopPolling;
+  });
+  return (times = 1) =>
+    act(() => {
+      for (let i = 0; i < times; i += 1) {
+        pollCallback?.();
+      }
+    });
+}
+
+function renderLocationSelect(props: Partial<Parameters<typeof LocationSelect>[0]> = {}) {
+  const onChange = props.onChange ?? vi.fn();
+  const utils = render(<LocationSelect location={null} onChange={onChange} {...props} />);
+  return { ...utils, onChange };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPlaces();
+  useIntervalMock.mockReturnValue(mockStopPolling);
+  delete (window as unknown as { google?: unknown }).google;
+});
+
+describe('LocationSelect', () => {
+  it('shows a loading spinner until the Google Maps API initializes', () => {
+    renderLocationSelect();
+
+    // Not initialized yet → a Spin (status role) is shown instead of the combobox.
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(document.querySelector('.ant-spin')).toBeInTheDocument();
+  });
+
+  it('renders an error alert when the API fails to load', () => {
+    const triggerPoll = setupPolling();
+    renderLocationSelect();
+
+    // Poll past the timeout without `window.google` ever appearing → hook sets an error.
+    triggerPoll(500);
+
+    expect(screen.getByText('Google Maps API is not loaded')).toBeInTheDocument();
+    expect(document.querySelector('.ant-alert-error')).toBeInTheDocument();
+  });
+
+  it('renders a searchable combobox once initialized', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    renderLocationSelect();
+
+    triggerPoll();
+
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toBeInTheDocument();
+    // showSearch + filterOption=false means the combobox is the live search input.
+    expect(combobox).toHaveValue('');
+  });
+
+  it('reflects the place value coming from the hook as the combobox text', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    mockPlaces({ value: 'Prague, Czechia' });
+    renderLocationSelect();
+
+    triggerPoll();
+
+    expect(screen.getByText('Prague, Czechia')).toBeInTheDocument();
+  });
+
+  it('shows a spinner inside the dropdown while suggestions are loading', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    // loading=true drives the `notFoundContent={loading ? <Spin/> : null}` branch.
+    mockPlaces({ value: 'Mi', suggestions: { data: [], loading: true } });
+    renderLocationSelect();
+    triggerPoll();
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+
+    expect(document.querySelector('.ant-select-dropdown .ant-spin')).toBeInTheDocument();
+  });
+
+  it('forwards typed search text to setValue', async () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    renderLocationSelect();
+    triggerPoll();
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Min' } });
+
+    await waitFor(() => expect(mockSetValue).toHaveBeenCalledWith('Min'));
+  });
+
+  it('renders suggestion options from the places data', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    mockPlaces({
+      value: 'M',
+      suggestions: { data: [{ description: 'Minsk, Belarus' }, { description: 'Munich, Germany' }], loading: false },
+    } as Partial<ReturnType<typeof usePlacesAutocomplete>>);
+    renderLocationSelect();
+    triggerPoll();
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+
+    // Scope to the listbox options (antd also renders a hidden measure mirror of the label).
+    expect(screen.getByRole('option', { name: 'Minsk, Belarus' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Munich, Germany' })).toBeInTheDocument();
+  });
+
+  it('parses a selected option into a Location and calls onChange', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    mockPlaces({
+      value: 'M',
+      suggestions: { data: [{ description: 'Minsk, Belarus' }], loading: false },
+    } as Partial<ReturnType<typeof usePlacesAutocomplete>>);
+    const { onChange } = renderLocationSelect();
+    triggerPoll();
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    // antd wires its select handler on the `.ant-select-item-option` wrapper element, so we
+    // must click that node (the only rendered option here) rather than the inner content node.
+    const option = document.querySelector('.ant-select-item-option');
+    expect(option).toHaveTextContent('Minsk, Belarus');
+    fireEvent.click(option as Element);
+
+    // handleSelect: setValue(value, false) then onChange(toLocation(value))
+    expect(mockSetValue).toHaveBeenCalledWith('Minsk, Belarus', false);
+    expect(onChange).toHaveBeenCalledWith({ cityName: 'Minsk', countryName: 'Belarus' } satisfies Location);
+  });
+
+  it('restores the location text on blur when the field was cleared', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    // value is empty → handleBlur should reset it from the provided location prop.
+    mockPlaces({ value: '' });
+    renderLocationSelect({ location: { cityName: 'Berlin', countryName: 'Germany' } });
+    triggerPoll();
+
+    fireEvent.blur(screen.getByRole('combobox'));
+
+    expect(mockSetValue).toHaveBeenCalledWith('Berlin, Germany', false);
+  });
+
+  it('resets to an empty string on blur when no location prop is given', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    mockPlaces({ value: '' });
+    renderLocationSelect({ location: null });
+    triggerPoll();
+
+    fireEvent.blur(screen.getByRole('combobox'));
+
+    expect(mockSetValue).toHaveBeenCalledWith('', false);
+  });
+
+  it('does not reset on blur when the field already has a value', () => {
+    const triggerPoll = setupPolling();
+    (window as unknown as { google: unknown }).google = {};
+    mockPlaces({ value: 'Paris, France' });
+    renderLocationSelect();
+    triggerPoll();
+
+    fireEvent.blur(screen.getByRole('combobox'));
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/shared/components/Forms/MarkdownInput.test.tsx
+++ b/client/src/shared/components/Forms/MarkdownInput.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button, Form } from 'antd';
+import MarkdownInput from './MarkdownInput';
+
+// react-markdown is an ESM micromark pipeline that is heavy and brittle under jsdom.
+// We stub it to a passthrough that renders its children verbatim so the surrounding
+// MarkdownInput logic (preview toggle, danger-paragraph branch) is still driven by real
+// interaction and we can assert the previewed text is handed to the renderer.
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock('remark-gfm', () => ({ default: () => {} }));
+
+function renderMarkdownInput(historicalCommentSelected = '') {
+  return render(
+    <Form>
+      <MarkdownInput historicalCommentSelected={historicalCommentSelected} />
+    </Form>,
+  );
+}
+
+// A reset button lets us exercise the Form.Item `onReset={resetText}` handler.
+function ResettableMarkdownInput() {
+  const [form] = Form.useForm();
+  return (
+    <Form form={form}>
+      <MarkdownInput historicalCommentSelected="" />
+      <Button onClick={() => form.resetFields()}>Reset</Button>
+    </Form>
+  );
+}
+
+const LONG_COMMENT = 'This is a detailed markdown comment well over thirty characters.';
+
+describe('MarkdownInput', () => {
+  it('renders the comment textarea and a Preview toggle in write mode', () => {
+    renderMarkdownInput();
+
+    expect(screen.getByLabelText(/Comment \(markdown syntax is supported\)/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /preview/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /about markdown/i })).toBeInTheDocument();
+  });
+
+  it('switches to preview mode and renders the typed text through react-markdown', async () => {
+    const user = userEvent.setup();
+    renderMarkdownInput();
+
+    await user.type(screen.getByRole('textbox'), LONG_COMMENT);
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    const markdown = screen.getByTestId('markdown');
+    expect(markdown).toHaveTextContent(LONG_COMMENT);
+    // A long, valid comment must NOT show the danger reminder.
+    expect(screen.queryByText('Please leave a comment')).not.toBeInTheDocument();
+    expect(screen.queryByText('Please leave a detailed comment')).not.toBeInTheDocument();
+    // The toggle now reads "Write".
+    expect(screen.getByRole('button', { name: /write/i })).toBeInTheDocument();
+  });
+
+  it('shows "Please leave a comment" in preview when the field is empty', async () => {
+    const user = userEvent.setup();
+    renderMarkdownInput();
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    expect(screen.getByText('Please leave a comment')).toBeInTheDocument();
+  });
+
+  it('shows "Please leave a detailed comment" in preview when text is shorter than 30 chars', async () => {
+    const user = userEvent.setup();
+    const { container } = renderMarkdownInput();
+
+    await user.type(screen.getByRole('textbox'), 'short text');
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    // The reminder is rendered as a danger-typed Typography.Paragraph. Scope to it to
+    // avoid colliding with the (hidden, same-text) Form.Item required-rule message.
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const reminder = container.querySelector('.ant-typography-danger');
+    expect(reminder).toHaveTextContent('Please leave a detailed comment');
+  });
+
+  it('toggles back to write mode from preview', async () => {
+    const user = userEvent.setup();
+    renderMarkdownInput();
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+    await user.click(screen.getByRole('button', { name: /write/i }));
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /preview/i })).toBeInTheDocument();
+  });
+
+  it('clears the text and leaves preview mode when the form is reset', async () => {
+    const user = userEvent.setup();
+    render(<ResettableMarkdownInput />);
+
+    // Type, switch to preview, then reset the form (fires the Form.Item onReset -> resetText).
+    await user.type(screen.getByRole('textbox'), 'Some markdown content over thirty characters long.');
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+    expect(screen.getByTestId('markdown')).toHaveTextContent('Some markdown content over thirty characters long.');
+
+    await user.click(screen.getByRole('button', { name: /reset/i }));
+
+    // resetText sets previewVisible=false (back to write mode) and clears the text.
+    expect(screen.getByRole('textbox')).toHaveValue('');
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+    expect(screen.getByTestId('markdown')).toHaveTextContent('');
+    expect(screen.getByText('Please leave a comment')).toBeInTheDocument();
+  });
+
+  it('seeds the preview text from a non-empty historicalCommentSelected prop', async () => {
+    const user = userEvent.setup();
+    renderMarkdownInput('Historical pre-filled comment longer than thirty chars.');
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    expect(screen.getByTestId('markdown')).toHaveTextContent('Historical pre-filled comment longer than thirty chars.');
+  });
+
+  it('updates the previewed text when a new historical comment is selected', async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderMarkdownInput('');
+
+    rerender(
+      <Form>
+        <MarkdownInput historicalCommentSelected="A freshly selected historical comment over thirty chars." />
+      </Form>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('markdown')).toHaveTextContent(
+        'A freshly selected historical comment over thirty chars.',
+      ),
+    );
+  });
+});

--- a/client/src/shared/components/Forms/ScoreInput.test.tsx
+++ b/client/src/shared/components/Forms/ScoreInput.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button, Form } from 'antd';
+import { ScoreInput } from './ScoreInput';
+
+// ScoreInput renders an antd `<Form.Item name="score">` wrapping an `<InputNumber>`.
+// Form.Item injects value/onChange, so we always render it inside a real antd Form
+// and drive the spinbutton like a user. A submit button lets us trigger validation.
+function renderScoreInput(props: Parameters<typeof ScoreInput>[0] = {}, onFinish = vi.fn()) {
+  const utils = render(
+    <Form onFinish={onFinish}>
+      <ScoreInput {...props} />
+      <Button htmlType="submit">Submit</Button>
+    </Form>,
+  );
+  return { ...utils, onFinish };
+}
+
+describe('ScoreInput', () => {
+  it('renders a spinbutton with a default "Score" label when no max is provided', () => {
+    renderScoreInput();
+
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    expect(screen.getByLabelText('Score')).toBeInTheDocument();
+  });
+
+  it('derives the max-points label from the maxScore prop', () => {
+    renderScoreInput({ maxScore: 80 });
+
+    expect(screen.getByLabelText('Score (Max 80 points)')).toBeInTheDocument();
+  });
+
+  it('falls back to the courseTask.maxScore when maxScore prop is absent', () => {
+    renderScoreInput({ courseTask: { id: 1, maxScore: 45 } });
+
+    expect(screen.getByLabelText('Score (Max 45 points)')).toBeInTheDocument();
+  });
+
+  it('defaults the courseTask max to 100 when its maxScore is falsy', () => {
+    renderScoreInput({ courseTask: { id: 1, maxScore: 0 } });
+
+    expect(screen.getByLabelText('Score (Max 100 points)')).toBeInTheDocument();
+  });
+
+  it('prefers the maxScore prop over the courseTask value', () => {
+    renderScoreInput({ maxScore: 25, courseTask: { id: 1, maxScore: 100 } });
+
+    expect(screen.getByLabelText('Score (Max 25 points)')).toBeInTheDocument();
+  });
+
+  it('lets the user type a score and submits it', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderScoreInput({ maxScore: 100 });
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '42');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledWith({ score: 42 }));
+  });
+
+  it('shows a required-error and blocks submit when left empty', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderScoreInput({ maxScore: 100 });
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(await screen.findByText('Please enter score')).toBeInTheDocument();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('clamps a value typed above the configured max on blur', async () => {
+    const user = userEvent.setup();
+    renderScoreInput({ maxScore: 50 });
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '999');
+    await user.tab();
+
+    await waitFor(() => expect(input).toHaveValue('50'));
+  });
+
+  it('clamps a negative value to the configured minimum of 0 on blur', async () => {
+    const user = userEvent.setup();
+    renderScoreInput({ maxScore: 50 });
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '-5');
+    await user.tab();
+
+    await waitFor(() => expect(input).toHaveValue('0'));
+  });
+});

--- a/client/vitest.config.mts
+++ b/client/vitest.config.mts
@@ -21,6 +21,9 @@ export default mergeConfig(
       // the slowest Table/Form-validation tests can exceed 30s on busy/CI runners.
       testTimeout: 60000,
       hookTimeout: 60000,
+      // Retry transient flakes (antd async validation/Table renders occasionally
+      // timing out under load). A genuine failure still fails all attempts.
+      retry: 2,
       env: {
         TZ: 'UTC',
       },
@@ -49,10 +52,10 @@ export default mergeConfig(
         // post-exclude baseline so this config-only change passes, then bumps up
         // as each test tier lands, ending at a flat 90% (free above 90, fail below).
         thresholds: {
-          statements: 34,
-          branches: 33,
-          functions: 30,
-          lines: 34,
+          statements: 40,
+          branches: 39,
+          functions: 36,
+          lines: 40,
         },
       },
       deps: {


### PR DESCRIPTION
## What & why

**Phase 2** of the client coverage initiative — the highest-value, previously-**0%** interactive forms and modals, tested the way a user drives them: render the real component, fill inputs, click, toggle checkboxes/radios, pick options; mock **only** the API and genuinely brittle widgets.

> Stacked on #3074 (base `alreadybored/client-coverage-config`). Merge that first; GitHub retargets this to `master` once it lands.

## Changes (20 new `*.test.tsx`, no source changes)
- **Stage Interview Feedback** (`modules/Interviews/pages/StageInterviewFeedback/**`) — the multi-step feedback form: step nav, nested conditional radios, the rating question picker/custom-question flow, per-field validation, submit payload, missed-interview short-circuit, legacy fallback.
- **Feedback / Interview** — `FeedbackForm` (ratings, recommendation→conditional comment, english-level, submit/reset) and the student `InterviewCard`/`ExtraInfo` (every registration state, register/cancel).
- **CourseManagement modals** — course / task / event / courses-list create-edit modals + certificate template picker & issue modal (validation, conditional sections, exact submit payloads).
- **Shared Form inputs** — `ScoreInput`, `GdprCheckbox`, `CommentInput`, `MarkdownInput`, `LocationSelect` (value/onChange, validation, toggles).

Brittle antd widgets are stubbed per policy (DatePicker/RangePicker, search-`Select`/`UserSearch`, `react-markdown`, `use-places-autocomplete`) so the surrounding form logic is still driven by real interaction. Most files land at ~95–100% per-file coverage.

## Test reliability
antd v6 in jsdom is CPU-heavy; under coverage + parallelism the slowest Form-validation/Table tests can transiently exceed the timeout on busy runners. Mitigated with `testTimeout: 60s` (in #3074) plus a small `test.retry` here — a genuine failure still fails all attempts.

## Verification
- ✅ `npm run test:ci` (client, Node 24): **161 files, 1075 tests green**; coverage **40.45 / 40.34 / 36.92 / 40.74**, clears the ratcheted floor (40/39/36/40).
- ✅ `eslint` + `oxfmt` clean.

Phase 2 — client unit-test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)