### PR TITLE
chore: clear out TODO/FIXME tech debt (theme, typing, antd, refactors)

### DIFF
--- a/client/src/components/Profile/__test__/MainCard.test.tsx
+++ b/client/src/components/Profile/__test__/MainCard.test.tsx
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { ProfileMainCardData } from '@client/services/user';
 import MainCard from '../MainCard';
 
-// TODO: Known Issue: https://stackoverflow.com/questions/59942808/how-can-i-use-jest-coverage-in-next-js
-
 // Stub the remote (Google Maps) LocationSelect with a simple value-emitting control so
 // handleLocationChange can be exercised without the maps integration.
 const { obfuscateProfile } = vi.hoisted(() => ({

--- a/client/src/modules/Score/components/ScoreTable/index.tsx
+++ b/client/src/modules/Score/components/ScoreTable/index.tsx
@@ -185,9 +185,11 @@ export function ScoreTable(props: Props) {
   }
 
   const handleChange: TableProps<ScoreStudentDto>['onChange'] = async (pagination, filters, sorter, { action }) => {
-    // Dirty hack to prevent sort request with old filters on Enter key in filter modal search input
-    // This is known issue please, see https://github.com/ant-design/ant-design/issues/37334
-    // TODO: Remove this hack after fix in antd
+    // Workaround: pressing Enter inside a filter dropdown's search input also triggers the
+    // column sorter, firing a sort request with the previous (pre-filter) filters. We stash the
+    // just-applied filters for a tick and reuse them if a sort fires immediately after.
+    // Upstream issue ant-design/ant-design#37334 was closed as "not planned" (re-checked on
+    // antd 6.3.1), so this workaround is intentionally permanent rather than a temporary hack.
     if (action === 'filter') {
       recentlyAppliedFilters.current = filters;
       setTimeout(() => (recentlyAppliedFilters.current = null), 50);

--- a/client/src/modules/Students/components/StudentsTable/index.tsx
+++ b/client/src/modules/Students/components/StudentsTable/index.tsx
@@ -36,8 +36,10 @@ export default function StudentsTable({
       loading={loading}
       bordered
       /**
-       * @see
-       * dirty-hack to fix x-scroll in antd table
+       * `x: ''` keeps horizontal scrolling available without pinning the table to a fixed width.
+       * Switching to a width value (e.g. `x: 'max-content'`) regresses sticky-header alignment on
+       * antd's scrollable table — notably with an empty dataSource (see ant-design/ant-design#35284).
+       * Re-verified on antd 6.3.1: the empty-string form is still required.
        */
       scroll={{ y: 'calc(100vh - 260px)', x: '' }}
     />

--- a/client/src/pages/admin/auto-test-task/[taskId].tsx
+++ b/client/src/pages/admin/auto-test-task/[taskId].tsx
@@ -1,6 +1,6 @@
 import { useRequest } from 'ahooks';
 import { Descriptions, Divider, Form, Space, Switch, Tag, Typography } from 'antd';
-import { AutoTestsApi, SelfEducationQuestionSelectedAnswersDto } from '@client/api';
+import { AutoTestsApi } from '@client/api';
 import { AdminPageLayout } from '@client/shared/components/PageLayout';
 import { Question } from '@client/modules/AutoTest/components';
 import { SessionProvider, useActiveCourseContext } from '@client/modules/Course/contexts';
@@ -101,14 +101,12 @@ function Page() {
             {selectedTask?.attributes.public.questions.map((question, index) => (
               <Question
                 key={index}
-                question={
-                  {
-                    ...question,
-                    // TODO: Investigate and fix potential type mismatch for selectedAnswers.
-                    // Related issue: https://github.com/rolling-scopes/rsschool-app/issues/2572
-                    selectedAnswers: selectedTask?.attributes.answers[index],
-                  } as SelfEducationQuestionSelectedAnswersDto
-                }
+                question={{
+                  ...question,
+                  // `attributes.answers[index]` holds the correct answers for this question;
+                  // default to an empty selection when none are recorded for the index.
+                  selectedAnswers: selectedTask?.attributes.answers[index] ?? [],
+                }}
               />
             ))}
           </Form>

--- a/client/src/providers/ThemeProvider.test.tsx
+++ b/client/src/providers/ThemeProvider.test.tsx
@@ -57,14 +57,26 @@ describe('ThemeProvider', () => {
     expect(() => ctx?.changeAutoTheme()).not.toThrow();
   });
 
-  it('provides the default light theme when nothing is stored', () => {
+  it('defaults to auto mode following the system (light) when nothing is stored', () => {
+    setMatchMedia(false);
     render(
       <ThemeProvider>
         <Consumer />
       </ThemeProvider>,
     );
+    expect(screen.getByTestId('auto')).toHaveTextContent('true');
     expect(screen.getByTestId('theme')).toHaveTextContent('light');
-    expect(screen.getByTestId('auto')).toHaveTextContent('false');
+  });
+
+  it('defaults to auto mode following the system (dark) when nothing is stored', () => {
+    setMatchMedia(true);
+    render(
+      <ThemeProvider>
+        <Consumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('auto')).toHaveTextContent('true');
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
   });
 
   it('themeChange to dark applies the dark theme, body class, and persists it', () => {
@@ -110,7 +122,9 @@ describe('ThemeProvider', () => {
     expect(screen.getByTestId('auto')).toHaveTextContent('false');
   });
 
-  it('enables auto mode when stored theme is "auto" and follows system (dark)', () => {
+  it('enables auto mode for a legacy stored "auto" value and follows system (dark)', () => {
+    // "auto" is no longer written to storage, but users upgraded from the old build may still
+    // have it. It is not a valid AppTheme, so it falls through to the auto (follow-system) branch.
     localStorage.setItem('app-theme', 'auto');
     setMatchMedia(true);
     render(
@@ -122,27 +136,33 @@ describe('ThemeProvider', () => {
     expect(screen.getByTestId('theme')).toHaveTextContent('dark');
   });
 
-  it('toggling auto on persists "auto" and applies the system (light) theme', () => {
+  it('toggling auto on clears the stored theme and applies the system (light) theme', () => {
+    // Start from an explicit manual theme so auto is off, then toggle it on.
+    localStorage.setItem('app-theme', AppTheme.Dark);
     setMatchMedia(false);
     render(
       <ThemeProvider>
         <Consumer />
       </ThemeProvider>,
     );
+    expect(screen.getByTestId('auto')).toHaveTextContent('false');
 
     fireEvent.click(screen.getByText('toggle-auto'));
 
     expect(screen.getByTestId('auto')).toHaveTextContent('true');
-    expect(localStorage.getItem('app-theme')).toBe('auto');
+    expect(localStorage.getItem('app-theme')).toBeNull();
     expect(screen.getByTestId('theme')).toHaveTextContent('light');
   });
 
-  it('toggling auto on then off flips the auto flag back to false', () => {
+  it('toggling auto off then on flips the auto flag', () => {
+    // Start from an explicit manual theme so auto is off initially.
+    localStorage.setItem('app-theme', AppTheme.Light);
     render(
       <ThemeProvider>
         <Consumer />
       </ThemeProvider>,
     );
+    expect(screen.getByTestId('auto')).toHaveTextContent('false');
 
     fireEvent.click(screen.getByText('toggle-auto'));
     expect(screen.getByTestId('auto')).toHaveTextContent('true');
@@ -152,6 +172,7 @@ describe('ThemeProvider', () => {
   });
 
   it('responds to system theme changes while auto mode is active', () => {
+    // Nothing stored → auto mode is on by default and subscribed to the media query.
     const mql = setMatchMedia(false);
     render(
       <ThemeProvider>
@@ -159,7 +180,7 @@ describe('ThemeProvider', () => {
       </ThemeProvider>,
     );
 
-    fireEvent.click(screen.getByText('toggle-auto'));
+    expect(screen.getByTestId('auto')).toHaveTextContent('true');
     expect(screen.getByTestId('theme')).toHaveTextContent('light');
 
     act(() => {

--- a/client/src/providers/ThemeProvider.test.tsx
+++ b/client/src/providers/ThemeProvider.test.tsx
@@ -134,6 +134,8 @@ describe('ThemeProvider', () => {
     );
     expect(screen.getByTestId('auto')).toHaveTextContent('true');
     expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    // the stale legacy value is cleared so auto mode stays represented by the absence of the key
+    expect(localStorage.getItem('app-theme')).toBeNull();
   });
 
   it('toggling auto on clears the stored theme and applies the system (light) theme', () => {

--- a/client/src/providers/ThemeProvider.tsx
+++ b/client/src/providers/ThemeProvider.tsx
@@ -76,8 +76,12 @@ const ThemeProvider = ({ children }: { children: ReactNode }) => {
       setAuto(false);
       applyTheme(storedTheme);
     } else {
-      // No explicit light/dark choice stored (or a legacy "auto" value): follow the system.
-      // The `[auto]` effect applies the system theme and subscribes to changes.
+      // No explicit light/dark choice stored (or a legacy "auto"/invalid value): follow the system.
+      // Clear any stale value so auto mode stays represented by the absence of the key, then let
+      // the `[auto]` effect apply the system theme and subscribe to changes.
+      if (storedTheme !== null) {
+        localStorage.removeItem('app-theme');
+      }
       setAuto(true);
     }
   }, []);

--- a/client/src/providers/ThemeProvider.tsx
+++ b/client/src/providers/ThemeProvider.tsx
@@ -48,10 +48,8 @@ const ThemeProvider = ({ children }: { children: ReactNode }) => {
     setAuto(prev => {
       const newAutoState = !prev;
       if (newAutoState) {
-        localStorage.setItem('app-theme', 'auto');
-        // FIXME: remove the line above and uncomment the line bellow
-        //  after enabling auto-theme
-        // localStorage.removeItem('app-theme');
+        // Absence of the stored key means "follow the system preference".
+        localStorage.removeItem('app-theme');
         applyTheme(getSystemTheme());
       }
       return newAutoState;
@@ -78,11 +76,8 @@ const ThemeProvider = ({ children }: { children: ReactNode }) => {
       setAuto(false);
       applyTheme(storedTheme);
     } else {
-      // setAuto(true); // FIXME: temporary disable set auto theme by default
-    }
-
-    // FIXME: remove the if statement after enabling auto-theme above
-    if ((storedTheme as string) === 'auto') {
+      // No explicit light/dark choice stored (or a legacy "auto" value): follow the system.
+      // The `[auto]` effect applies the system theme and subscribes to changes.
       setAuto(true);
     }
   }, []);

--- a/nestjs/src/courses/interviews/interviews.service.ts
+++ b/nestjs/src/courses/interviews/interviews.service.ts
@@ -161,11 +161,22 @@ export class InterviewsService {
     }));
   }
 
-  /**
-   * TODO: rewrite it. Hard to maintain and understand
-   */
   public async getStageInterviewAvailableStudents(courseId: number): Promise<AvailableStudentDto[]> {
-    const { entities, raw } = await this.studentRepository
+    const { entities, raw } = await this.buildAvailableStudentsQuery(courseId).getRawAndEntities();
+
+    return entities
+      .filter(student => InterviewsService.isAvailableForStageInterview(student))
+      .map(student =>
+        this.mapToAvailableStudentDto(student, raw.find(item => item.student_id === student.id)?.sis_createdDate),
+      );
+  }
+
+  /**
+   * Registered, mentoring-eligible students of the course (not failed, not expelled, no mentor yet),
+   * with their stage interviews, feedbacks and registration date joined for downstream mapping.
+   */
+  private buildAvailableStudentsQuery(courseId: number) {
+    return this.studentRepository
       .createQueryBuilder('student')
       .innerJoin(StageInterviewStudent, 'sis', 'sis.studentId = student.id')
       .innerJoin('student.user', 'user')
@@ -196,37 +207,39 @@ export class InterviewsService {
         ].join(' AND '),
         { courseId },
       )
-      .orderBy('student.totalScore', 'DESC')
-      .getRawAndEntities();
+      .orderBy('student.totalScore', 'DESC');
+  }
 
-    const result = entities
-      .filter(s => {
-        return (
-          !s.stageInterviews ||
-          s.stageInterviews.length === 0 ||
-          s.stageInterviews.every(i => (i.isCompleted && i.decision !== 'draft') || i.isCanceled)
-        );
-      })
-      .map(student => {
-        const { id, user, totalScore } = student;
-        const stageInterviews: StageInterview[] = student.stageInterviews || [];
-        const lastStageInterview = InterviewsService.getLastStageInterview(stageInterviews);
-        return {
-          id,
-          totalScore,
-          githubId: user.githubId,
-          name: UsersService.getFullName(student.user),
-          cityName: user.cityName,
-          countryName: user.countryName,
-          isGoodCandidate: this.isGoodCandidate(stageInterviews),
-          rating: lastStageInterview?.rating,
-          maxScore: lastStageInterview?.maxScore,
-          feedbackVersion: lastStageInterview?.version,
-          registeredDate: raw.find(item => item.student_id === student.id)?.sis_createdDate,
-        };
-      });
+  /**
+   * A student is available for a new stage interview when they have no interviews yet, or every
+   * existing interview is either canceled or completed with a final (non-draft) decision.
+   */
+  private static isAvailableForStageInterview(student: Student): boolean {
+    const interviews = student.stageInterviews;
+    return (
+      !interviews ||
+      interviews.length === 0 ||
+      interviews.every(interview => (interview.isCompleted && interview.decision !== 'draft') || interview.isCanceled)
+    );
+  }
 
-    return result;
+  private mapToAvailableStudentDto(student: Student, registeredDate: string): AvailableStudentDto {
+    const stageInterviews: StageInterview[] = student.stageInterviews || [];
+    const lastStageInterview = InterviewsService.getLastStageInterview(stageInterviews);
+
+    return {
+      id: student.id,
+      totalScore: student.totalScore,
+      githubId: student.user.githubId,
+      name: UsersService.getFullName(student.user),
+      cityName: student.user.cityName,
+      countryName: student.user.countryName,
+      isGoodCandidate: this.isGoodCandidate(stageInterviews),
+      rating: lastStageInterview?.rating,
+      maxScore: lastStageInterview?.maxScore,
+      feedbackVersion: lastStageInterview?.version,
+      registeredDate,
+    };
   }
 
   /**

--- a/nestjs/src/courses/interviews/interviews.service.ts
+++ b/nestjs/src/courses/interviews/interviews.service.ts
@@ -163,12 +163,25 @@ export class InterviewsService {
 
   public async getStageInterviewAvailableStudents(courseId: number): Promise<AvailableStudentDto[]> {
     const { entities, raw } = await this.buildAvailableStudentsQuery(courseId).getRawAndEntities();
+    const registrationDateByStudentId = InterviewsService.mapRegistrationDates(raw);
 
     return entities
       .filter(student => InterviewsService.isAvailableForStageInterview(student))
-      .map(student =>
-        this.mapToAvailableStudentDto(student, raw.find(item => item.student_id === student.id)?.sis_createdDate),
-      );
+      .map(student => this.mapToAvailableStudentDto(student, registrationDateByStudentId.get(student.id) ?? ''));
+  }
+
+  /**
+   * Build a studentId → registration date lookup from the raw rows once, so mapping is O(1) per
+   * student instead of scanning `raw` (which the left joins can inflate) for every student.
+   */
+  private static mapRegistrationDates(raw: { student_id: number; sis_createdDate: string }[]): Map<number, string> {
+    const registrationDateByStudentId = new Map<number, string>();
+    for (const row of raw) {
+      if (!registrationDateByStudentId.has(row.student_id)) {
+        registrationDateByStudentId.set(row.student_id, row.sis_createdDate);
+      }
+    }
+    return registrationDateByStudentId;
   }
 
   /**

--- a/nestjs/src/mentors-hall-of-fame/mentors-hall-of-fame.service.test.ts
+++ b/nestjs/src/mentors-hall-of-fame/mentors-hall-of-fame.service.test.ts
@@ -428,6 +428,18 @@ describe('MentorsHallOfFameService', () => {
       expect(mockQueryBuilder.where).toHaveBeenCalledTimes(1);
     });
 
+    it('counts gratitudes with a plain COUNT (no redundant DISTINCT)', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValueOnce(mockMentorData).mockResolvedValueOnce([]);
+
+      await service.refreshCache();
+
+      expect(mockGratitudesQueryBuilder.addSelect).toHaveBeenCalledWith('COUNT(feedback.id)', 'gratitudesCount');
+      expect(mockGratitudesQueryBuilder.addSelect).not.toHaveBeenCalledWith(
+        'COUNT(DISTINCT feedback.id)',
+        'gratitudesCount',
+      );
+    });
+
     it('logs and keeps cache unchanged when refresh fails', async () => {
       const loggerErrorSpy = vi.spyOn(
         (service as unknown as { logger: { error: (message: string, error: unknown) => void } }).logger,

--- a/nestjs/src/mentors-hall-of-fame/mentors-hall-of-fame.service.ts
+++ b/nestjs/src/mentors-hall-of-fame/mentors-hall-of-fame.service.ts
@@ -62,9 +62,12 @@ export class MentorsHallOfFameService implements OnModuleInit {
 
     const gratitudesSubquery = this.userRepository.manager
       .createQueryBuilder()
+      // The subquery selects from a single `feedback` table (no fan-out joins) and groups by
+      // `toUserId`, so `feedback.id` (the primary key) is already unique within each group.
+      // `COUNT(DISTINCT feedback.id)` would therefore equal `COUNT(feedback.id)`; we use the
+      // plain count to avoid a redundant de-duplication pass.
       .select('feedback.toUserId', 'toUserId')
-      // TODO: Check if we need to count distinct feedback.id or not on real data
-      .addSelect('COUNT(DISTINCT feedback.id)', 'gratitudesCount')
+      .addSelect('COUNT(feedback.id)', 'gratitudesCount')
       .from(Feedback, 'feedback')
       .groupBy('feedback.toUserId');
 


### PR DESCRIPTION
## Context

A sweep of `TODO`/`FIXME`/`@deprecated` markers across `nestjs` and `client` surfaced a batch of small, self-contained debt items. This PR clears the actionable, low-risk ones — one focused commit per item. (The legacy interview-feedback cluster, blocked on a separate data migration, and the opportunities CV access-control question, blocked on a product decision, are intentionally left out.)

## What's in here (one commit each)

| Item | Change |
|------|--------|
| **mentors-hall** | Drop redundant `COUNT(DISTINCT feedback.id)` → `COUNT(feedback.id)` (single table, grouped by `toUserId`, PK already unique). Resolves the "do we need DISTINCT" TODO; pinned with a unit test. |
| **auto-test task page** | Remove an `as SelfEducationQuestionSelectedAnswersDto` cast that masked a real `number[] \| undefined` mismatch; default with `?? []` so the object literal matches the DTO. Resolves #2572. |
| **auto theme** | Finish the half-disabled feature: follow the system colour scheme by default, persist "auto" as the *absence* of the stored key, drop the three temporary `FIXME` guards. |
| **MainCard test** | Remove a stale jest-coverage TODO (suite runs on Vitest). |
| **StudentsTable** | Re-verified the `scroll.x: ''` workaround on antd 6.3.1 — still required (switching to a width regresses sticky-header alignment, ant-design#35284). Replaced the vague "dirty hack" note with an accurate one. |
| **ScoreTable** | ant-design#37334 (Enter in a filter dropdown also triggers the sorter) was closed upstream as *not planned*, so the filter-stashing workaround is permanent. Removed the misleading "remove after fix in antd" TODO. |
| **interviews service** | Decompose the ~65-line `getStageInterviewAvailableStudents` into named helpers (query / availability predicate / row→DTO mapping). Behaviour preserved (covered by existing characterization specs). |

## Verification

- All touched unit suites pass (`nestjs` + `client`), `tsc --noEmit` clean for the changed files, ESLint clean.
- **auto theme** verified live in the browser: fresh state follows the OS scheme; Dark/Light/Auto switching persists/clears the key correctly.
- App smoke-tested authenticated (full nav renders, no console errors beyond the known Next 16 dev HMR warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)