### PR TITLE
refactor(autotest): return student verifications grouped by course task from the server

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -7450,7 +7450,7 @@ export interface StudentTaskVerificationDto {
      * @type {string}
      * @memberof StudentTaskVerificationDto
      */
-    'details': string;
+    'details': string | null;
     /**
      * 
      * @type {string}
@@ -9872,7 +9872,7 @@ export interface VerificationCourseTaskDto {
      * @type {string}
      * @memberof VerificationCourseTaskDto
      */
-    'type': string;
+    'type': string | null;
     /**
      * 
      * @type {VerificationTaskDto}

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -1979,6 +1979,25 @@ export type CourseTaskDtoCheckerEnum = typeof CourseTaskDtoCheckerEnum[keyof typ
 /**
  * 
  * @export
+ * @interface CourseTaskVerificationsDto
+ */
+export interface CourseTaskVerificationsDto {
+    /**
+     * 
+     * @type {number}
+     * @memberof CourseTaskVerificationsDto
+     */
+    'courseTaskId': number;
+    /**
+     * 
+     * @type {Array<StudentTaskVerificationDto>}
+     * @memberof CourseTaskVerificationsDto
+     */
+    'verifications': Array<StudentTaskVerificationDto>;
+}
+/**
+ * 
+ * @export
  * @interface CourseUserDto
  */
 export interface CourseUserDto {
@@ -7393,6 +7412,67 @@ export interface StudentSummaryDto {
 /**
  * 
  * @export
+ * @interface StudentTaskVerificationDto
+ */
+export interface StudentTaskVerificationDto {
+    /**
+     * 
+     * @type {number}
+     * @memberof StudentTaskVerificationDto
+     */
+    'id': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof StudentTaskVerificationDto
+     */
+    'createdDate': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof StudentTaskVerificationDto
+     */
+    'studentId': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof StudentTaskVerificationDto
+     */
+    'courseTaskId': number;
+    /**
+     * 
+     * @type {VerificationCourseTaskDto}
+     * @memberof StudentTaskVerificationDto
+     */
+    'courseTask': VerificationCourseTaskDto;
+    /**
+     * 
+     * @type {string}
+     * @memberof StudentTaskVerificationDto
+     */
+    'details': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof StudentTaskVerificationDto
+     */
+    'status': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof StudentTaskVerificationDto
+     */
+    'score': number;
+    /**
+     * 
+     * @type {Array<{ [key: string]: object; }>}
+     * @memberof StudentTaskVerificationDto
+     */
+    'metadata': Array<{ [key: string]: object; }>;
+}
+/**
+ * 
+ * @export
  * @interface StudentsDto
  */
 export interface StudentsDto {
@@ -9774,6 +9854,44 @@ export interface Validations {
      * @memberof Validations
      */
     'githubPrInUrl': boolean;
+}
+/**
+ * 
+ * @export
+ * @interface VerificationCourseTaskDto
+ */
+export interface VerificationCourseTaskDto {
+    /**
+     * 
+     * @type {number}
+     * @memberof VerificationCourseTaskDto
+     */
+    'id': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof VerificationCourseTaskDto
+     */
+    'type': string;
+    /**
+     * 
+     * @type {VerificationTaskDto}
+     * @memberof VerificationCourseTaskDto
+     */
+    'task': VerificationTaskDto;
+}
+/**
+ * 
+ * @export
+ * @interface VerificationTaskDto
+ */
+export interface VerificationTaskDto {
+    /**
+     * 
+     * @type {string}
+     * @memberof VerificationTaskDto
+     */
+    'name': string;
 }
 /**
  * 
@@ -12975,7 +13093,7 @@ export const CourseTaskVerificationsApiFp = function(configuration?: Configurati
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getStudentTaskVerifications(courseId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+        async getStudentTaskVerifications(courseId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<CourseTaskVerificationsDto>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getStudentTaskVerifications(courseId, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -13036,7 +13154,7 @@ export const CourseTaskVerificationsApiFactory = function (configuration?: Confi
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getStudentTaskVerifications(courseId: number, options?: any): AxiosPromise<void> {
+        getStudentTaskVerifications(courseId: number, options?: any): AxiosPromise<Array<CourseTaskVerificationsDto>> {
             return localVarFp.getStudentTaskVerifications(courseId, options).then((request) => request(axios, basePath));
         },
         /**

--- a/client/src/modules/AutoTest/components/VerificationsTable/renderers.tsx
+++ b/client/src/modules/AutoTest/components/VerificationsTable/renderers.tsx
@@ -42,7 +42,7 @@ export function getColumns(maxScore: number): ColumnType<Verification>[] {
       responsive: DISPLAY_ACCURACY,
       render: (_, row: Verification) => {
         const accuracyWordWithNumber = /accuracy:\s+(\d+%)/gi;
-        const [, accuracyNumber] = accuracyWordWithNumber.exec(row.details) ?? [];
+        const [, accuracyNumber] = accuracyWordWithNumber.exec(row.details ?? '') ?? [];
         return accuracyNumber ?? '–';
       },
     },
@@ -62,7 +62,7 @@ export function getColumns(maxScore: number): ColumnType<Verification>[] {
   ];
 }
 
-function renderDetails(value: string, row: Verification) {
+function renderDetails(value: string | null, row: Verification) {
   if (row?.courseTask?.type === CourseTaskDetailedDtoTypeEnum.Codewars) {
     return (
       <>

--- a/client/src/modules/AutoTest/hooks/useCourseTaskVerifications/useCourseTaskVerifications.test.ts
+++ b/client/src/modules/AutoTest/hooks/useCourseTaskVerifications/useCourseTaskVerifications.test.ts
@@ -64,6 +64,20 @@ describe('useCourseTaskVerifications', () => {
     expect(result.current.tasks?.[0]?.name).toBe('Visible');
   });
 
+  it('attaches each course task only the verifications grouped under its id', async () => {
+    getCourseTasksDetailed.mockResolvedValueOnce({ data: [detailedTask({ id: 1 })] });
+    getTaskVerifications.mockReset();
+    getTaskVerifications.mockResolvedValue([
+      { courseTaskId: 1, verifications: [{ id: 11, courseTaskId: 1, score: 90 }] },
+      { courseTaskId: 999, verifications: [{ id: 22, courseTaskId: 999, score: 10 }] },
+    ]);
+
+    const { result } = renderHook(() => useCourseTaskVerifications(42));
+
+    await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+    expect(result.current.tasks?.[0]?.verifications).toEqual([{ id: 11, courseTaskId: 1, score: 90 }]);
+  });
+
   it('toggles isExerciseVisible via startTask and finishTask', async () => {
     getCourseTasksDetailed.mockResolvedValueOnce({ data: [] });
     const { result } = renderHook(() => useCourseTaskVerifications(42));

--- a/client/src/modules/AutoTest/hooks/useCourseTaskVerifications/useCourseTaskVerifications.ts
+++ b/client/src/modules/AutoTest/hooks/useCourseTaskVerifications/useCourseTaskVerifications.ts
@@ -6,7 +6,7 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import { mapTo } from '@client/modules/AutoTest/utils/map';
 import { useEffect, useMemo, useState } from 'react';
 import { useLocalStorage } from 'react-use';
-import { CourseService } from '@client/services/course';
+import { CourseService, Verification } from '@client/services/course';
 
 dayjs.extend(isSameOrAfter);
 
@@ -35,14 +35,22 @@ export function useCourseTaskVerifications(courseId: number) {
 
   const {
     loading,
-    data: allVerifications = [],
+    data: verificationGroups = [],
     error,
     run: reload,
   } = useRequest(async () => await courseService.getTaskVerifications());
 
+  const verificationsByTask = useMemo(() => {
+    const grouped = new Map<number, Verification[]>();
+    for (const group of verificationGroups) {
+      grouped.set(group.courseTaskId, group.verifications);
+    }
+    return grouped;
+  }, [verificationGroups]);
+
   const tasks = useMemo(
-    () => courseTasks?.map(ct => mapTo(ct, allVerifications, manuallyDoneTaskIds)),
-    [courseTasks, allVerifications, manuallyDoneTaskIds],
+    () => courseTasks?.map(ct => mapTo(ct, verificationsByTask.get(ct.id) ?? [], manuallyDoneTaskIds)),
+    [courseTasks, verificationsByTask, manuallyDoneTaskIds],
   );
 
   function markTaskAsDone(taskId: number) {

--- a/client/src/modules/AutoTest/utils/map.test.ts
+++ b/client/src/modules/AutoTest/utils/map.test.ts
@@ -26,14 +26,12 @@ function verification(overrides: Partial<Verification> = {}): Verification {
 }
 
 describe('mapTo', () => {
-  it('keeps only verifications belonging to the given task', () => {
-    const result = mapTo(task(), [
-      verification({ id: 1, courseTaskId: 1, score: 10 }),
-      verification({ id: 2, courseTaskId: 999, score: 20 }),
-    ]);
+  it('passes the given (already task-scoped) verifications straight through', () => {
+    const verifications = [verification({ id: 1, score: 10 }), verification({ id: 2, score: 20 })];
 
-    expect(result.verifications).toHaveLength(1);
-    expect(result.verifications[0]?.id).toBe(1);
+    const result = mapTo(task(), verifications);
+
+    expect(result.verifications).toEqual(verifications);
   });
 
   describe('state', () => {

--- a/client/src/modules/AutoTest/utils/map.ts
+++ b/client/src/modules/AutoTest/utils/map.ts
@@ -57,19 +57,18 @@ function getStatus(
   return CourseTaskStatus.Available;
 }
 
-// TODO: refactor nestjs models to return CourseTaskVerifications from server
+// `verifications` are already scoped to this course task — the server returns them grouped by
+// courseTaskId (see CourseTaskVerificationsDto), so no client-side filtering is needed here.
 export function mapTo(
   courseTask: CourseTaskDetailedDto,
   verifications: Verification[],
   manuallyDoneIds: number[] = [],
 ): CourseTaskVerifications {
-  const taskVerifications = verifications.filter(v => v.courseTaskId === courseTask.id);
-
   return {
     ...courseTask,
-    state: getState(courseTask, taskVerifications),
-    status: getStatus(courseTask, taskVerifications, manuallyDoneIds),
+    state: getState(courseTask, verifications),
+    status: getStatus(courseTask, verifications, manuallyDoneIds),
     publicAttributes: courseTask.publicAttributes as SelfEducationPublicAttributes,
-    verifications: taskVerifications,
+    verifications,
   };
 }

--- a/client/src/services/course.ts
+++ b/client/src/services/course.ts
@@ -43,9 +43,9 @@ export interface Verification {
     task: {
       name: string;
     };
-    type: string;
+    type: string | null;
   };
-  details: string;
+  details: string | null;
   metadata: unknown[];
   score: number;
   status: string;

--- a/nestjs/src/courses/task-verifications/dto/course-task-verifications.dto.ts
+++ b/nestjs/src/courses/task-verifications/dto/course-task-verifications.dto.ts
@@ -9,8 +9,8 @@ class VerificationCourseTaskDto {
   @ApiProperty()
   id: number;
 
-  @ApiProperty()
-  type: string;
+  @ApiProperty({ nullable: true, type: String })
+  type: string | null;
 
   @ApiProperty({ type: VerificationTaskDto })
   task: VerificationTaskDto;
@@ -32,8 +32,8 @@ export class StudentTaskVerificationDto {
   @ApiProperty({ type: VerificationCourseTaskDto })
   courseTask: VerificationCourseTaskDto;
 
-  @ApiProperty()
-  details: string;
+  @ApiProperty({ nullable: true, type: String })
+  details: string | null;
 
   @ApiProperty()
   status: string;

--- a/nestjs/src/courses/task-verifications/dto/course-task-verifications.dto.ts
+++ b/nestjs/src/courses/task-verifications/dto/course-task-verifications.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class VerificationTaskDto {
+  @ApiProperty()
+  name: string;
+}
+
+class VerificationCourseTaskDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  type: string;
+
+  @ApiProperty({ type: VerificationTaskDto })
+  task: VerificationTaskDto;
+}
+
+export class StudentTaskVerificationDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  createdDate: Date;
+
+  @ApiProperty()
+  studentId: number;
+
+  @ApiProperty()
+  courseTaskId: number;
+
+  @ApiProperty({ type: VerificationCourseTaskDto })
+  courseTask: VerificationCourseTaskDto;
+
+  @ApiProperty()
+  details: string;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  score: number;
+
+  @ApiProperty({ type: 'array', items: { type: 'object', additionalProperties: true } })
+  metadata: unknown[];
+}
+
+/**
+ * A student's task verifications grouped by course task, so the client can look them up by
+ * `courseTaskId` directly instead of filtering the full flat list per task.
+ */
+export class CourseTaskVerificationsDto {
+  @ApiProperty()
+  courseTaskId: number;
+
+  @ApiProperty({ type: [StudentTaskVerificationDto] })
+  verifications: StudentTaskVerificationDto[];
+}

--- a/nestjs/src/courses/task-verifications/dto/index.ts
+++ b/nestjs/src/courses/task-verifications/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './self-education.dto';
 export * from './task-verifications-attempts.dto';
 export * from './create-task-verification.dto';
+export * from './course-task-verifications.dto';

--- a/nestjs/src/courses/task-verifications/student-verifications.spec.ts
+++ b/nestjs/src/courses/task-verifications/student-verifications.spec.ts
@@ -9,8 +9,9 @@ import { CloudApiService } from 'src/cloud-api/cloud-api.service';
 import { SelfEducationService } from './self-education.service';
 import { StudentTaskVerificationsController } from './task-verifications.controller';
 
-// Fixtures mirrored from server/src/routes/course/__test__/studentVerifications.test.ts to prove business-logic equivalence
-const mockVerifications = [{ id: 1, status: 'completed', score: 90 }];
+// Fixtures mirrored from server/src/routes/course/__test__/studentVerifications.test.ts.
+// The endpoint now returns the verifications grouped by courseTaskId (see CourseTaskVerificationsDto).
+const mockVerifications = [{ id: 1, status: 'completed', score: 90, courseTaskId: 10 }];
 
 const taskVerificationsRepository = { createQueryBuilder: vi.fn() };
 const studentsRepository = { createQueryBuilder: vi.fn() };
@@ -78,7 +79,7 @@ describe('student verifications', () => {
     expect(verificationsQb.where).toHaveBeenCalledWith('v.studentId = :id', { id: 42 });
     expect(verificationsQb.andWhere).toHaveBeenCalledWith('courseTask.disabled = :disabled', { disabled: false });
     expect(verificationsQb.orderBy).toHaveBeenCalledWith('v.updatedDate', 'DESC');
-    expect(result).toEqual(mockVerifications);
+    expect(result).toEqual([{ courseTaskId: 10, verifications: mockVerifications }]);
   });
 
   it('responds 400 when student is not found in the course', async () => {

--- a/nestjs/src/courses/task-verifications/student-verifications.spec.ts
+++ b/nestjs/src/courses/task-verifications/student-verifications.spec.ts
@@ -10,8 +10,32 @@ import { SelfEducationService } from './self-education.service';
 import { StudentTaskVerificationsController } from './task-verifications.controller';
 
 // Fixtures mirrored from server/src/routes/course/__test__/studentVerifications.test.ts.
-// The endpoint now returns the verifications grouped by courseTaskId (see CourseTaskVerificationsDto).
-const mockVerifications = [{ id: 1, status: 'completed', score: 90, courseTaskId: 10 }];
+// The endpoint now returns the verifications grouped by courseTaskId (see CourseTaskVerificationsDto),
+// mapped to the documented DTO fields (entity internals such as updatedDate are dropped).
+const mockVerification = {
+  id: 1,
+  createdDate: new Date('2024-01-01T00:00:00.000Z'),
+  updatedDate: new Date('2024-01-02T00:00:00.000Z'),
+  studentId: 42,
+  courseTaskId: 10,
+  courseTask: { id: 10, type: 'jstask', task: { name: 'Task A' } },
+  details: 'ok',
+  status: 'completed',
+  score: 90,
+  metadata: [],
+};
+const mockVerifications = [mockVerification];
+const expectedDto = {
+  id: 1,
+  createdDate: new Date('2024-01-01T00:00:00.000Z'),
+  studentId: 42,
+  courseTaskId: 10,
+  courseTask: { id: 10, type: 'jstask', task: { name: 'Task A' } },
+  details: 'ok',
+  status: 'completed',
+  score: 90,
+  metadata: [],
+};
 
 const taskVerificationsRepository = { createQueryBuilder: vi.fn() };
 const studentsRepository = { createQueryBuilder: vi.fn() };
@@ -79,7 +103,7 @@ describe('student verifications', () => {
     expect(verificationsQb.where).toHaveBeenCalledWith('v.studentId = :id', { id: 42 });
     expect(verificationsQb.andWhere).toHaveBeenCalledWith('courseTask.disabled = :disabled', { disabled: false });
     expect(verificationsQb.orderBy).toHaveBeenCalledWith('v.updatedDate', 'DESC');
-    expect(result).toEqual([{ courseTaskId: 10, verifications: mockVerifications }]);
+    expect(result).toEqual([{ courseTaskId: 10, verifications: [expectedDto] }]);
   });
 
   it('responds 400 when student is not found in the course', async () => {

--- a/nestjs/src/courses/task-verifications/task-verifications.controller.ts
+++ b/nestjs/src/courses/task-verifications/task-verifications.controller.ts
@@ -22,6 +22,7 @@ import {
 import { CourseGuard, CourseRole, CurrentRequest, DefaultGuard, RequiredRoles, RoleGuard } from '../../auth';
 import { CreateTaskVerificationDto } from './dto/create-task-verification.dto';
 import { TaskVerificationAttemptDto } from './dto/task-verifications-attempts.dto';
+import { CourseTaskVerificationsDto } from './dto/course-task-verifications.dto';
 import { TaskVerificationsService } from './task-verifications.service';
 
 @Controller('courses/:courseId/tasks/:courseTaskId/verifications')
@@ -81,7 +82,7 @@ export class StudentTaskVerificationsController {
 
   @Get('/')
   @ApiOperation({ operationId: 'getStudentTaskVerifications' })
-  @ApiOkResponse()
+  @ApiOkResponse({ type: [CourseTaskVerificationsDto] })
   @ApiBadRequestResponse()
   @UseGuards(DefaultGuard, CourseGuard)
   public async getStudentTaskVerifications(

--- a/nestjs/src/courses/task-verifications/task-verifications.service.test.ts
+++ b/nestjs/src/courses/task-verifications/task-verifications.service.test.ts
@@ -16,6 +16,7 @@ describe('TaskVerificationsService', () => {
     find: vi.fn(),
     findOne: vi.fn(),
     save: vi.fn(),
+    createQueryBuilder: vi.fn(),
   };
 
   const courseTasksRepository = {
@@ -25,6 +26,7 @@ describe('TaskVerificationsService', () => {
 
   const studentsRepository = {
     findOneByOrFail: vi.fn(),
+    createQueryBuilder: vi.fn(),
   };
 
   const cloudService = {
@@ -404,6 +406,49 @@ describe('TaskVerificationsService', () => {
         },
       ]);
       expect(result).toEqual({ id: 556 });
+    });
+  });
+
+  describe('getStudentVerifications', () => {
+    function qb(terminal: Record<string, unknown>) {
+      const builder: Record<string, unknown> = {};
+      for (const method of ['innerJoin', 'addSelect', 'where', 'andWhere', 'orderBy']) {
+        builder[method] = vi.fn(() => builder);
+      }
+      return Object.assign(builder, terminal);
+    }
+
+    it('returns null when the student is not found in the course', async () => {
+      studentsRepository.createQueryBuilder.mockReturnValue(qb({ getOne: vi.fn().mockResolvedValue(null) }));
+
+      const result = await service.getStudentVerifications(13, 'ghost');
+
+      expect(result).toBeNull();
+    });
+
+    it('groups the student verifications by courseTaskId', async () => {
+      studentsRepository.createQueryBuilder.mockReturnValue(qb({ getOne: vi.fn().mockResolvedValue({ id: 7 }) }));
+      const verifications = [
+        { id: 1, courseTaskId: 100, score: 80 },
+        { id: 2, courseTaskId: 200, score: 50 },
+        { id: 3, courseTaskId: 100, score: 90 },
+      ];
+      taskVerificationsRepository.createQueryBuilder.mockReturnValue(
+        qb({ getMany: vi.fn().mockResolvedValue(verifications) }),
+      );
+
+      const result = await service.getStudentVerifications(13, 'alreadybored');
+
+      expect(result).toEqual([
+        {
+          courseTaskId: 100,
+          verifications: [
+            { id: 1, courseTaskId: 100, score: 80 },
+            { id: 3, courseTaskId: 100, score: 90 },
+          ],
+        },
+        { courseTaskId: 200, verifications: [{ id: 2, courseTaskId: 200, score: 50 }] },
+      ]);
     });
   });
 });

--- a/nestjs/src/courses/task-verifications/task-verifications.service.test.ts
+++ b/nestjs/src/courses/task-verifications/task-verifications.service.test.ts
@@ -418,6 +418,35 @@ describe('TaskVerificationsService', () => {
       return Object.assign(builder, terminal);
     }
 
+    const CREATED = new Date('2024-01-01T00:00:00.000Z');
+    function verification(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 1,
+        createdDate: CREATED,
+        updatedDate: new Date('2024-01-02T00:00:00.000Z'),
+        studentId: 7,
+        courseTaskId: 100,
+        courseTask: { id: 100, type: 'jstask', task: { name: 'Task A' } },
+        details: 'ok',
+        status: 'completed',
+        score: 80,
+        metadata: [],
+        ...overrides,
+      };
+    }
+    const dto = (overrides: Record<string, unknown> = {}) => ({
+      id: 1,
+      createdDate: CREATED,
+      studentId: 7,
+      courseTaskId: 100,
+      courseTask: { id: 100, type: 'jstask', task: { name: 'Task A' } },
+      details: 'ok',
+      status: 'completed',
+      score: 80,
+      metadata: [],
+      ...overrides,
+    });
+
     it('returns null when the student is not found in the course', async () => {
       studentsRepository.createQueryBuilder.mockReturnValue(qb({ getOne: vi.fn().mockResolvedValue(null) }));
 
@@ -426,15 +455,21 @@ describe('TaskVerificationsService', () => {
       expect(result).toBeNull();
     });
 
-    it('groups the student verifications by courseTaskId', async () => {
+    it('groups verifications by courseTaskId and exposes only the documented DTO fields', async () => {
       studentsRepository.createQueryBuilder.mockReturnValue(qb({ getOne: vi.fn().mockResolvedValue({ id: 7 }) }));
-      const verifications = [
-        { id: 1, courseTaskId: 100, score: 80 },
-        { id: 2, courseTaskId: 200, score: 50 },
-        { id: 3, courseTaskId: 100, score: 90 },
-      ];
       taskVerificationsRepository.createQueryBuilder.mockReturnValue(
-        qb({ getMany: vi.fn().mockResolvedValue(verifications) }),
+        qb({
+          getMany: vi.fn().mockResolvedValue([
+            verification({ id: 1, courseTaskId: 100, score: 80 }),
+            verification({
+              id: 2,
+              courseTaskId: 200,
+              score: 50,
+              courseTask: { id: 200, type: 'cv:markdown', task: { name: 'Task B' } },
+            }),
+            verification({ id: 3, courseTaskId: 100, score: 90 }),
+          ]),
+        }),
       );
 
       const result = await service.getStudentVerifications(13, 'alreadybored');
@@ -442,13 +477,40 @@ describe('TaskVerificationsService', () => {
       expect(result).toEqual([
         {
           courseTaskId: 100,
+          verifications: [dto({ id: 1, score: 80 }), dto({ id: 3, score: 90 })],
+        },
+        {
+          courseTaskId: 200,
           verifications: [
-            { id: 1, courseTaskId: 100, score: 80 },
-            { id: 3, courseTaskId: 100, score: 90 },
+            dto({
+              id: 2,
+              courseTaskId: 200,
+              score: 50,
+              courseTask: { id: 200, type: 'cv:markdown', task: { name: 'Task B' } },
+            }),
           ],
         },
-        { courseTaskId: 200, verifications: [{ id: 2, courseTaskId: 200, score: 50 }] },
       ]);
+      // entity internals (e.g. updatedDate) must not leak into the documented response
+      expect(result![0]!.verifications[0]).not.toHaveProperty('updatedDate');
+    });
+
+    it('surfaces null details and null course-task type instead of dropping them', async () => {
+      studentsRepository.createQueryBuilder.mockReturnValue(qb({ getOne: vi.fn().mockResolvedValue({ id: 7 }) }));
+      taskVerificationsRepository.createQueryBuilder.mockReturnValue(
+        qb({
+          getMany: vi
+            .fn()
+            .mockResolvedValue([
+              verification({ details: null, courseTask: { id: 100, type: null, task: { name: 'Task A' } } }),
+            ]),
+        }),
+      );
+
+      const result = await service.getStudentVerifications(13, 'alreadybored');
+
+      expect(result![0]!.verifications[0]!.details).toBeNull();
+      expect(result![0]!.verifications[0]!.courseTask.type).toBeNull();
     });
   });
 });

--- a/nestjs/src/courses/task-verifications/task-verifications.service.ts
+++ b/nestjs/src/courses/task-verifications/task-verifications.service.ts
@@ -8,7 +8,7 @@ import { isBefore, isValid, subHours } from 'date-fns';
 import { CloudApiService } from 'src/cloud-api/cloud-api.service';
 import { MoreThan, Repository } from 'typeorm';
 import { SelfEducationAnswers, SelfEducationQuestionSelectedAnswersDto, TaskVerificationAttemptDto } from './dto';
-import { CourseTaskVerificationsDto } from './dto/course-task-verifications.dto';
+import { CourseTaskVerificationsDto, StudentTaskVerificationDto } from './dto/course-task-verifications.dto';
 import { SelfEducationService } from './self-education.service';
 
 export type VerificationEvent = {
@@ -246,13 +246,35 @@ export class TaskVerificationsService {
   }
 
   private groupVerificationsByCourseTask(verifications: TaskVerification[]): CourseTaskVerificationsDto[] {
-    const byCourseTask = new Map<number, TaskVerification[]>();
+    const byCourseTask = new Map<number, StudentTaskVerificationDto[]>();
     for (const verification of verifications) {
       const group = byCourseTask.get(verification.courseTaskId) ?? [];
-      group.push(verification);
+      group.push(this.toStudentTaskVerificationDto(verification));
       byCourseTask.set(verification.courseTaskId, group);
     }
 
     return [...byCourseTask.entries()].map(([courseTaskId, verifications]) => ({ courseTaskId, verifications }));
+  }
+
+  /**
+   * Map the entity to a plain DTO so the response exposes only the documented fields (no entity
+   * internals such as `updatedDate` leak) and nullable columns are surfaced honestly.
+   */
+  private toStudentTaskVerificationDto(verification: TaskVerification): StudentTaskVerificationDto {
+    return {
+      id: verification.id,
+      createdDate: verification.createdDate,
+      studentId: verification.studentId,
+      courseTaskId: verification.courseTaskId,
+      courseTask: {
+        id: verification.courseTask.id,
+        type: verification.courseTask.type ?? null,
+        task: { name: verification.courseTask.task.name },
+      },
+      details: verification.details ?? null,
+      status: verification.status,
+      score: verification.score,
+      metadata: verification.metadata,
+    };
   }
 }

--- a/nestjs/src/courses/task-verifications/task-verifications.service.ts
+++ b/nestjs/src/courses/task-verifications/task-verifications.service.ts
@@ -8,6 +8,7 @@ import { isBefore, isValid, subHours } from 'date-fns';
 import { CloudApiService } from 'src/cloud-api/cloud-api.service';
 import { MoreThan, Repository } from 'typeorm';
 import { SelfEducationAnswers, SelfEducationQuestionSelectedAnswersDto, TaskVerificationAttemptDto } from './dto';
+import { CourseTaskVerificationsDto } from './dto/course-task-verifications.dto';
 import { SelfEducationService } from './self-education.service';
 
 export type VerificationEvent = {
@@ -217,7 +218,10 @@ export class TaskVerificationsService {
     return { id };
   }
 
-  public async getStudentVerifications(courseId: number, githubId: string) {
+  public async getStudentVerifications(
+    courseId: number,
+    githubId: string,
+  ): Promise<CourseTaskVerificationsDto[] | null> {
     const student = await this.studentsRepository
       .createQueryBuilder('student')
       .innerJoin('student.user', 'user')
@@ -228,7 +232,7 @@ export class TaskVerificationsService {
       return null;
     }
 
-    return this.taskVerificationsRepository
+    const verifications = await this.taskVerificationsRepository
       .createQueryBuilder('v')
       .innerJoin('v.courseTask', 'courseTask')
       .innerJoin('courseTask.task', 'task')
@@ -237,5 +241,18 @@ export class TaskVerificationsService {
       .andWhere('courseTask.disabled = :disabled', { disabled: false })
       .orderBy('v.updatedDate', 'DESC')
       .getMany();
+
+    return this.groupVerificationsByCourseTask(verifications);
+  }
+
+  private groupVerificationsByCourseTask(verifications: TaskVerification[]): CourseTaskVerificationsDto[] {
+    const byCourseTask = new Map<number, TaskVerification[]>();
+    for (const verification of verifications) {
+      const group = byCourseTask.get(verification.courseTaskId) ?? [];
+      group.push(verification);
+      byCourseTask.set(verification.courseTaskId, group);
+    }
+
+    return [...byCourseTask.entries()].map(([courseTaskId, verifications]) => ({ courseTaskId, verifications }));
   }
 }

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -5879,7 +5879,7 @@
         "type": "object",
         "properties": {
           "id": { "type": "number" },
-          "type": { "type": "string" },
+          "type": { "type": "string", "nullable": true },
           "task": { "$ref": "#/components/schemas/VerificationTaskDto" }
         },
         "required": ["id", "type", "task"]
@@ -5892,7 +5892,7 @@
           "studentId": { "type": "number" },
           "courseTaskId": { "type": "number" },
           "courseTask": { "$ref": "#/components/schemas/VerificationCourseTaskDto" },
-          "details": { "type": "string" },
+          "details": { "type": "string", "nullable": true },
           "status": { "type": "string" },
           "score": { "type": "number" },
           "metadata": { "type": "array", "items": { "type": "object", "additionalProperties": true } }

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -2440,7 +2440,17 @@
       "get": {
         "operationId": "getStudentTaskVerifications",
         "parameters": [{ "name": "courseId", "required": true, "in": "path", "schema": { "type": "number" } }],
-        "responses": { "200": { "description": "" }, "400": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/CourseTaskVerificationsDto" } }
+              }
+            }
+          },
+          "400": { "description": "" }
+        },
         "summary": "",
         "tags": ["course task verifications"]
       }
@@ -5863,6 +5873,49 @@
           "studentId": { "type": "number" }
         },
         "required": ["courseTaskId", "studentId"]
+      },
+      "VerificationTaskDto": { "type": "object", "properties": { "name": { "type": "string" } }, "required": ["name"] },
+      "VerificationCourseTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "number" },
+          "type": { "type": "string" },
+          "task": { "$ref": "#/components/schemas/VerificationTaskDto" }
+        },
+        "required": ["id", "type", "task"]
+      },
+      "StudentTaskVerificationDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "number" },
+          "createdDate": { "format": "date-time", "type": "string" },
+          "studentId": { "type": "number" },
+          "courseTaskId": { "type": "number" },
+          "courseTask": { "$ref": "#/components/schemas/VerificationCourseTaskDto" },
+          "details": { "type": "string" },
+          "status": { "type": "string" },
+          "score": { "type": "number" },
+          "metadata": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+        },
+        "required": [
+          "id",
+          "createdDate",
+          "studentId",
+          "courseTaskId",
+          "courseTask",
+          "details",
+          "status",
+          "score",
+          "metadata"
+        ]
+      },
+      "CourseTaskVerificationsDto": {
+        "type": "object",
+        "properties": {
+          "courseTaskId": { "type": "number" },
+          "verifications": { "type": "array", "items": { "$ref": "#/components/schemas/StudentTaskVerificationDto" } }
+        },
+        "required": ["courseTaskId", "verifications"]
       },
       "Map": { "type": "object", "properties": {} },
       "NotificationUserSettingsDto": {


### PR DESCRIPTION
## Context

The student-verifications endpoint returned a **flat** list of all the student's verifications, so the client re-filtered it per task (`verifications.filter(v => v.courseTaskId === ct.id)` inside `mapTo`, run for every task) — the `// TODO: refactor nestjs models to return CourseTaskVerifications from server` note in `client/src/modules/AutoTest/utils/map.ts`.

## Change

- **Backend**: `getStudentVerifications` now groups the rows by `courseTaskId` and returns a typed `CourseTaskVerificationsDto[]` (`{ courseTaskId, verifications[] }`); the endpoint's `@ApiOkResponse` is typed accordingly.
- **SDK**: regenerated the OpenAPI spec + typescript-axios client (`getStudentTaskVerifications` now returns `Array<CourseTaskVerificationsDto>`).
- **Client**: `useCourseTaskVerifications` builds a `courseTaskId → verifications` lookup once; `mapTo` no longer filters and just passes the already-scoped list through. The `manuallyDoneIds` / `markTaskAsDone` behaviour is preserved.

Net effect: the O(tasks × verifications) per-render filter is gone; the contract is now typed end-to-end.

## Verification

- `nestjs` + `client` unit suites pass (incl. new grouping test on the service and a lookup test on the hook); `tsc --noEmit` clean; ESLint clean.
- **Live end-to-end**: logged in as a seeded student and called `GET /courses/23/student-verifications` → `200`, returning `[{courseTaskId:720, verifications:[…2…]}, {courseTaskId:733, verifications:[…1…]}]` with nested `courseTask` intact.
- **UI**: the student Auto-Test page rendered the seeded attempts under the correct tasks (scores 95 and 40 in the *Done* tab); no console errors beyond the known Next 16 dev HMR/hydration warning. Seed data cleaned up afterwards.

> Rebased onto current `master`; the AutoTest changes merged cleanly with the recently-added "Done Task" (`manuallyDoneIds`) feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)