### PR TITLE
feat: improved cross-check notifications

### DIFF
--- a/nestjs/src/courses/course-tasks/course-tasks.service.spec.ts
+++ b/nestjs/src/courses/course-tasks/course-tasks.service.spec.ts
@@ -251,6 +251,35 @@ describe('CourseTasksService', () => {
     });
   });
 
+  describe('getCrossCheckTasksPendingDeadline', () => {
+    it('filters active distributed cross-check tasks within the crossCheckEndDate window', async () => {
+      courseTaskRepository.find.mockResolvedValue([]);
+
+      await service.getCrossCheckTasksPendingDeadline(5);
+
+      const args = courseTaskRepository.find.mock.calls[0][0];
+      expect(args.where).toMatchObject({
+        courseId: 5,
+        disabled: false,
+        checker: Checker.CrossCheck,
+        crossCheckStatus: CrossCheckStatus.Distributed,
+      });
+      expect(args.where.studentStartDate).toEqual(LessThanOrEqual(expect.any(String)));
+      expect(args.where.crossCheckEndDate).toEqual(Between(expect.any(String), expect.any(String)));
+      expect(args.relations).toEqual(['task']);
+      expect(args.order).toEqual({ crossCheckEndDate: 'ASC' });
+    });
+
+    it('honours custom deadlineWithinHours and safeBuffer options', async () => {
+      courseTaskRepository.find.mockResolvedValue([]);
+
+      await service.getCrossCheckTasksPendingDeadline(5, { deadlineWithinHours: 48, safeBuffer: 2 });
+
+      const where = courseTaskRepository.find.mock.calls[0][0].where;
+      expect(where.crossCheckEndDate).toEqual(Between(expect.any(String), expect.any(String)));
+    });
+  });
+
   describe('createCourseTask', () => {
     it('inserts the course task', async () => {
       const payload = { courseId: 5, taskId: 1 };

--- a/nestjs/src/courses/course-tasks/course-tasks.service.ts
+++ b/nestjs/src/courses/course-tasks/course-tasks.service.ts
@@ -210,6 +210,31 @@ export class CourseTasksService {
     });
   }
 
+  public getCrossCheckTasksPendingDeadline(
+    courseId: number,
+    { deadlineWithinHours = 24, safeBuffer = 1 }: { deadlineWithinHours?: number; safeBuffer?: number } = {},
+  ) {
+    const now = new Date();
+    const endDate = addHours(now, deadlineWithinHours).toISOString();
+
+    const where: FindOptionsWhere<CourseTask> = {
+      courseId,
+      disabled: false,
+      checker: Checker.CrossCheck,
+      crossCheckStatus: CrossCheckStatus.Distributed,
+      studentStartDate: LessThanOrEqual(now.toISOString()),
+      crossCheckEndDate: Between(addHours(now, safeBuffer).toISOString(), endDate),
+    };
+
+    return this.courseTaskRepository.find({
+      where,
+      relations: ['task'],
+      order: {
+        crossCheckEndDate: 'ASC',
+      },
+    });
+  }
+
   public createCourseTask(courseEvent: Partial<CourseTask>) {
     return this.courseTaskRepository.insert(courseEvent);
   }

--- a/nestjs/src/courses/tasks/tasks.controller.spec.ts
+++ b/nestjs/src/courses/tasks/tasks.controller.spec.ts
@@ -11,12 +11,13 @@ const flushMicrotasks = () => new Promise<void>(resolve => setImmediate(resolve)
 
 describe('TasksController', () => {
   let controller: TasksController;
-  let tasksService: Mocked<Pick<TasksService, 'getPendingTasksDeadline'>>;
+  let tasksService: Mocked<Pick<TasksService, 'getPendingTasksDeadline' | 'getPendingCrossCheckDeadline'>>;
   let notificationService: Mocked<Pick<UserNotificationsService, 'sendEventNotification'>>;
 
   beforeEach(async () => {
     const mockTasksService = {
       getPendingTasksDeadline: vi.fn(),
+      getPendingCrossCheckDeadline: vi.fn(),
     } as Partial<TasksService> as TasksService;
     const mockNotificationService = {
       sendEventNotification: vi.fn(),
@@ -107,6 +108,78 @@ describe('TasksController', () => {
       await flushMicrotasks();
 
       // both users are attempted even though the first one throws (error is swallowed and logged)
+      expect(notificationService.sendEventNotification).toHaveBeenCalledTimes(2);
+      expect(notificationService.sendEventNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 100 }));
+      expect(notificationService.sendEventNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 200 }));
+    });
+  });
+
+  describe('notifyCrossCheckDeadlines', () => {
+    it('delegates to the tasks service using the deadlineInHours from the dto', async () => {
+      tasksService.getPendingCrossCheckDeadline.mockResolvedValue(new Map());
+      const dto: CheckTasksDeadlineDto = { deadlineInHours: 12 };
+
+      await controller.notifyCrossCheckDeadlines(dto);
+
+      expect(tasksService.getPendingCrossCheckDeadline).toHaveBeenCalledWith(12);
+    });
+
+    it('returns undefined (background notification work is fire-and-forget)', async () => {
+      tasksService.getPendingCrossCheckDeadline.mockResolvedValue(new Map());
+
+      const result = await controller.notifyCrossCheckDeadlines({ deadlineInHours: 24 });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('sends one crossCheckDeadline notification per student with their pending tasks', async () => {
+      const tasksForUser1 = [{ task: { id: 10 }, crossCheckEndDate: '2024-02-01' }];
+      const tasksForUser2 = [{ task: { id: 11 }, crossCheckEndDate: '2024-02-02' }];
+      const students = new Map<number, unknown[]>([
+        [100, tasksForUser1],
+        [200, tasksForUser2],
+      ]);
+      tasksService.getPendingCrossCheckDeadline.mockResolvedValue(students as never);
+      notificationService.sendEventNotification.mockResolvedValue(undefined);
+
+      await controller.notifyCrossCheckDeadlines({ deadlineInHours: 24 });
+      await flushMicrotasks();
+
+      expect(notificationService.sendEventNotification).toHaveBeenCalledTimes(2);
+      expect(notificationService.sendEventNotification).toHaveBeenCalledWith({
+        data: { tasks: tasksForUser1 },
+        notificationId: 'crossCheckDeadline',
+        userId: 100,
+      });
+      expect(notificationService.sendEventNotification).toHaveBeenCalledWith({
+        data: { tasks: tasksForUser2 },
+        notificationId: 'crossCheckDeadline',
+        userId: 200,
+      });
+    });
+
+    it('does not send any notification when no students have pending cross-check tasks', async () => {
+      tasksService.getPendingCrossCheckDeadline.mockResolvedValue(new Map());
+
+      await controller.notifyCrossCheckDeadlines({ deadlineInHours: 24 });
+      await flushMicrotasks();
+
+      expect(notificationService.sendEventNotification).not.toHaveBeenCalled();
+    });
+
+    it('continues notifying remaining students when one notification rejects', async () => {
+      const students = new Map<number, unknown[]>([
+        [100, [{ task: { id: 10 }, crossCheckEndDate: '2024-02-01' }]],
+        [200, [{ task: { id: 11 }, crossCheckEndDate: '2024-02-02' }]],
+      ]);
+      tasksService.getPendingCrossCheckDeadline.mockResolvedValue(students as never);
+      notificationService.sendEventNotification
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined);
+
+      await controller.notifyCrossCheckDeadlines({ deadlineInHours: 24 });
+      await flushMicrotasks();
+
       expect(notificationService.sendEventNotification).toHaveBeenCalledTimes(2);
       expect(notificationService.sendEventNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 100 }));
       expect(notificationService.sendEventNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 200 }));

--- a/nestjs/src/courses/tasks/tasks.controller.ts
+++ b/nestjs/src/courses/tasks/tasks.controller.ts
@@ -43,4 +43,32 @@ export class TasksController {
         }),
     );
   }
+
+  @Post('/notify/cross-check')
+  @ApiOperation({ operationId: 'notifyCrossCheckDeadlines' })
+  @ApiForbiddenResponse()
+  @RequiredRoles([Role.Admin])
+  public async notifyCrossCheckDeadlines(@Body() dto: CheckTasksDeadlineDto) {
+    const students = await this.tasksService.getPendingCrossCheckDeadline(dto.deadlineInHours);
+
+    Promise.resolve().then(
+      () =>
+        // eslint-disable-next-line no-async-promise-executor
+        new Promise(async () => {
+          this.logger.log({ message: 'processing cross-check deadline notifications...' });
+
+          for (const [userId, tasks] of students) {
+            try {
+              await this.notificationService.sendEventNotification({
+                data: { tasks },
+                notificationId: 'crossCheckDeadline',
+                userId,
+              });
+            } catch (e) {
+              this.logger.log({ message: (e as Error).message, userId });
+            }
+          }
+        }),
+    );
+  }
 }

--- a/nestjs/src/courses/tasks/tasks.service.spec.ts
+++ b/nestjs/src/courses/tasks/tasks.service.spec.ts
@@ -20,15 +20,24 @@ const makeCourseTask = (taskId: number, solutionStudentIds?: number[] | null) =>
   taskSolutions: solutionStudentIds == null ? solutionStudentIds : solutionStudentIds.map(studentId => ({ studentId })),
 });
 
+// Minimal course-task shape as returned by getCrossCheckTasksPendingDeadline (task + crossCheckEndDate).
+const makeCrossCheckCourseTask = (taskId: number, crossCheckEndDate = '2024-01-15') => ({
+  task: { id: taskId, name: `task-${taskId}` },
+  crossCheckEndDate,
+});
+
 describe('TasksService', () => {
   let service: TasksService;
   let coursesService: Mocked<Pick<CoursesService, 'getActiveCourses'>>;
-  let courseTasksService: Mocked<Pick<CourseTasksService, 'getTasksPendingDeadline'>>;
+  let courseTasksService: Mocked<
+    Pick<CourseTasksService, 'getTasksPendingDeadline' | 'getCrossCheckTasksPendingDeadline'>
+  >;
 
   beforeEach(async () => {
     const mockCoursesService = { getActiveCourses: vi.fn() } as Partial<CoursesService> as CoursesService;
     const mockCourseTasksService = {
       getTasksPendingDeadline: vi.fn(),
+      getCrossCheckTasksPendingDeadline: vi.fn(),
     } as Partial<CourseTasksService> as CourseTasksService;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -181,6 +190,103 @@ describe('TasksService', () => {
       courseTasksService.getTasksPendingDeadline.mockResolvedValue([makeCourseTask(10, [])] as never);
 
       const result = await service.getPendingTasksDeadline(24);
+
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('getPendingCrossCheckDeadline', () => {
+    it('requests active courses with the students relation', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([]);
+
+      await service.getPendingCrossCheckDeadline(24);
+
+      expect(coursesService.getActiveCourses).toHaveBeenCalledWith(['students']);
+    });
+
+    it('returns an empty map when there are no active courses', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([]);
+
+      const result = await service.getPendingCrossCheckDeadline(24);
+
+      expect(result.size).toBe(0);
+      expect(courseTasksService.getCrossCheckTasksPendingDeadline).not.toHaveBeenCalled();
+    });
+
+    it('forwards courseId and deadlineWithinHours to the course-tasks service per course', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([makeCourse(7, [makeStudent(1, 100)])]);
+      courseTasksService.getCrossCheckTasksPendingDeadline.mockResolvedValue([]);
+
+      await service.getPendingCrossCheckDeadline(48);
+
+      expect(courseTasksService.getCrossCheckTasksPendingDeadline).toHaveBeenCalledWith(7, { deadlineWithinHours: 48 });
+    });
+
+    it('maps every active student to the pending cross-check task keyed by userId (no submission check)', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([makeCourse(7, [makeStudent(1, 100), makeStudent(2, 200)])]);
+      courseTasksService.getCrossCheckTasksPendingDeadline.mockResolvedValue([
+        makeCrossCheckCourseTask(10, '2024-02-01'),
+      ] as never);
+
+      const result = await service.getPendingCrossCheckDeadline(24);
+
+      expect(result.size).toBe(2);
+      expect(result.get(100)?.[0]).toEqual({
+        course: expect.objectContaining({ id: 7, name: 'course-7' }),
+        task: expect.objectContaining({ id: 10 }),
+        crossCheckEndDate: '2024-02-01',
+      });
+      expect(result.get(100)?.[0].course).not.toHaveProperty('students');
+      expect(result.get(200)).toHaveLength(1);
+    });
+
+    it('skips expelled students entirely', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([
+        makeCourse(7, [makeStudent(1, 100, true), makeStudent(2, 200)]),
+      ]);
+      courseTasksService.getCrossCheckTasksPendingDeadline.mockResolvedValue([makeCrossCheckCourseTask(10)] as never);
+
+      const result = await service.getPendingCrossCheckDeadline(24);
+
+      expect(result.size).toBe(1);
+      expect(result.has(100)).toBe(false);
+      expect(result.get(200)).toHaveLength(1);
+    });
+
+    it('accumulates multiple pending cross-check tasks under the same userId', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([makeCourse(7, [makeStudent(1, 100)])]);
+      courseTasksService.getCrossCheckTasksPendingDeadline.mockResolvedValue([
+        makeCrossCheckCourseTask(10),
+        makeCrossCheckCourseTask(11),
+      ] as never);
+
+      const result = await service.getPendingCrossCheckDeadline(24);
+
+      const pending = result.get(100);
+      expect(pending).toHaveLength(2);
+      expect(pending?.map(p => p.task.id)).toEqual([10, 11]);
+    });
+
+    it('aggregates pending cross-check tasks for the same userId across courses', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([
+        makeCourse(7, [makeStudent(1, 100)]),
+        makeCourse(8, [makeStudent(2, 100)]),
+      ]);
+      courseTasksService.getCrossCheckTasksPendingDeadline
+        .mockResolvedValueOnce([makeCrossCheckCourseTask(10)] as never)
+        .mockResolvedValueOnce([makeCrossCheckCourseTask(20)] as never);
+
+      const result = await service.getPendingCrossCheckDeadline(24);
+
+      expect(result.size).toBe(1);
+      expect(result.get(100)?.map(p => p.task.id).sort()).toEqual([10, 20]);
+    });
+
+    it('produces no entries when no cross-check tasks are pending', async () => {
+      coursesService.getActiveCourses.mockResolvedValue([makeCourse(7, [makeStudent(1, 100)])]);
+      courseTasksService.getCrossCheckTasksPendingDeadline.mockResolvedValue([]);
+
+      const result = await service.getPendingCrossCheckDeadline(24);
 
       expect(result.size).toBe(0);
     });

--- a/nestjs/src/courses/tasks/tasks.service.spec.ts
+++ b/nestjs/src/courses/tasks/tasks.service.spec.ts
@@ -279,7 +279,12 @@ describe('TasksService', () => {
       const result = await service.getPendingCrossCheckDeadline(24);
 
       expect(result.size).toBe(1);
-      expect(result.get(100)?.map(p => p.task.id).sort()).toEqual([10, 20]);
+      expect(
+        result
+          .get(100)
+          ?.map(p => p.task.id)
+          .sort(),
+      ).toEqual([10, 20]);
     });
 
     it('produces no entries when no cross-check tasks are pending', async () => {

--- a/nestjs/src/courses/tasks/tasks.service.ts
+++ b/nestjs/src/courses/tasks/tasks.service.ts
@@ -3,6 +3,7 @@ import { CoursesService } from 'src/courses/courses.service';
 import { CourseTasksService } from 'src/courses';
 import { Course } from '@entities/course';
 import { Task } from '@entities/task';
+import { CourseTask } from '@entities/courseTask';
 
 @Injectable()
 export class TasksService {
@@ -44,6 +45,42 @@ export class TasksService {
       }
     }
     this.logger.log({ message: `students missing deadlines ${studentMap.size}` });
+
+    return studentMap;
+  }
+
+  public async getPendingCrossCheckDeadline(deadlineWithinHours: number) {
+    const activeCourses = await this.courseService.getActiveCourses(['students']);
+    const studentMap = new Map<
+      number,
+      { course: Omit<Course, 'students'>; task: Task; crossCheckEndDate: CourseTask['crossCheckEndDate'] }[]
+    >();
+
+    for (const course of activeCourses) {
+      const { students, ...courseInfo } = course;
+      const courseTasks = await this.courseTasksService.getCrossCheckTasksPendingDeadline(courseInfo.id, {
+        deadlineWithinHours,
+      });
+      this.logger.log({
+        message: `course: ${course.id} has ${courseTasks.length} cross-check tasks pending deadline`,
+      });
+
+      if (!courseTasks.length) continue;
+
+      for (const student of students) {
+        if (student.isExpelled) continue;
+        for (const courseTask of courseTasks) {
+          const studentPendingTasks = studentMap.get(student.userId) ?? [];
+          studentPendingTasks.push({
+            course: courseInfo,
+            task: courseTask.task,
+            crossCheckEndDate: courseTask.crossCheckEndDate,
+          });
+          studentMap.set(student.userId, studentPendingTasks);
+        }
+      }
+    }
+    this.logger.log({ message: `students with pending cross-check deadlines ${studentMap.size}` });
 
     return studentMap;
   }

--- a/nestjs/src/models/notification.ts
+++ b/nestjs/src/models/notification.ts
@@ -23,6 +23,7 @@ export type NotificationId =
   | 'courseCertificate'
   | 'courseScheduleChange'
   | 'taskDeadline'
+  | 'crossCheckDeadline'
   | 'interviewerAssigned'
   | 'emailConfirmation'
   | 'mentor:assigned'

--- a/nestjs/src/ormconfig.ts
+++ b/nestjs/src/ormconfig.ts
@@ -19,7 +19,10 @@ const config: DataSourceOptions = {
   migrations,
   synchronize: false,
   migrationsRun: true,
-  subscribers: [path.resolve(__dirname, '**/*.subscriber.*')],
+  subscribers: [
+    path.resolve(__dirname, '**/*.subscriber.ts'),
+    path.resolve(__dirname, '**/*.subscriber.js'),
+  ],
   logging: ['migration', 'error', 'warn'],
 };
 

--- a/nestjs/src/ormconfig.ts
+++ b/nestjs/src/ormconfig.ts
@@ -19,10 +19,7 @@ const config: DataSourceOptions = {
   migrations,
   synchronize: false,
   migrationsRun: true,
-  subscribers: [
-    path.resolve(__dirname, '**/*.subscriber.ts'),
-    path.resolve(__dirname, '**/*.subscriber.js'),
-  ],
+  subscribers: [path.resolve(__dirname, '**/*.subscriber.ts'), path.resolve(__dirname, '**/*.subscriber.js')],
   logging: ['migration', 'error', 'warn'],
 };
 

--- a/nestjs/src/schedule/schedule.service.spec.ts
+++ b/nestjs/src/schedule/schedule.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { User } from '@entities/user';
 import { History } from '@entities/history';
 import { CourseEvent } from '@entities/courseEvent';
+import { CrossCheckStatus } from '@entities/courseTask';
 import { CoursesService } from 'src/courses/courses.service';
 import { ScheduleService } from './schedule.service';
 
@@ -187,22 +188,24 @@ describe('ScheduleService', () => {
         expect(result).toEqual({ crossCheckEndDate: '2024-02-15', crossCheckEndDateOld: '2024-01-15' });
       });
 
-      it('returns an empty object when no task date changed', () => {
+      it('returns undefined when no task date changed and the status is unchanged', () => {
         const result = service.getUpdatedFields(
           'course_task',
           {
             studentStartDate: '2024-01-01',
             studentEndDate: '2024-01-10',
             crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Distributed,
           } as never,
           {
             studentStartDate: '2024-01-01',
             studentEndDate: '2024-01-10',
             crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Distributed,
           } as never,
         );
 
-        expect(result).toEqual({});
+        expect(result).toBeUndefined();
       });
 
       it('treats two null dates as equal and reports no change', () => {
@@ -220,7 +223,81 @@ describe('ScheduleService', () => {
           } as never,
         );
 
-        expect(result).toEqual({});
+        expect(result).toBeUndefined();
+      });
+
+      it('reports a cross-check started transition (initial -> distributed) with no date change', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Distributed,
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Initial,
+          } as never,
+        );
+
+        expect(result).toEqual({ isCrossCheckStarted: true });
+      });
+
+      it('reports a cross-check completed transition (distributed -> completed) with no date change', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Completed,
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Distributed,
+          } as never,
+        );
+
+        expect(result).toEqual({ isCrossCheckCompleted: true });
+      });
+
+      it('does not surface unknown/backward status transitions (completed -> distributed)', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          { crossCheckStatus: CrossCheckStatus.Distributed } as never,
+          { crossCheckStatus: CrossCheckStatus.Completed } as never,
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      it('merges a date change with a cross-check transition in one update', () => {
+        const result = service.getUpdatedFields(
+          'course_task',
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-02-10',
+            crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Distributed,
+          } as never,
+          {
+            studentStartDate: '2024-01-01',
+            studentEndDate: '2024-01-10',
+            crossCheckEndDate: '2024-01-15',
+            crossCheckStatus: CrossCheckStatus.Initial,
+          } as never,
+        );
+
+        expect(result).toEqual({
+          studentEndDate: '2024-02-10',
+          studentEndDateOld: '2024-01-10',
+          isCrossCheckStarted: true,
+        });
       });
 
       it('coerces missing previous dates to undefined in every old field', () => {
@@ -465,7 +542,7 @@ describe('ScheduleService', () => {
       expect(changes[0]).toMatchObject({ isNew: true, place: 'New', placeOld: 'Old' });
     });
 
-    it('ignores records with an unrecognized operation', async () => {
+    it('ignores records with an unrecognized operation, leaving no course to notify', async () => {
       const unknownRecord = {
         operation: 'unknown',
         entityId: 100,
@@ -475,13 +552,51 @@ describe('ScheduleService', () => {
       } as unknown as History;
       historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [unknownRecord]));
       courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
+      courseService.getByIds.mockResolvedValue([]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      // the empty course bucket is pruned, so getByIds is queried with no ids and nobody is notified
+      expect(courseService.getByIds).toHaveBeenCalledWith([], expect.any(Object));
+      expect(result).toEqual([]);
+    });
+
+    it('drops a cross-check status-only no-op update (no phantom "is updated")', async () => {
+      const noopRecord = {
+        operation: 'update',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Distributed },
+        previous: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Distributed },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [noopRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
+      courseService.getByIds.mockResolvedValue([]);
+      userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
+
+      const result = await service.getChangedCoursesRecipients(2);
+
+      expect(courseService.getByIds).toHaveBeenCalledWith([], expect.any(Object));
+      expect(result).toEqual([]);
+    });
+
+    it('emits a cross-check started marker when the status moves initial -> distributed', async () => {
+      const startedRecord = {
+        operation: 'update',
+        entityId: 100,
+        event: 'course_task',
+        update: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Distributed },
+        previous: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Initial },
+      } as unknown as History;
+      historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [startedRecord]));
+      courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
       courseService.getByIds.mockResolvedValue([{ id: 5, alias: 'course-a', name: 'Course A', completed: false }]);
       userRepository.createQueryBuilder.mockReturnValue(makeQb('getRawMany', [{ id: 42, aliases: ['course-a'] }]));
 
       const result = await service.getChangedCoursesRecipients(2);
 
-      // course bucket exists (courseId tracked) but no change was recorded
-      expect(result[0][1][0].changes).toEqual([]);
+      expect(result[0][1][0].changes[0]).toMatchObject({ isCrossCheckStarted: true, type: 'task', name: 'Task 200' });
     });
 
     it('defaults the change name to an empty string when no task/event entry is found', async () => {

--- a/nestjs/src/schedule/schedule.service.spec.ts
+++ b/nestjs/src/schedule/schedule.service.spec.ts
@@ -567,8 +567,18 @@ describe('ScheduleService', () => {
         operation: 'update',
         entityId: 100,
         event: 'course_task',
-        update: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Distributed },
-        previous: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Distributed },
+        update: {
+          courseId: 5,
+          taskId: 200,
+          studentEndDate: '2024-01-10',
+          crossCheckStatus: CrossCheckStatus.Distributed,
+        },
+        previous: {
+          courseId: 5,
+          taskId: 200,
+          studentEndDate: '2024-01-10',
+          crossCheckStatus: CrossCheckStatus.Distributed,
+        },
       } as unknown as History;
       historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [noopRecord]));
       courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);
@@ -586,8 +596,18 @@ describe('ScheduleService', () => {
         operation: 'update',
         entityId: 100,
         event: 'course_task',
-        update: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Distributed },
-        previous: { courseId: 5, taskId: 200, studentEndDate: '2024-01-10', crossCheckStatus: CrossCheckStatus.Initial },
+        update: {
+          courseId: 5,
+          taskId: 200,
+          studentEndDate: '2024-01-10',
+          crossCheckStatus: CrossCheckStatus.Distributed,
+        },
+        previous: {
+          courseId: 5,
+          taskId: 200,
+          studentEndDate: '2024-01-10',
+          crossCheckStatus: CrossCheckStatus.Initial,
+        },
       } as unknown as History;
       historyRepository.createQueryBuilder.mockReturnValue(makeQb('getMany', [startedRecord]));
       courseEventRepository.query.mockResolvedValue([{ id: 200, name: 'Task 200', type: 'task' }]);

--- a/nestjs/src/schedule/schedule.service.ts
+++ b/nestjs/src/schedule/schedule.service.ts
@@ -10,7 +10,7 @@ import { Mentor } from '@entities/mentor';
 import { CourseUser } from '@entities/courseUser';
 import { History } from '@entities/history';
 import { CourseEvent } from '@entities/courseEvent';
-import { CourseTask } from '@entities/courseTask';
+import { CourseTask, CrossCheckStatus } from '@entities/courseTask';
 
 @Injectable()
 export class ScheduleService {
@@ -116,6 +116,14 @@ export class ScheduleService {
       });
     });
 
+    // Drop courses whose records were all skipped (e.g. status-only no-op updates),
+    // so they don't produce an empty notification.
+    for (const [courseId, recordsMap] of courseMap) {
+      if (recordsMap.size === 0) {
+        courseMap.delete(courseId);
+      }
+    }
+
     return courseMap;
   }
 
@@ -177,10 +185,15 @@ export class ScheduleService {
           ...this.getInsertFields(event, entryPrevious),
         });
       } else if (operation === 'update') {
+        const updatedFields = this.getUpdatedFields(event, entryUpdate, entryPrevious);
+        // No real change (no date change AND no recognised cross-check transition) -> do not list the task.
+        if (!updatedFields) {
+          continue;
+        }
         recordsMap.set(entryKey, {
           ...prevEntry,
           type,
-          ...this.getUpdatedFields(event, entryUpdate, entryPrevious),
+          ...updatedFields,
         });
       }
     }
@@ -274,6 +287,8 @@ export class ScheduleService {
         studentStartDateOld: string | Date;
         studentEndDateOld: string | Date;
         crossCheckEndDateOld: string | Date;
+        isCrossCheckStarted: boolean;
+        isCrossCheckCompleted: boolean;
       }
     > = {};
 
@@ -291,7 +306,29 @@ export class ScheduleService {
       fields.crossCheckEndDateOld = previousTask.crossCheckEndDate ?? undefined;
     }
 
-    return fields;
+    const transition = this.getCrossCheckTransition(task, previousTask);
+    if (transition) {
+      Object.assign(fields, transition);
+    }
+
+    // For tasks return undefined (mirroring the course_event branch) when nothing meaningful
+    // changed, so buildChangesMaps can skip status-only no-op updates instead of listing a
+    // phantom "Task is updated".
+    return Object.keys(fields).length > 0 ? fields : undefined;
+  }
+
+  private getCrossCheckTransition(task: CourseTask, previousTask: CourseTask) {
+    const from = previousTask?.crossCheckStatus;
+    const to = task?.crossCheckStatus;
+    if (!to || from === to) return undefined;
+    if (from === CrossCheckStatus.Initial && to === CrossCheckStatus.Distributed) {
+      return { isCrossCheckStarted: true as const };
+    }
+    if (from === CrossCheckStatus.Distributed && to === CrossCheckStatus.Completed) {
+      return { isCrossCheckCompleted: true as const };
+    }
+    // Unknown / backward transitions (e.g. an admin reset) are not surfaced.
+    return undefined;
   }
 
   private isDateEqual(date1: string | Date | null, date2: string | Date | null) {
@@ -307,6 +344,8 @@ type Recipients = UserCourses[];
 type ChangeEvent = {
   isNew?: boolean;
   isRemoved?: boolean;
+  isCrossCheckStarted?: boolean;
+  isCrossCheckCompleted?: boolean;
   type: string;
   name?: string;
 } & Partial<CourseEvent | CourseTask>;

--- a/nestjs/src/spec.json
+++ b/nestjs/src/spec.json
@@ -1081,6 +1081,19 @@
         "tags": ["courses tasks"]
       }
     },
+    "/tasks/notify/cross-check": {
+      "post": {
+        "operationId": "notifyCrossCheckDeadlines",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CheckTasksDeadlineDto" } } }
+        },
+        "responses": { "403": { "description": "" } },
+        "summary": "",
+        "tags": ["courses tasks"]
+      }
+    },
     "/courses/stats/expelled": {
       "get": {
         "operationId": "getExpelledStats",


### PR DESCRIPTION
## What & why

Fixes false "Task … is updated" notifications and adds cross-check-specific messaging + a cross-check deadline reminder.

Root cause of the false notifications: the schedule-change job diffs the `history` table, but the cross-check cron (and manual distribution) `save({...courseTask, crossCheckStatus})` writes a `history` row on every status change. For tasks, `getUpdatedFields` always returned an object (even empty `{}`) and never looked at `crossCheckStatus`, so a status-only change surfaced as a phantom "is updated".

## Changes

**1. Distinct cross-check messages** — `schedule.service.ts` now detects the `crossCheckStatus` transition (`Initial→Distributed` = started, `Distributed→Completed` = completed) from the history `previous`/`update` and emits `isCrossCheckStarted` / `isCrossCheckCompleted` on the change. Covers both the cron and manual distribution (same history row).

**2. Drop phantom / blank "is updated"** — `getUpdatedFields` (task branch) now returns `undefined` when nothing meaningful changed (mirroring the event branch); `buildChangesMaps` skips such updates and empty course buckets are pruned, so status-only no-op saves no longer generate a notification.

**3. Cross-check deadline reminder** — new `POST /tasks/notify/cross-check` (`notifyCrossCheckDeadlines`) + `getPendingCrossCheckDeadline` / `getCrossCheckTasksPendingDeadline`, reminding all active students of a course ~24h before `crossCheckEndDate` (mirrors the existing task-deadline flow). New notification id `crossCheckDeadline`.

**Also:** `ormconfig.ts` subscribers glob narrowed (`*.subscriber.ts`/`.js`) so it no longer matches `*.subscriber.spec.ts` — this unblocks `npm run openapi:spec`. `spec.json` regenerated for the new endpoint.

## Follow-up (not in this PR)
- Configure notification templates in `/admin/notifications`: update `courseScheduleChange` (render the new started/completed flags) and create the `crossCheckDeadline` notification.
- Serverless PR (rsschool-app-private) adds the daily `CheckCrossCheckDeadlines` lambda that calls the new endpoint — merge this PR first.

## Testing
`npm run test:ci` (nestjs, 100% on schedule/tasks), `lint`, `ci:format`, `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)