### PR TITLE
fix: reset session cache after student registration

### DIFF
--- a/client/src/modules/Registry/hooks/useStudentData/useStudentData.test.tsx
+++ b/client/src/modules/Registry/hooks/useStudentData/useStudentData.test.tsx
@@ -8,16 +8,25 @@ import { useStudentData } from './useStudentData';
 // CdnService (courses + student registration) and DisciplinesApi (certificate gating),
 // then submits through ProfileApi + CdnService. We mock those service classes so the
 // real eligibility/registration/modal logic runs against deterministic fixtures.
-const { getMyProfile, getProfileInfo, getCourses, registerStudent, getDisciplinesByIds, updateUser, messageError } =
-  vi.hoisted(() => ({
-    getMyProfile: vi.fn(),
-    getProfileInfo: vi.fn(),
-    getCourses: vi.fn(),
-    registerStudent: vi.fn(),
-    getDisciplinesByIds: vi.fn(),
-    updateUser: vi.fn(),
-    messageError: vi.fn(),
-  }));
+const {
+  getMyProfile,
+  getProfileInfo,
+  getCourses,
+  registerStudent,
+  getDisciplinesByIds,
+  updateUser,
+  clearAuthUserSessionCache,
+  messageError,
+} = vi.hoisted(() => ({
+  getMyProfile: vi.fn(),
+  getProfileInfo: vi.fn(),
+  getCourses: vi.fn(),
+  registerStudent: vi.fn(),
+  getDisciplinesByIds: vi.fn(),
+  updateUser: vi.fn(),
+  clearAuthUserSessionCache: vi.fn(),
+  messageError: vi.fn(),
+}));
 
 // Stable message mock so the error assertion sees the exact spy the hook called
 // (the shared `@client/hooks` mock returns a fresh object per call).
@@ -50,6 +59,9 @@ vi.mock('@client/api', async importOriginal => {
     },
     ProfileApi: class {
       updateUser = updateUser;
+    },
+    AuthApi: class {
+      clearAuthUserSessionCache = clearAuthUserSessionCache;
     },
   };
 });
@@ -98,7 +110,7 @@ const enrolledCourse = {
 // so Modal.useModal's confirm dialog can actually render and be clicked.
 type Api = ReturnType<typeof useStudentData>;
 function Harness({ courseAlias, onReady }: { courseAlias?: string; onReady: (api: Api) => void }) {
-  const api = useStudentData('octocat', courseAlias);
+  const api = useStudentData('octocat', 42, courseAlias);
   onReady(api);
   return (<>{api.modalContext}</>) as ReactNode;
 }
@@ -122,6 +134,7 @@ beforeEach(() => {
   getDisciplinesByIds.mockResolvedValue({ data: [] });
   updateUser.mockResolvedValue({});
   registerStudent.mockResolvedValue({});
+  clearAuthUserSessionCache.mockResolvedValue({});
 });
 
 describe('useStudentData', () => {
@@ -195,6 +208,47 @@ describe('useStudentData', () => {
     });
     expect(registerStudent).toHaveBeenCalledWith({ type: 'student', courseId: 1 });
     await waitFor(() => expect(view.current.currentStep).toBe(1));
+  });
+
+  test('resets the cached auth session so the new course is visible right away', async () => {
+    const view = renderHookView();
+    await waitFor(() => expect(view.current.loading).toBe(false));
+
+    await act(async () => {
+      await view.current.handleSubmit({
+        courseId: 1,
+        location: { countryName: 'Poland', cityName: 'Warsaw' },
+        primaryEmail: 'a@b.c',
+        contactsEpamEmail: 'a@epam.com',
+        firstName: 'Ada',
+        lastName: 'L',
+        languagesMentoring: ['English'],
+      } as never);
+    });
+
+    expect(clearAuthUserSessionCache).toHaveBeenCalledWith(42);
+  });
+
+  test('still completes registration when the session cache reset fails', async () => {
+    clearAuthUserSessionCache.mockRejectedValueOnce(new Error('boom'));
+    const view = renderHookView();
+    await waitFor(() => expect(view.current.loading).toBe(false));
+
+    await act(async () => {
+      await view.current.handleSubmit({
+        courseId: 1,
+        location: { countryName: 'Poland', cityName: 'Warsaw' },
+        primaryEmail: 'a@b.c',
+        contactsEpamEmail: 'a@epam.com',
+        firstName: 'Ada',
+        lastName: 'L',
+        languagesMentoring: ['English'],
+      } as never);
+    });
+
+    // Registration itself succeeded, so the user must reach the Done step without an error.
+    await waitFor(() => expect(view.current.currentStep).toBe(1));
+    expect(messageError).not.toHaveBeenCalled();
   });
 
   test('warns about existing enrollments and registers only after confirming', async () => {

--- a/client/src/modules/Registry/hooks/useStudentData/useStudentData.tsx
+++ b/client/src/modules/Registry/hooks/useStudentData/useStudentData.tsx
@@ -8,7 +8,7 @@ import { DoneSection, GeneralSection } from '@client/modules/Registry/components
 import { Form, Modal, theme, Typography } from 'antd';
 import { useRouter } from 'next/router';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
-import { DisciplinesApi, ProfileApi } from '@client/api';
+import { AuthApi, DisciplinesApi, ProfileApi } from '@client/api';
 import { TYPES } from '@client/configs/registry';
 import { ERROR_MESSAGES } from '@client/modules/Registry/constants';
 import { useMessage } from '@client/hooks';
@@ -26,8 +26,9 @@ const cdnService = new CdnService();
 const profileApi = new ProfileApi();
 const userService = new UserService();
 const disciplinesApi = new DisciplinesApi();
+const authApi = new AuthApi();
 
-export function useStudentData(githubId: string, courseAlias?: string) {
+export function useStudentData(githubId: string, userId: number, courseAlias?: string) {
   const { message } = useMessage();
   const router = useRouter();
   const [form] = Form.useForm<StudentFormData>();
@@ -148,6 +149,10 @@ export function useStudentData(githubId: string, courseAlias?: string) {
 
         try {
           await Promise.all(requests);
+          // The auth user (and its course roles) is cached server-side for 10 minutes, so without
+          // resetting it a freshly registered student keeps a role-less session and sees no course
+          // data. Registration already succeeded here, so a failed reset must not look like an error.
+          await authApi.clearAuthUserSessionCache(userId).catch(() => undefined);
           setCurrentStep(previousStep => previousStep + 1);
         } catch {
           message.error(ERROR_MESSAGES.tryLater);
@@ -156,7 +161,7 @@ export function useStudentData(githubId: string, courseAlias?: string) {
         }
       }
     },
-    [loading, dataLoading, student?.registeredForCourses],
+    [loading, dataLoading, userId, student?.registeredForCourses],
   );
 
   function getCourseName() {

--- a/client/src/modules/Registry/pages/Student/Student.test.tsx
+++ b/client/src/modules/Registry/pages/Student/Student.test.tsx
@@ -49,7 +49,7 @@ function setData(overrides: Partial<typeof baseData> = {}) {
   mockedUseStudentData.mockReturnValue({ ...baseData, ...overrides });
 }
 
-function renderPage(session: Partial<Session> = { githubId: 'octocat' }) {
+function renderPage(session: Partial<Session> = { githubId: 'octocat', id: 1 }) {
   return render(
     <SessionContext.Provider value={session as Session}>
       <StudentRegistry />
@@ -64,13 +64,13 @@ beforeEach(() => {
 });
 
 describe('StudentRegistry', () => {
-  test('passes the session githubId and course query param to useStudentData', () => {
+  test('passes session data and course query param to useStudentData', () => {
     vi.mocked(useRouter).mockReturnValue({ query: { course: 'js-2024' }, push: vi.fn() } as never);
     setData({ courses: [{ id: 1 } as never] });
 
-    renderPage({ githubId: 'octocat' });
+    renderPage({ githubId: 'octocat', id: 1 });
 
-    expect(mockedUseStudentData).toHaveBeenCalledWith('octocat', 'js-2024');
+    expect(mockedUseStudentData).toHaveBeenCalledWith('octocat', 1, 'js-2024');
   });
 
   test('renders nothing but the modal context while loading', () => {

--- a/client/src/modules/Registry/pages/Student/Student.tsx
+++ b/client/src/modules/Registry/pages/Student/Student.tsx
@@ -9,7 +9,7 @@ export function StudentRegistry() {
   const session = useContext(SessionContext);
   const router = useRouter();
   const { courses, loading, registered, steps, currentStep, form, handleSubmit, modalContext, missingDisciplines } =
-    useStudentData(session.githubId, router.query.course as string | undefined);
+    useStudentData(session.githubId, session.id, router.query.course as string | undefined);
 
   let content: React.ReactNode;
   if (loading || registered) {

--- a/client/src/pages/registry/epamlearningjs.tsx
+++ b/client/src/pages/registry/epamlearningjs.tsx
@@ -2,7 +2,7 @@ import { Button, Col, Form, Input, message, Result, Row, Typography } from 'antd
 import { PageLayout } from '@client/shared/components/PageLayout';
 import { GdprCheckbox, LocationSelect } from '@client/shared/components/Forms';
 import { withGoogleMaps } from '@client/components/withGoogleMaps';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useAsync, useUpdate } from 'react-use';
 import { CoursesService } from '@client/services/courses';
 import { Course } from '@client/services/models';
@@ -11,8 +11,8 @@ import { emailPattern, englishNamePattern } from '@client/services/validators';
 import { TYPES } from './../../configs/registry';
 import { ProfileApi } from '@client/api';
 import { Location } from '@common/models/profile';
-import { SessionProvider } from '@client/modules/Course/contexts';
-import { CreateRegistrationDtoTypeEnum, RegistryApi } from '@client/api';
+import { SessionContext, SessionProvider } from '@client/modules/Course/contexts';
+import { AuthApi, CreateRegistrationDtoTypeEnum, RegistryApi } from '@client/api';
 
 const defaultColumnSizes = { xs: 18, sm: 10, md: 8, lg: 6 };
 const defaultRowGutter = 24;
@@ -20,6 +20,7 @@ const defaultRowGutter = 24;
 const courseAlias = 'epamlearningjs';
 const profileApi = new ProfileApi();
 const registryApi = new RegistryApi();
+const authApi = new AuthApi();
 
 type FormData = {
   firstName: string;
@@ -31,6 +32,7 @@ type FormData = {
 
 function EpamLearningJSPage() {
   const [form] = Form.useForm<FormData>();
+  const session = useContext(SessionContext);
 
   const update = useUpdate();
   const [submitted, setSubmitted] = useState(false);
@@ -71,6 +73,10 @@ function EpamLearningJSPage() {
     try {
       await profileApi.updateUser(userModel);
       await registryApi.createRegistration(registryModel);
+      // The auth user (and its course roles) is cached server-side for 10 minutes, so without
+      // resetting it a freshly registered student keeps a role-less session and sees no course
+      // data. Registration already succeeded here, so a failed reset must not look like an error.
+      await authApi.clearAuthUserSessionCache(session.id).catch(() => undefined);
       setSubmitted(true);
     } catch {
       message.error('An error occured. Please try later.');


### PR DESCRIPTION
**Issue**:

No separate issue — reported directly. Same root cause as #2756, which fixed the mentor side.

**Description**:

After registering for a course, a student could see no course data for up to 10 minutes, as if the registration never happened.

`JwtStrategy` caches the resolved `AuthUser` — including its `courseUsers`/roles — under `auth-user-${userId}` for 10 minutes ([jwt.strategy.ts](https://github.com/rolling-scopes/rsschool-app/blob/master/nestjs/src/auth/strategies/jwt.strategy.ts)). Nothing invalidates that entry when a role is granted, so a freshly registered student keeps a role-less session until the TTL expires.

#2756 added `DELETE /auth/cache/:userId` and applied the reset to mentor confirmation. This PR applies the same fix to both student registration flows:

- `/registry/student` — `useStudentData` clears the cache after a successful registration (user id passed down from the session).
- `/registry/epamlearningjs` — same, reading the id from `SessionContext`.

No backend changes were needed: the endpoint from #2756 already covers this case, and it is guarded so a user can only clear their own cache.

Two notes on scope:

- `/registry/mentor` is intentionally untouched — it writes to the mentor registry and does not grant a course role. That role is granted at `/course/mentor/confirm`, already fixed in #2756.
- Unlike #2756, the reset is not inside the registration `try` block; it is awaited with `.catch(() => undefined)`. Registration has already succeeded at that point, so surfacing a failed cache reset as "An error occurred. Please try later." would push the student to re-register (and hit a duplicate error) instead of simply waiting out the TTL. Happy to align it with #2756 if consistency is preferred.

Tests: two new cases in `useStudentData.test.tsx` — the reset is called with the session user id, and registration still completes when the reset fails.

**Self-Check**:

- [ ] Database migration added (if required)
- [x] Changes tested locally