### PR TITLE
perf(nginx): reuse keep-alive connections to the NestJS upstream

### DIFF
--- a/setup/nginx/nginx.conf
+++ b/setup/nginx/nginx.conf
@@ -26,6 +26,10 @@ http {
     # Pool of idle keep-alive connections to the API container. Without it every
     # proxied request opens a new TCP connection (proxy defaults to HTTP/1.0).
     keepalive 32;
+    # Must stay below Node's server.keepAliveTimeout (5s default, not overridden
+    # in nestjs) — if nginx reuses a connection Node is closing, non-idempotent
+    # requests are not retried and fail with 502.
+    keepalive_timeout 4s;
   }
 
   default_type application/octet-stream;

--- a/setup/nginx/nginx.conf
+++ b/setup/nginx/nginx.conf
@@ -23,6 +23,9 @@ http {
 
   upstream nestjs_target {
     server nestjs:8080;
+    # Pool of idle keep-alive connections to the API container. Without it every
+    # proxied request opens a new TCP connection (proxy defaults to HTTP/1.0).
+    keepalive 32;
   }
 
   default_type application/octet-stream;
@@ -92,10 +95,15 @@ http {
 
     location /api/v2/ {
       rewrite ^(.*)\/api/v2(\/.+)$ $1$2 break;
+      # HTTP/1.1 + cleared Connection header are required for upstream keepalive to engage.
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
       proxy_pass http://nestjs_target;
     }
 
     location /certificate/ {
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
       proxy_pass http://nestjs_target;
     }
 
@@ -145,6 +153,9 @@ http {
 
     location /api/v2/ {
       rewrite ^(.*)\/api/v2(\/.+)$ $1$2 break;
+      # HTTP/1.1 + cleared Connection header are required for upstream keepalive to engage.
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
       proxy_pass http://nestjs_target;
     }
 


### PR DESCRIPTION
## Summary

nginx→NestJS proxying currently uses the defaults: HTTP/1.0 and `Connection: close`, so **every** `/api/v2` and `/certificate` request opens a brand-new TCP connection to the `nestjs` container. This PR enables upstream keep-alive:

- `keepalive 32;` in the `nestjs_target` upstream — pool of idle connections kept per worker (a cap on *idle* sockets, not a concurrency limit; 4 workers → at most 128 idle sockets to Node);
- `proxy_http_version 1.1;` + `proxy_set_header Connection "";` in the three locations that proxy to it (both required for upstream keepalive to engage, per nginx docs);
- `keepalive_timeout 4s;` in the upstream — this one is load-bearing, see below.

## Why `keepalive_timeout 4s`

Node's HTTP server closes an idle keep-alive connection after **5 s** (`server.keepAliveTimeout` default; our `main.ts` doesn't override it). nginx's default idle timeout for pooled upstream connections is **60 s**. With the proxy-side timeout longer than the backend's, there is a classic race: Node starts closing a connection that has been idle ~5 s at the same moment nginx takes it from the pool and writes a request into it → "upstream prematurely closed connection". nginx transparently retries idempotent requests on a fresh connection, but POST/PATCH with the body already sent are **not** retried by default (`proxy_next_upstream` without `non_idempotent`) → sporadic 502s — and mostly at low/medium traffic, where idle gaps longer than 5 s are common. Same failure class as the well-documented ALB-in-front-of-Node 502s.

Capping the pool's idle timeout below Node's closes the race from the nginx side and keeps the change config-only. 4 s leaves a ~1 s safety margin — orders of magnitude above intra-docker-network latency — while retaining a bit more connection reuse during quiet hours than a lower value would. (The canonical alternative — raising `keepAliveTimeout`/`headersTimeout` in `main.ts` above nginx's idle timeout — touches app code; it can be done as a follow-up, at which point this cap can be relaxed.)

The `client_target` upstream is intentionally left as-is to keep the change minimal; it can get the same treatment separately.

## Why this wasn't here before

Checked the full git history of `nginx.conf`: upstream `keepalive` / `proxy_http_version` have never been present — only the client-facing `keepalive_timeout` (browser↔nginx). So this is not a reverted experiment, just an optimization that was never applied.

## Verification

- `nginx -t` passes on this exact config in `nginx:1.21-alpine` — the image prod runs (per `docker-compose.yml`); upstream-context `keepalive_timeout` requires nginx ≥ 1.15.3, satisfied.
- `X-Request-Time` response header (already emitted) can be compared before/after on prod.
- Deploy pipeline scp's `nginx.conf` and runs `docker-compose restart nginx` on every deploy, so the connection pool is rebuilt right after each backend restart (no stale pooled sockets), and rollback is just revert + redeploy.

Refs #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
