### PR TITLE
feat(nestjs): switch the HTTP adapter from Express to Fastify

### DIFF
--- a/nestjs/package.json
+++ b/nestjs/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "@apalchys/pino-cloudwatch": "0.9.0",
     "@aws-sdk/client-s3": "3.749.0",
+    "@fastify/cookie": "11.1.2",
+    "@fastify/static": "8.3.0",
     "@nestjs/axios": "4.0.0",
     "@nestjs/cache-manager": "3.1.3",
     "@nestjs/common": "11.1.29",
@@ -37,6 +39,7 @@
     "@nestjs/mapped-types": "2.1.0",
     "@nestjs/passport": "11.0.5",
     "@nestjs/platform-express": "11.1.29",
+    "@nestjs/platform-fastify": "11.1.29",
     "@nestjs/schedule": "5.0.1",
     "@nestjs/swagger": "11.4.6",
     "@nestjs/typeorm": "11.0.0",

--- a/nestjs/src/main.ts
+++ b/nestjs/src/main.ts
@@ -4,24 +4,31 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 import { NestFactory } from '@nestjs/core';
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
-import { setupApp } from './setup';
+import { createAdapter, setupApp } from './setup';
 import './core/templates';
 
 const port = process.env.NODE_PORT || 3002;
 const isLambda = !!process.env.AWS_LAMBDA;
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { bufferLogs: true, logger: isLambda ? console : undefined });
+  const app = await NestFactory.create<NestFastifyApplication>(AppModule, createAdapter(), {
+    bufferLogs: true,
+    logger: isLambda ? console : undefined,
+  });
 
-  setupApp(app);
+  await setupApp(app);
 
   const config = new DocumentBuilder().setTitle('RS School API').build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('swagger', app, document);
 
-  await app.listen(port);
+  // 0.0.0.0 is required: fastify binds localhost by default, which would make
+  // the prod container unreachable behind nginx (Lambda would mask the bug —
+  // its web adapter connects to localhost).
+  await app.listen(port, '0.0.0.0');
 }
 
 bootstrap();

--- a/nestjs/src/openapi-spec.ts
+++ b/nestjs/src/openapi-spec.ts
@@ -1,12 +1,17 @@
 import { NestFactory } from '@nestjs/core';
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { createAdapter } from './setup';
 import * as fs from 'fs';
 import { exit } from 'process';
 
 const generate = async () => {
   const config = new DocumentBuilder().addServer('/api/v2').build();
-  const app = await NestFactory.create(AppModule, { logger: ['error'] });
+  const app = await NestFactory.create<NestFastifyApplication>(AppModule, createAdapter(), { logger: ['error'] });
+  // Route-registration canary: find-my-way validates the whole route tree at
+  // init, so an incompatible route fails the spec generation instead of prod.
+  await app.init();
   const document = SwaggerModule.createDocument(app, config);
 
   fs.writeFileSync('./src/spec.json', JSON.stringify(document));

--- a/nestjs/src/setup.spec.ts
+++ b/nestjs/src/setup.spec.ts
@@ -1,11 +1,12 @@
-import { INestApplication } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Logger } from 'nestjs-pino';
 import { ConfigService } from './config';
-import { setupApp } from './setup';
+import { createAdapter, setupApp } from './setup';
 
 function createAppMock(host: string) {
   const enableCors = vi.fn();
+  const register = vi.fn().mockResolvedValue(undefined);
   const app = {
     get: vi.fn((token: unknown) => {
       if (token === ConfigService) return { host };
@@ -15,20 +16,20 @@ function createAppMock(host: string) {
     }),
     enableCors,
     useLogger: vi.fn(),
-    use: vi.fn(),
+    register,
     useGlobalFilters: vi.fn(),
     useGlobalInterceptors: vi.fn(),
     useGlobalPipes: vi.fn(),
-  } as unknown as INestApplication;
+  } as unknown as NestFastifyApplication;
 
-  return { app, enableCors };
+  return { app, enableCors, register };
 }
 
 describe('setupApp CORS', () => {
-  it('scopes the origin to the app host and allows credentials (never wildcard)', () => {
+  it('scopes the origin to the app host and allows credentials (never wildcard)', async () => {
     const { app, enableCors } = createAppMock('https://app.rs.school');
 
-    setupApp(app);
+    await setupApp(app);
 
     expect(enableCors).toHaveBeenCalledWith({ origin: 'https://app.rs.school', credentials: true });
     // Guard against a regression to the bare `enableCors()` (wildcard, no credentials).
@@ -38,11 +39,33 @@ describe('setupApp CORS', () => {
     expect(options?.credentials).toBe(true);
   });
 
-  it('falls back to localhost when the host is unset', () => {
+  it('falls back to localhost when the host is unset', async () => {
     const { app, enableCors } = createAppMock('');
 
-    setupApp(app);
+    await setupApp(app);
 
     expect(enableCors).toHaveBeenCalledWith({ origin: 'http://localhost:3000', credentials: true });
+  });
+
+  it('registers the cookie plugin (jwt strategy reads request.cookies)', async () => {
+    const { app, register } = createAppMock('');
+
+    await setupApp(app);
+
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createAdapter', () => {
+  it('configures the fastify instance to match the legacy express behavior', () => {
+    const adapter = createAdapter();
+    const instance = adapter.getInstance();
+
+    // 20mb body limit (jupyter notebook uploads) — fastify default is 1mb.
+    expect(instance.initialConfig.bodyLimit).toBe(20 * 1024 * 1024);
+    expect(instance.initialConfig.ignoreTrailingSlash).toBe(true);
+    expect(instance.initialConfig.caseSensitive).toBe(false);
+    // trustProxy is not exposed through initialConfig; its effect is covered
+    // by the smoke suite running behind supertest's direct connection.
   });
 });

--- a/nestjs/src/setup.ts
+++ b/nestjs/src/setup.ts
@@ -1,20 +1,40 @@
 import { BadRequestException, INestApplication, ValidationError, ValidationPipe } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import * as Sentry from '@sentry/node';
-import cookieParser from 'cookie-parser';
-import { json } from 'express';
+import fastifyCookie from '@fastify/cookie';
 import { Logger } from 'nestjs-pino';
 import { EntityNotFoundFilter, SentryFilter } from './core/filters';
 import { LoggingInterceptor, NoCacheInterceptor } from './core/interceptors';
 import { ValidationFilter } from './core/validation';
-import { HttpAdapterHost } from '@nestjs/core';
 import { ConfigService } from './config';
 
 type ValidationLogger = Pick<Logger, 'warn'>;
 
 /**
- * Adapter-agnostic HTTP behavior: CORS, global filters and the global
- * validation pipe. Shared between the production bootstrap (setupApp) and the
- * HTTP smoke suite (test/http) so both always exercise identical wiring.
+ * The single source of truth for the fastify configuration — shared by the
+ * production bootstrap (main.ts), the openapi spec generator and the HTTP
+ * smoke suite, so all of them run the exact same adapter.
+ */
+export function createAdapter() {
+  return new FastifyAdapter({
+    // 20mb matches the legacy limit (jupyter notebook uploads to /files/upload).
+    bodyLimit: 20 * 1024 * 1024,
+    // Express was trailing-slash tolerant and case-insensitive; keep url
+    // matching behavior identical after the swap (#1123).
+    ignoreTrailingSlash: true,
+    caseSensitive: false,
+    // Client ip/protocol come through nginx (prod) or the Lambda web adapter
+    // (staging), so trust the x-forwarded-* headers like Express did.
+    trustProxy: true,
+  });
+}
+
+/**
+ * Adapter-agnostic HTTP behavior: CORS, global interceptors/filters and the
+ * global validation pipe. Shared between the production bootstrap (setupApp)
+ * and the HTTP smoke suite (test/http) so both always exercise identical
+ * wiring.
  */
 export function configureHttp(app: INestApplication, options: { host?: string; logger?: ValidationLogger } = {}) {
   const { host, logger } = options;
@@ -46,16 +66,13 @@ export function configureHttp(app: INestApplication, options: { host?: string; l
   app.useGlobalFilters(new ValidationFilter(httpAdapterHost));
 }
 
-export function setupApp(app: INestApplication) {
+export async function setupApp(app: NestFastifyApplication) {
   const logger = app.get(Logger);
   const config = app.get(ConfigService);
   app.useLogger(logger);
-  app.use(cookieParser());
-  // Register a global JSON body parser. NestJS skips registering its own default
-  // body parsers once any json middleware is applied, so this must be global —
-  // a path-scoped json() would leave every other route without a parsed JSON body.
-  // 20mb limit matches the legacy koa server (jupyter notebook uploads to /files/upload).
-  app.use(json({ limit: '20mb' }));
+  // Populates request.cookies (the jwt strategy reads the auth-token cookie);
+  // replaces the express cookie-parser middleware.
+  await app.register(fastifyCookie);
 
   if (process.env.SENTRY_DSN) {
     const ignoredExceptions = ['UnauthorizedException', 'TokenExpiredError', 'NotFoundException'];

--- a/nestjs/test/http/errors-cors.smoke.spec.ts
+++ b/nestjs/test/http/errors-cors.smoke.spec.ts
@@ -94,20 +94,28 @@ describe.each(ADAPTERS)('error shapes and CORS over HTTP [%s]', adapter => {
     });
   });
 
-  it('treats an empty json body as an empty object (fails dto validation)', async () => {
-    // Express (body-parser) parses an empty body as {}. Fastify instead fails
-    // with FST_ERR_CTP_EMPTY_JSON_BODY — this pin is the tripwire for that
-    // divergence at adapter-swap time.
+  it('rejects an empty json body with 400 (shape differs by adapter)', async () => {
+    // The one accepted adapter divergence: express (body-parser) parses an
+    // empty body as {} and the dto validation answers; fastify rejects it at
+    // the content-type parser with FST_ERR_CTP_EMPTY_JSON_BODY. Both are 400s.
     const response = await request(app.getHttpServer())
       .post('/smoke/echo')
       .set('Content-Type', 'application/json')
       .expect(400);
 
-    expect(response.body).toEqual({
-      statusCode: 400,
-      message: 'name must be a string',
-      error: 'Bad Request',
-    });
+    if (adapter === 'express') {
+      expect(response.body).toEqual({
+        statusCode: 400,
+        message: 'name must be a string',
+        error: 'Bad Request',
+      });
+    } else {
+      // Nest's exception layer reshapes fastify's FST_ERR_CTP_EMPTY_JSON_BODY.
+      expect(response.body).toEqual({
+        statusCode: 400,
+        message: "Body cannot be empty when content-type is set to 'application/json'",
+      });
+    }
   });
 
   it('returns 400 for malformed json', async () => {
@@ -140,7 +148,9 @@ describe.each(ADAPTERS)('error shapes and CORS over HTTP [%s]', adapter => {
     expect(response.headers['access-control-allow-origin']).toBe(TEST_HOST);
     expect(response.headers['access-control-allow-credentials']).toBe('true');
     expect(response.headers['access-control-allow-methods']).toContain('GET');
-    expect(response.headers.vary).toContain('Origin');
+    // Minor divergence: the express cors package varies preflights on Origin,
+    // @fastify/cors varies them on Access-Control-Request-Headers.
+    expect(response.headers.vary).toContain(adapter === 'express' ? 'Origin' : 'Access-Control-Request-Headers');
   });
 
   it('sets CORS headers on an actual cross-origin response', async () => {

--- a/nestjs/test/http/harness.ts
+++ b/nestjs/test/http/harness.ts
@@ -1,44 +1,49 @@
 import { INestApplication, ModuleMetadata } from '@nestjs/common';
 import { ExpressAdapter } from '@nestjs/platform-express';
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
 import cookieParser from 'cookie-parser';
+import fastifyCookie from '@fastify/cookie';
 import { json } from 'express';
 import type { Response } from 'superagent';
-import { configureHttp } from 'src/setup';
+import { configureHttp, createAdapter } from 'src/setup';
 
 /**
- * Adapters the smoke suite runs against. The Fastify migration (#1123) flips
- * this to ['express', 'fastify'] so every spec proves behavioral parity
- * between the two adapters before the swap ships.
+ * The parity suite runs every smoke spec against both adapters: 'fastify' is
+ * what production runs (#1123), 'express' is the reference the pins were
+ * recorded against. The express leg goes away together with the
+ * @nestjs/platform-express dependency.
  */
-export const ADAPTERS = ['express'] as const;
+export const ADAPTERS = ['express', 'fastify'] as const;
 export type AdapterName = (typeof ADAPTERS)[number];
 
 export const TEST_HOST = 'http://localhost:3000';
 
-function createAdapter(adapter: AdapterName) {
-  switch (adapter) {
-    case 'express':
-      return new ExpressAdapter();
-  }
-}
-
 /**
- * Boots a purpose-built testing module as a real HTTP application: the same
- * body/cookie parsing as the production bootstrap (src/setup.ts) plus the
- * shared configureHttp() wiring (CORS, filters, validation pipe). Controllers,
- * guards and passport strategies are real; services are mocked by the caller.
+ * Boots a purpose-built testing module as a real HTTP application with the
+ * same request plumbing as the production bootstrap (src/setup.ts) plus the
+ * shared configureHttp() wiring (CORS, interceptors, filters, validation
+ * pipe). Controllers, guards and passport strategies are real; services are
+ * mocked by the caller.
  */
 export async function createHttpApp(metadata: ModuleMetadata, adapter: AdapterName): Promise<INestApplication> {
   const moduleRef = await Test.createTestingModule(metadata).compile();
-  const app = moduleRef.createNestApplication(createAdapter(adapter), { logger: false });
 
-  // Mirrors the adapter-specific part of setupApp.
+  if (adapter === 'fastify') {
+    const app = moduleRef.createNestApplication<NestFastifyApplication>(createAdapter(), { logger: false });
+    await app.register(fastifyCookie);
+    configureHttp(app, { host: TEST_HOST, logger: { warn: () => undefined } });
+    await app.init();
+    // Fastify queues requests until the instance is ready; supertest talks to
+    // the raw node server, so readiness must be awaited explicitly.
+    await app.getHttpAdapter().getInstance().ready();
+    return app;
+  }
+
+  const app = moduleRef.createNestApplication(new ExpressAdapter(), { logger: false });
   app.use(cookieParser());
   app.use(json({ limit: '20mb' }));
-
   configureHttp(app, { host: TEST_HOST, logger: { warn: () => undefined } });
-
   await app.init();
   return app;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,6 +1108,8 @@
       "dependencies": {
         "@apalchys/pino-cloudwatch": "0.9.0",
         "@aws-sdk/client-s3": "3.749.0",
+        "@fastify/cookie": "11.1.2",
+        "@fastify/static": "8.3.0",
         "@nestjs/axios": "4.0.0",
         "@nestjs/cache-manager": "3.1.3",
         "@nestjs/common": "11.1.29",
@@ -1117,6 +1119,7 @@
         "@nestjs/mapped-types": "2.1.0",
         "@nestjs/passport": "11.0.5",
         "@nestjs/platform-express": "11.1.29",
+        "@nestjs/platform-fastify": "11.1.29",
         "@nestjs/schedule": "5.0.1",
         "@nestjs/swagger": "11.4.6",
         "@nestjs/typeorm": "11.0.0",
@@ -1267,6 +1270,63 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "nestjs/node_modules/@fastify/static": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-8.3.0.tgz",
+      "integrity": "sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^0.5.4",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^11.0.0"
+      }
+    },
+    "nestjs/node_modules/@fastify/static/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "nestjs/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "nestjs/node_modules/@nestjs/cache-manager": {
@@ -1450,6 +1510,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "nestjs/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "nestjs/node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
@@ -1480,6 +1552,22 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "nestjs/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "nestjs/node_modules/fork-ts-checker-webpack-plugin": {
       "version": "9.1.0",
@@ -1555,6 +1643,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "nestjs/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "nestjs/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1604,7 +1707,6 @@
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1634,7 +1736,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -4809,6 +4910,415 @@
         }
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.1.0.tgz",
+      "integrity": "sha512-F3EVbzWt+xcnVaOHmWyIlpuFtbxOln7HDZQsh09MtMmMm/CipMayNt8hnIL8VQi54u2ZociDbf+iluGYkf7B1A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.6.tgz",
+      "integrity": "sha512-NtuzM0SfaMJbGlnjr9LWQUN5LzgSrbB8tf/wRZNas+4E1O/Nmzl53e7ruT61HDZyRCJGC6FxIogmNZO1c5ETBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/fast-uri": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.1.2.tgz",
+      "integrity": "sha512-Dtrpk/YOGUsbRMvP/8ZqPpwnMRv0qSqodFdoQ2B589Obc7jw4s4Qla+cV72Bsm7WsZJnqlYFX/i7uSBq0xzg6g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^2.0.0",
+        "fastify-plugin": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/cookie/node_modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@fastify/cors": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.3.0.tgz",
+      "integrity": "sha512-ggQGua+xHv1MvePbPr0v//xLYEsCXbWspquXCJS9Ot5YoRXq8J8ZWzHnxDBVnbtXosvistXo6LtNzOJswf64Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^6.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/formbody": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/formbody/-/formbody-8.0.2.tgz",
+      "integrity": "sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/formbody/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.2.tgz",
+      "integrity": "sha512-NE8HgKLgYejV9lDpqkEFaDKMLYelJBVfHekhB0UKvX0ghagXRJqg68feg8er1NPXxG4N9i6vPxzt8E+3wHfcmA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.1.tgz",
+      "integrity": "sha512-BYo+EiaKwlxH+WetGk6hAs1d39iP0y1gqB8lGF/qwkJ9ZZ/cBY1vx5NvExb9Sc3yRMFjD5X4Eyh4e4+TzRkzdw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.3.tgz",
+      "integrity": "sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/content-disposition": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -6298,6 +6808,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
@@ -6487,6 +7006,42 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/platform-fastify": {
+      "version": "11.1.29",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-11.1.29.tgz",
+      "integrity": "sha512-upe47WhS8NzFQY5zfd7MzNyOevdeD5G6A9Yw2a7ip6xDyx9O+6jJ9aAXo4WNGLNvwLa8BuNV2/HVNFSj3wrmeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/cors": "11.3.0",
+        "@fastify/formbody": "8.0.2",
+        "fast-querystring": "1.1.2",
+        "fastify": "5.11.0",
+        "fastify-plugin": "6.0.0",
+        "find-my-way": "9.7.0",
+        "light-my-request": "6.6.0",
+        "path-to-regexp": "8.4.2",
+        "reusify": "1.1.0",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^10.1.2",
+        "@fastify/view": "^10.0.0 || ^11.0.0 || ^12.0.0",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "@fastify/view": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/schedule": {
@@ -11323,6 +11878,12 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -11792,6 +12353,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
       }
     },
     "node_modules/axios": {
@@ -14982,6 +15563,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -15001,12 +15588,116 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -15075,6 +15766,80 @@
       "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
       "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
       "license": "MIT"
+    },
+    "node_modules/fastify": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.0.tgz",
+      "integrity": "sha512-Y/Ecx1yt0hYzrQR+QVLbxaUN8wCX+MQzMevh29r5RRvlOIArmi4+WAXXaGl5Hw5gBr2wduZpZaT3gRCnXoyVgA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -15181,6 +15946,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -17558,6 +18337,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -17712,6 +18510,56 @@
       "version": "1.12.38",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.38.tgz",
       "integrity": "sha512-vwzxmasAy9hZigxtqTbFEwp8ZdZ975TiqVDwj5bKx5sR+zi5ucUQy9mbVTkKM9GzqdLdxux/hTw2nmN5J7POMA==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -19096,6 +19944,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -21164,7 +22024,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21263,6 +22122,31 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "6.0.1",
@@ -21490,6 +22374,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -21655,6 +22561,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -23000,6 +23912,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/toggle-selection": {


### PR DESCRIPTION
## Summary

The finale of #1123: the API now runs on **@nestjs/platform-fastify 11 / fastify 5**. Everything risky was extracted into the seven preparatory PRs (#3086–#3091, #3098), so the swap itself is ~4 source files.

- `createAdapter()` in `setup.ts` — single source of truth for the fastify config, shared by `main.ts`, `openapi-spec.ts` and the smoke harness: `bodyLimit: 20mb` (jupyter uploads), `ignoreTrailingSlash: true` + `caseSensitive: false` (Express url-matching semantics preserved), `trustProxy: true` (nginx / Lambda web adapter).
- `@fastify/cookie` replaces cookie-parser (the jwt strategy reads `request.cookies`); the express `json({limit})` middleware is replaced by the adapter `bodyLimit`; Swagger UI is served via `@fastify/static` (`/swagger` and `/swagger/` both 200).
- **`app.listen(port, '0.0.0.0')`** — load-bearing: fastify binds localhost by default; the prod Docker container behind nginx would be unreachable, and the Lambda web adapter (which connects to localhost) would mask exactly this bug on staging.
- `openapi-spec.ts` now `app.init()`s on the fastify adapter — find-my-way validates the whole route tree on every spec generation (permanent canary; the tree registers clean).

## Parity evidence

The smoke suite (#3086) now runs **every pin against both adapters** (`ADAPTERS = ['express', 'fastify']`): 76 HTTP-level assertions ✕ green on both — GitHub OAuth redirect URL + login state, callback `Set-Cookie` **byte-exact**, logout clear-cookie, dev login, jwt/basic 401 bodies, CSV headers/bodies, PDF stream bytes, webhook HMAC accept/reject, EntityNotFound/Validation/pipe error shapes, unknown-route 404, CORS preflight + credentialed responses, `Cache-Control: no-cache`.

Two accepted divergences, each pinned per adapter in the suite:
- empty JSON body → 400 with fastify's parser message instead of body-parser's `{}` + dto validation;
- CORS preflights `Vary: Access-Control-Request-Headers` instead of `Origin`.

Live boot check (fastify, against the local DB): dev login round trip (real JWT, cookie, redirect), score CSV with `content-length`, schedule, webhook 401, case-insensitive + trailing-slash urls, Swagger UI, pino request logging — all working. `spec.json` byte-identical, full `test:ci` (2073+ tests, 90% gate) and lint green.

## Rollback / soak

`express`, `cookie-parser`, `swagger-ui-express` and `@nestjs/platform-express` are **intentionally still in dependencies** — `git revert` of this single commit is a complete rollback. After a prod soak the cleanup PR removes them (keeping platform-express as a devDependency for the dual-adapter suite) and closes #1123.

## Staging checklist before merge (`deploy` label)

- [ ] real GitHub OAuth login → cookie on rs.school → logout
- [ ] certificate PDF via `/certificate/…`, one CSV export from the UI
- [ ] score page (CacheInterceptor), `/swagger`
- [ ] webhook probe with the staging secret; CloudWatch pino logs; Sentry on a forced error
- [ ] after prod deploy: `curl -I https://app.rs.school/api/v2/certificate/templates` — the container must be reachable (0.0.0.0 bind; Lambda does not test this path!)

Refs #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)