### PR TITLE
chore(infra): ship nginx logs to CloudWatch with upstream diagnostics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,13 @@ services:
     container_name: nginx
     image: nginx:1.21-alpine
     restart: unless-stopped
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: eu-central-1
+        awslogs-group: rsschool-app
+        awslogs-stream: nginx
+        awslogs-create-group: 'true'
     volumes:
       - ./nginx:/etc/nginx
       - ./letsencrypt:/etc/letsencrypt

--- a/setup/nginx/nginx.conf
+++ b/setup/nginx/nginx.conf
@@ -34,6 +34,11 @@ http {
 
   default_type application/octet-stream;
 
+  # Per-request upstream diagnostics for the API locations (global access_log
+  # stays off). Written to stdout, which the awslogs driver ships to CloudWatch.
+  log_format upstream_diag '$time_iso8601 $status up=$upstream_addr up_status=$upstream_status '
+                           'connect=$upstream_connect_time total=$request_time "$request"';
+
   server_tokens off;
   sendfile on;
   tcp_nopush on;
@@ -99,6 +104,7 @@ http {
 
     location /api/v2/ {
       rewrite ^(.*)\/api/v2(\/.+)$ $1$2 break;
+      access_log /dev/stdout upstream_diag;
       # HTTP/1.1 + cleared Connection header are required for upstream keepalive to engage.
       proxy_http_version 1.1;
       proxy_set_header Connection "";
@@ -106,6 +112,7 @@ http {
     }
 
     location /certificate/ {
+      access_log /dev/stdout upstream_diag;
       proxy_http_version 1.1;
       proxy_set_header Connection "";
       proxy_pass http://nestjs_target;
@@ -157,6 +164,7 @@ http {
 
     location /api/v2/ {
       rewrite ^(.*)\/api/v2(\/.+)$ $1$2 break;
+      access_log /dev/stdout upstream_diag;
       # HTTP/1.1 + cleared Connection header are required for upstream keepalive to engage.
       proxy_http_version 1.1;
       proxy_set_header Connection "";


### PR DESCRIPTION
## Summary

Follow-up to the Fastify swap incident (#3101 + revert). Post-mortem from the app-container logs showed the **Fastify container was healthy and serving the whole time** (1171 requests, 10:58–13:43 UTC, continuous 200/304s) while clients were getting 502s — i.e. the failure lived at the nginx→container connection layer. And that layer is currently a black box: `access_log off`, `error_log` stays inside the container, no log driver on the service.

This PR makes the next such incident diagnosable from CloudWatch in minutes:

- **nginx service gets the awslogs driver** (group `rsschool-app`, stream `nginx`) — same pattern as the app containers. The official image already symlinks `error.log` → stderr, so upstream `connect() failed` lines flow with no image changes.
- **Per-request upstream diagnostics on the API locations only** (`/api/v2/` on both vhosts + `/certificate/`): a `log_format` with `$upstream_addr`, `$upstream_status`, `$upstream_connect_time`, `$request_time`. A 502 line will show exactly which upstream address nginx tried and how it failed. Global `access_log off` stays (client_target traffic remains unlogged).

## Notes

- Log volume: only API locations, one line per request — comparable to the app's own request logging that already goes to the same group.
- This is prep for re-landing the Fastify swap: with these logs, a repeat of the incident pinpoints the mechanism immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)